### PR TITLE
Avoid a NullPointerException when unsubscribing before subscribing

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
@@ -35,13 +35,17 @@ public abstract class BinaryJedisPubSub {
   }
 
   public void unsubscribe() {
-    client.unsubscribe();
-    client.flush();
+    if (client != null) {
+      client.unsubscribe();
+      client.flush();
+    }
   }
 
   public void unsubscribe(byte[]... channels) {
-    client.unsubscribe(channels);
-    client.flush();
+    if (client != null) {
+      client.unsubscribe(channels);
+      client.flush();
+    }
   }
 
   public void subscribe(byte[]... channels) {
@@ -55,13 +59,17 @@ public abstract class BinaryJedisPubSub {
   }
 
   public void punsubscribe() {
-    client.punsubscribe();
-    client.flush();
+    if (client != null) {
+      client.punsubscribe();
+      client.flush();
+    }
   }
 
   public void punsubscribe(byte[]... patterns) {
-    client.punsubscribe(patterns);
-    client.flush();
+    if (client != null) {
+      client.punsubscribe(patterns);
+      client.flush();
+    }
   }
 
   public boolean isSubscribed() {


### PR DESCRIPTION
In my subscription code, I start up another thread to handle the subscription
before returning the unsubscribe handler. If the caller calls unsubscribe before
the new thread has had a change to call `jedis.subscribe`, I get a
NullPointerException. This makes unsubscribe do nothing in that case. There might
be better ways to handle this situation.
