### PR TITLE
Call renew slots before final retry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>2.3.0</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-pool2</artifactId>
 			<version>2.4.2</version>

--- a/src/test/java/redis/clients/jedis/JedisClusterCommandTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterCommandTest.java
@@ -1,0 +1,53 @@
+package redis.clients.jedis;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Louis Morgan
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JedisClusterCommandTest {
+
+  @Mock
+  private Jedis connection;
+
+  @Mock
+  private JedisClusterConnectionHandler connectionHandler;
+
+  @Test
+  public void onConnectionExceptionClusterRenewsSlotCacheAndThenRetries() {
+    when(connectionHandler.getConnectionFromSlot(anyInt())).thenReturn(connection);
+    when(connection.get("foo")).thenThrow(new JedisConnectionException("Command failed"));
+
+    try {
+      new JedisClusterCommand<String>(connectionHandler, 3) {
+        @Override
+        public String execute(Jedis connection) {
+          return connection.get("foo");
+        }
+      }.run("foo");
+    } catch (JedisConnectionException expected) {
+      // We expect this to be thrown
+    }
+
+    // maxAttempts is 3, so we expect 2 attempts to get the key, followed by a call to
+    // renewSlotCache(), followed by a further attempt to get the key
+    InOrder inOrder = Mockito.inOrder(connection, connectionHandler);
+    inOrder.verify(connection).get("foo");
+    inOrder.verify(connection).close();
+    inOrder.verify(connection).get("foo");
+    inOrder.verify(connection).close();
+    inOrder.verify(connectionHandler).renewSlotCache();
+    inOrder.verify(connection).get("foo");
+    inOrder.verify(connection).close();
+  }
+}


### PR DESCRIPTION
We lost one of our cluster's master nodes and started seeing a lot of `JedisConnectionException`s being thrown. The cluster itself was working, but Jedis seemed to be hanging on to the old state. Searching in the issues we found #1439 which seems to point out the issue: the call to `cluster slots` to refresh the state of the cluster is called _after_ the final retry, so has no effect.

With this change we call `renewSlotCache()` _before_ the final retry. As before `renewSlotCache()` will never be called if `maxAttempts` is two, since that would mean calling `cluster slots` after a single failure.

I've added a failing (well, now passing!) unit test to validate the fix. I'm using Mockito in that test which isn't being used elsewhere in the project, so I added it as a separate commit to make it easier to remove if you didn't want to add a dependency just for this bug fix.

Fixes #1439 