### PR TITLE
Jedis#eval with the specified timeout

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -61,16 +61,20 @@ public class Connection implements Closeable {
     this.soTimeout = soTimeout;
   }
 
-  public void setTimeoutInfinite() {
+  public void setTimeout(int timeout) {
     try {
       if (!isConnected()) {
         connect();
       }
-      socket.setSoTimeout(0);
+      socket.setSoTimeout(timeout);
     } catch (SocketException ex) {
       broken = true;
       throw new JedisConnectionException(ex);
     }
+  }
+
+  public void setTimeoutInfinite() {
+    setTimeout(0);
   }
 
   public void rollbackTimeout() {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -2731,12 +2731,27 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
 
   @Override
   public Object eval(String script, int keyCount, String... params) {
-    client.setTimeoutInfinite();
-    try {
+    return eval(0, script, keyCount, params);
+  }
+
+  @Override
+  public Object eval(int timeout, String script) {
+    return eval(timeout, script, 0);
+  }
+
+  @Override
+  public Object eval(int timeout, String script, int keyCount, String... params) {
+    if (timeout == client.getSoTimeout()) {
       client.eval(script, keyCount, params);
       return getEvalResult();
-    } finally {
-      client.rollbackTimeout();
+    } else {
+      client.setTimeout(timeout);
+      try {
+        client.eval(script, keyCount, params);
+        return getEvalResult();
+      } finally {
+        client.rollbackTimeout();
+      }
     }
   }
 

--- a/src/main/java/redis/clients/jedis/commands/ScriptingCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/ScriptingCommands.java
@@ -9,6 +9,10 @@ public interface ScriptingCommands {
 
   Object eval(String script);
 
+  Object eval(int timeout, String script);
+
+  Object eval(int timeout, String script, int keyCount, String... params);
+
   Object evalsha(String script);
 
   Object evalsha(String sha1, List<String> keys, List<String> args);


### PR DESCRIPTION
I would suggest this change in order to be specify what timeout for eval, see #1147.
This change is backwards compatible, however I still think infinite timeout is not a good idea.
