### PR TITLE
Ditch localhost resolution

### DIFF
--- a/src/main/java/redis/clients/jedis/HostAndPort.java
+++ b/src/main/java/redis/clients/jedis/HostAndPort.java
@@ -1,20 +1,12 @@
 package redis.clients.jedis;
 
 import java.io.Serializable;
-import java.net.InetAddress;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class HostAndPort implements Serializable {
   private static final long serialVersionUID = -519876229978427751L;
 
-  protected static Logger log = LoggerFactory.getLogger(HostAndPort.class.getName());
-  public static volatile String localhost;
-
-
-  private String host;
-  private int port;
+  private final String host;
+  private final int port;
 
   public HostAndPort(String host, int port) {
     this.host = host;
@@ -36,15 +28,12 @@ public class HostAndPort implements Serializable {
     if (!(obj instanceof HostAndPort)) return false;
 
     HostAndPort hp = (HostAndPort) obj;
-
-    String thisHost = convertHost(host);
-    String hpHost = convertHost(hp.host);
-    return port == hp.port && thisHost.equals(hpHost);
+    return port == hp.port && host.equals(hp.host);
   }
 
   @Override
   public int hashCode() {
-    return 31 * convertHost(host).hashCode() + port;
+    return 31 * host.hashCode() + port;
   }
 
   @Override
@@ -96,69 +85,9 @@ public class HostAndPort implements Serializable {
       String[] parts = extractParts(from);
       String host = parts[0];
       int port = Integer.parseInt(parts[1]);
-      return new HostAndPort(convertHost(host), port);
+      return new HostAndPort(host, port);
     } catch (NumberFormatException ex) {
       throw new IllegalArgumentException(ex);
     }
-  }
-
-  public static String convertHost(String host) {
-    try {
-        /*
-         * Validate the host name as an IPV4/IPV6 address.
-         * If this is an AWS ENDPOINT it will not parse.
-         * In that case accept host as is.
-         *
-         * Costs: If this is an IPV4/6 encoding, e.g. 127.0.0.1 then no DNS lookup
-         * is done.  If it is a name then a DNS lookup is done but it is normally cached.
-         * Secondarily, this class is typically used to create a connection once
-         * at the beginning of processing and then not used again.  So even if the DNS
-         * lookup needs to be done then the cost is miniscule.
-         */
-      InetAddress inetAddress = InetAddress.getByName(host);
-
-      // isLoopbackAddress() handles both IPV4 and IPV6
-      if (inetAddress.isLoopbackAddress() || host.equals("0.0.0.0") || host.startsWith("169.254")) {
-        return getLocalhost();
-      }
-    } catch (Exception e) {
-      // Not a valid IP address
-      log.warn("{}.convertHost '{}' is not a valid IP address. ", HostAndPort.class.getName(), host, e);
-    }
-    return host;
-  }
-
-  public static void setLocalhost(String localhost) {
-    synchronized (HostAndPort.class) {
-      HostAndPort.localhost = localhost;
-    }
-  }
-
-  /**
-   * This method resolves the localhost in a 'lazy manner'.
-   *
-   * @return localhost
-   */
-  public static String getLocalhost() {
-    if (localhost == null) {
-      synchronized (HostAndPort.class) {
-        if (localhost == null) {
-          return localhost = getLocalHostQuietly();
-        }
-      }
-    }
-    return localhost;
-  }
-
-  public static String getLocalHostQuietly() {
-    String localAddress;
-    try {
-      localAddress = InetAddress.getLocalHost().getHostAddress();
-    } catch (Exception ex) {
-      log.error("{}.getLocalHostQuietly : cant resolve localhost address",
-        HostAndPort.class.getName(), ex);
-      localAddress = "localhost";
-    }
-    return localAddress;
   }
 }

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -21,7 +21,7 @@ public final class Protocol {
   private static final String WRONGPASS_PREFIX = "WRONGPASS";
   private static final String NOPERM_PREFIX = "NOPERM";
 
-  public static final String DEFAULT_HOST = "localhost";
+  public static final String DEFAULT_HOST = "127.0.0.1";
   public static final int DEFAULT_PORT = 6379;
   public static final int DEFAULT_SENTINEL_PORT = 26379;
   public static final int DEFAULT_TIMEOUT = 2000;

--- a/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
+++ b/src/test/java/redis/clients/jedis/tests/HostAndPortTest.java
@@ -2,8 +2,6 @@ package redis.clients.jedis.tests;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-
 import redis.clients.jedis.HostAndPort;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -47,11 +45,5 @@ public class HostAndPortTest {
   public void checkParseStringWithoutPort() throws Exception {
     String host = "localhost";
     HostAndPort.parseString(host + ":");
-  }
-
-  @Test
-  public void checkConvertHost() {
-    String host = "2a11:1b1:0:111:e111:1f11:1111:1f1e";
-    assertEquals(host, HostAndPort.convertHost(host));
   }
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisSentinelTest.java
@@ -61,9 +61,8 @@ public class JedisSentinelTest {
       assertTrue(inMasters);
 
       List<String> masterHostAndPort = j.sentinelGetMasterAddrByName(MASTER_NAME);
-      HostAndPort masterFromSentinel = new HostAndPort(masterHostAndPort.get(0),
-          Integer.parseInt(masterHostAndPort.get(1)));
-      assertEquals(master, masterFromSentinel);
+      assertEquals(MASTER_IP, masterHostAndPort.get(0));
+      assertEquals(master.getPort(), Integer.parseInt(masterHostAndPort.get(1)));
 
       List<Map<String, String>> slaves = j.sentinelSlaves(MASTER_NAME);
       assertTrue(!slaves.isEmpty());


### PR DESCRIPTION
The duty of setting/providing hosts properly can be left for the users. Moreover, altering values provided by the users or Redis may not be a good idea as because this may lead into some system dependant issues.

Note: Default host is set to `127.0.0.1`, similar to [redis-cli](https://github.com/antirez/redis/blob/5.0.5/src/redis-cli.c#L6994).