### PR TITLE
squid:S2974 - Classes without public constructors should be final

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3615,7 +3615,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
    * return Set result.
    * @param <E>
    */
-  protected static class SetFromList<E> extends AbstractSet<E> implements Serializable {
+  protected static final class SetFromList<E> extends AbstractSet<E> implements Serializable {
     private static final long serialVersionUID = -2850347066962734052L;
     private final List<E> list;
 

--- a/src/main/java/redis/clients/jedis/DebugParams.java
+++ b/src/main/java/redis/clients/jedis/DebugParams.java
@@ -1,6 +1,6 @@
 package redis.clients.jedis;
 
-public class DebugParams {
+public final class DebugParams {
   private String[] command;
 
   private DebugParams() {

--- a/src/main/java/redis/clients/jedis/params/geo/GeoRadiusParam.java
+++ b/src/main/java/redis/clients/jedis/params/geo/GeoRadiusParam.java
@@ -6,7 +6,7 @@ import redis.clients.util.SafeEncoder;
 
 import java.util.ArrayList;
 
-public class GeoRadiusParam extends Params {
+public final class GeoRadiusParam extends Params {
   private static final String WITHCOORD = "withcoord";
   private static final String WITHDIST = "withdist";
 

--- a/src/main/java/redis/clients/jedis/params/set/SetParams.java
+++ b/src/main/java/redis/clients/jedis/params/set/SetParams.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import redis.clients.jedis.params.Params;
 import redis.clients.util.SafeEncoder;
 
-public class SetParams extends Params {
+public final class SetParams extends Params {
 
   private static final String XX = "xx";
   private static final String NX = "nx";

--- a/src/main/java/redis/clients/jedis/params/sortedset/ZAddParams.java
+++ b/src/main/java/redis/clients/jedis/params/sortedset/ZAddParams.java
@@ -5,7 +5,7 @@ import redis.clients.util.SafeEncoder;
 
 import java.util.ArrayList;
 
-public class ZAddParams extends Params {
+public final class ZAddParams extends Params {
 
   private static final String XX = "xx";
   private static final String NX = "nx";

--- a/src/main/java/redis/clients/jedis/params/sortedset/ZIncrByParams.java
+++ b/src/main/java/redis/clients/jedis/params/sortedset/ZIncrByParams.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
  * <br/>
  * Works with Redis 3.0.2 and onwards.
  */
-public class ZIncrByParams extends Params {
+public final class ZIncrByParams extends Params {
 
   private static final String XX = "xx";
   private static final String NX = "nx";

--- a/src/main/java/redis/clients/util/IOUtils.java
+++ b/src/main/java/redis/clients/util/IOUtils.java
@@ -3,7 +3,7 @@ package redis.clients.util;
 import java.io.IOException;
 import java.net.Socket;
 
-public class IOUtils {
+public final class IOUtils {
   private IOUtils() {
   }
 

--- a/src/main/java/redis/clients/util/Slowlog.java
+++ b/src/main/java/redis/clients/util/Slowlog.java
@@ -3,7 +3,7 @@ package redis.clients.util;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Slowlog {
+public final class Slowlog {
   private final long id;
   private final long timeStamp;
   private final long executionTime;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162 - "equals" methods should be symmetric and work for subclasses

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162

Please let me know if you have any questions.

M-Ezzat
