### PR TITLE
Added support for binary keys in DEBUG OBJECT command

### DIFF
--- a/src/main/java/redis/clients/jedis/DebugParams.java
+++ b/src/main/java/redis/clients/jedis/DebugParams.java
@@ -1,9 +1,11 @@
 package redis.clients.jedis;
 
-public class DebugParams {
-    private String[] command;
+import redis.clients.util.SafeEncoder;
 
-    public String[] getCommand() {
+public class DebugParams {
+    private byte[][] command;
+
+    public byte[][] getCommand() {
 	return command;
     }
 
@@ -13,19 +15,25 @@ public class DebugParams {
 
     public static DebugParams SEGFAULT() {
 	DebugParams debugParams = new DebugParams();
-	debugParams.command = new String[] { "SEGFAULT" };
+	debugParams.command = new byte[][] { SafeEncoder.encode("SEGFAULT") };
 	return debugParams;
     }
 
     public static DebugParams OBJECT(String key) {
 	DebugParams debugParams = new DebugParams();
-	debugParams.command = new String[] { "OBJECT", key };
+	debugParams.command = new byte[][] { SafeEncoder.encode("OBJECT"), SafeEncoder.encode(key) };
 	return debugParams;
+    }
+    
+    public static DebugParams OBJECT(byte[] key) {
+    DebugParams debugParams = new DebugParams();
+    debugParams.command = new byte[][] { SafeEncoder.encode("OBJECT"), key };
+    return debugParams;
     }
 
     public static DebugParams RELOAD() {
 	DebugParams debugParams = new DebugParams();
-	debugParams.command = new String[] { "RELOAD" };
+	debugParams.command = new byte[][] { SafeEncoder.encode("RELOAD") };
 	return debugParams;
     }
 }

--- a/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
@@ -120,4 +120,14 @@ public class ControlCommandsTest extends JedisCommandTestBase {
         resp = jedis.debug(DebugParams.RELOAD());
         assertNotNull(resp);
     }
+    
+    @Test
+	public void debugBinaryKey() {
+		byte[] key = { 117, 3, -17 };
+		jedis.set(key, "bar".getBytes());
+		String resp = jedis.debug(DebugParams.OBJECT(key));
+		assertNotNull(resp);
+		resp = jedis.debug(DebugParams.RELOAD());
+		assertNotNull(resp);
+	}
 }


### PR DESCRIPTION
We use especially serialized keys which can not be converted to UTF-8 Strings, so I added support to call a DEBUG OBJECT command using a binary key.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/xetorthio/jedis/371)

<!-- Reviewable:end -->
