### PR TITLE
Deploy SNAPSHOTs to Sonatype's OSS Snapshot Repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,18 @@ before_install:
     - cd ./stunnel-5.29 && ./configure && make && sudo make install && cd ..
 install:
   - make travis-install
-script: TEST="\!ModuleTest" make test
+script:
+  -
+    VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version|grep -Ev '(^\[|Download\w+:)')
+  - echo "Project Version ${VERSION}"
+  - |
+    if [[ ${TRAVIS_PULL_REQUEST} == "false" && ${TRAVIS_SECURE_ENV_VARS} && $VERSION =~ ^.*-SNAPSHOT$ ]] ; then
+      TEST="\!ModuleTest" make deploy
+    else
+      TEST="\!ModuleTest" make test
+    fi
 cache:
   directories:
-    - $HOME/.m2
+  - "$HOME/.m2"
 addons:
   hostname: jedis

--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,11 @@ test: compile-module start
 	mvn -Dtest=${SKIP_SSL}${TEST} clean compile test
 	make stop
 
+deploy: compile-module start
+	sleep 2
+	mvn -Dtest=${SKIP_SSL}${TEST} -DaltDeploymentRepository=sonatype-nexus-snapshots::default::https://oss.sonatype.org/content/repositories/snapshots/ --settings settings.xml clean compile deploy
+	make stop
+
 package: start
 	mvn clean package
 	make stop

--- a/pom.xml
+++ b/pom.xml
@@ -138,9 +138,6 @@
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>2.8.1</version>
-        <configuration>
-          <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-        </configuration>
       </plugin>
       <plugin>
 	      <groupId>com.googlecode.maven-java-formatter-plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>jar</packaging>
 	<groupId>redis.clients</groupId>
@@ -12,15 +13,15 @@
 	<version>3.0.0-SNAPSHOT</version>
 	<name>Jedis</name>
 	<description>Jedis is a blazingly small and sane Redis java client.</description>
-  <url>https://github.com/xetorthio/jedis</url>
+	<url>https://github.com/xetorthio/jedis</url>
 
 	<mailingLists>
 		<mailingList>
 			<name>Jedis Mailing List</name>
 			<post>jedis_redis@googlegroups.com</post>
 			<archive>
-        http://groups.google.com/group/jedis_redis
-      </archive>
+				http://groups.google.com/group/jedis_redis
+			</archive>
 		</mailingList>
 	</mailingLists>
 
@@ -37,18 +38,22 @@
 		<url>http://github.com/xetorthio/jedis/issues</url>
 	</issueManagement>
 
-  <scm>
-    <connection>scm:git:git@github.com:xetorthio/jedis.git</connection>
-    <url>scm:git:git@github.com:xetorthio/jedis.git</url>
-    <developerConnection>scm:git:git@github.com:xetorthio/jedis.git</developerConnection>
-    <tag>jedis-2.2.0</tag>
-  </scm>
+	<scm>
+		<connection>scm:git:git@github.com:xetorthio/jedis.git</connection>
+		<url>scm:git:git@github.com:xetorthio/jedis.git</url>
+		<developerConnection>scm:git:git@github.com:xetorthio/jedis.git</developerConnection>
+		<tag>jedis-2.2.0</tag>
+	</scm>
 
 	<properties>
-		<redis-hosts>localhost:6379,localhost:6380,localhost:6381,localhost:6382,localhost:6383,localhost:6384,localhost:6385</redis-hosts>
+		<redis-hosts>
+			localhost:6379,localhost:6380,localhost:6381,localhost:6382,localhost:6383,localhost:6384,localhost:6385
+		</redis-hosts>
 		<sentinel-hosts>localhost:26379,localhost:26380,localhost:26381</sentinel-hosts>
-		<cluster-hosts>localhost:7379,localhost:7380,localhost:7381,localhost:7382,localhost:7383,localhost:7384,localhost:7385</cluster-hosts>
-    	<github.global.server>github</github.global.server>
+		<cluster-hosts>
+			localhost:7379,localhost:7380,localhost:7381,localhost:7382,localhost:7383,localhost:7384,localhost:7385
+		</cluster-hosts>
+		<github.global.server>github</github.global.server>
 	</properties>
 
 	<dependencies>
@@ -68,13 +73,13 @@
 		</dependency>
 	</dependencies>
 
-  <distributionManagement>
-      <repository>
-          <id>github</id>
-          <name>GitHub ${project.artifactId} Repository</name>
-          <url>https://raw.github.com/xetorthio/${project.artifactId}/mvn-repo</url>
-      </repository>
-  </distributionManagement>
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub ${project.artifactId} Repository</name>
+			<url>https://raw.github.com/xetorthio/${project.artifactId}/mvn-repo</url>
+		</repository>
+	</distributionManagement>
 
 	<build>
 		<plugins>
@@ -104,14 +109,14 @@
 				<configuration>
 					<attach>true</attach>
 				</configuration>
-                                <executions>
-                                    <execution>
-                                        <id>attach-sources</id>
-                                        <goals>
-                                            <goal>jar</goal>
-                                        </goals>
-                                    </execution>
-                                </executions>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -121,54 +126,54 @@
 					<aggregate>true</aggregate>
 					<additionalparam>-Xdoclint:none</additionalparam>
 				</configuration>
-                                <executions>
-                                    <execution>
-                                        <id>attach-javadoc</id>
-                                        <goals>
-                                            <goal>jar</goal>
-                                        </goals>
-                                    </execution>
-                                </executions>
+				<executions>
+					<execution>
+						<id>attach-javadoc</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.4.2</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.1</version>
-      </plugin>
-      <plugin>
-	      <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
-	      <artifactId>maven-java-formatter-plugin</artifactId>
-	      <version>0.4</version>
-	      <configuration>
-		      <configFile>${project.basedir}/hbase-formatter.xml</configFile>
-	      </configuration>
-      </plugin>
 			<plugin>
-			  <artifactId>maven-jar-plugin</artifactId>
-			  <version>2.6</version>
-			  <configuration>
-			    <archive>  
-			      <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-			    </archive> 
-			  </configuration>
-			</plugin> 
-      		<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.4.2</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.1</version>
+			</plugin>
+			<plugin>
+				<groupId>com.googlecode.maven-java-formatter-plugin</groupId>
+				<artifactId>maven-java-formatter-plugin</artifactId>
+				<version>0.4</version>
+				<configuration>
+					<configFile>${project.basedir}/hbase-formatter.xml</configFile>
+				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.5.3</version>		
+				<version>2.5.3</version>
 				<executions>
-				    <execution>
-				      <id>bundle-manifest</id>
-				      <phase>process-classes</phase>
-				      <goals>    
-				        <goal>manifest</goal>
-				      </goals>   
-				    </execution>
-				</executions>		
+					<execution>
+						<id>bundle-manifest</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>sonatype-nexus-snapshots</id>
+      <username>${env.CI_DEPLOY_USERNAME}</username>
+      <password>${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
TravisCI now deploys jedis SNAPSHOT artifacts to Sonatype's OSS Snapshot Repo if:
- The build is not a pull-request
- Travis has secure env variables set up
- The artifact version ends with SNAPSHOT

---

Related ticket: #1369 
Requires secure env variables to be set up in [TravisCI](https://travis-ci.org/xetorthio/jedis/settings), specifically:
- `CI_DEPLOY_USERNAME`
- `CI_DEPLOY_PASSWORD`
