### PR TITLE
Remove dependency on 'Locale' for Keyword enum

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
@@ -1,12 +1,12 @@
 package redis.clients.jedis;
 
-import static redis.clients.jedis.Protocol.Keyword.MESSAGE;
-import static redis.clients.jedis.Protocol.Keyword.PMESSAGE;
-import static redis.clients.jedis.Protocol.Keyword.PONG;
-import static redis.clients.jedis.Protocol.Keyword.PSUBSCRIBE;
-import static redis.clients.jedis.Protocol.Keyword.PUNSUBSCRIBE;
-import static redis.clients.jedis.Protocol.Keyword.SUBSCRIBE;
-import static redis.clients.jedis.Protocol.Keyword.UNSUBSCRIBE;
+import static redis.clients.jedis.Protocol.Keyword.message;
+import static redis.clients.jedis.Protocol.Keyword.pmessage;
+import static redis.clients.jedis.Protocol.Keyword.pong;
+import static redis.clients.jedis.Protocol.Keyword.psubscribe;
+import static redis.clients.jedis.Protocol.Keyword.punsubscribe;
+import static redis.clients.jedis.Protocol.Keyword.subscribe;
+import static redis.clients.jedis.Protocol.Keyword.unsubscribe;
 
 import java.util.Arrays;
 import java.util.List;
@@ -104,32 +104,32 @@ public abstract class BinaryJedisPubSub {
         throw new JedisException("Unknown message type: " + firstObj);
       }
       final byte[] resp = (byte[]) firstObj;
-      if (Arrays.equals(SUBSCRIBE.raw, resp)) {
+      if (Arrays.equals(subscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bchannel = (byte[]) reply.get(1);
         onSubscribe(bchannel, subscribedChannels);
-      } else if (Arrays.equals(UNSUBSCRIBE.raw, resp)) {
+      } else if (Arrays.equals(unsubscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bchannel = (byte[]) reply.get(1);
         onUnsubscribe(bchannel, subscribedChannels);
-      } else if (Arrays.equals(MESSAGE.raw, resp)) {
+      } else if (Arrays.equals(message.raw, resp)) {
         final byte[] bchannel = (byte[]) reply.get(1);
         final byte[] bmesg = (byte[]) reply.get(2);
         onMessage(bchannel, bmesg);
-      } else if (Arrays.equals(PMESSAGE.raw, resp)) {
+      } else if (Arrays.equals(pmessage.raw, resp)) {
         final byte[] bpattern = (byte[]) reply.get(1);
         final byte[] bchannel = (byte[]) reply.get(2);
         final byte[] bmesg = (byte[]) reply.get(3);
         onPMessage(bpattern, bchannel, bmesg);
-      } else if (Arrays.equals(PSUBSCRIBE.raw, resp)) {
+      } else if (Arrays.equals(psubscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bpattern = (byte[]) reply.get(1);
         onPSubscribe(bpattern, subscribedChannels);
-      } else if (Arrays.equals(PUNSUBSCRIBE.raw, resp)) {
+      } else if (Arrays.equals(punsubscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bpattern = (byte[]) reply.get(1);
         onPUnsubscribe(bpattern, subscribedChannels);
-      } else if (Arrays.equals(PONG.raw, resp)) {
+      } else if (Arrays.equals(pong.raw, resp)) {
         final byte[] bpattern = (byte[]) reply.get(1);
         onPong(bpattern);
       } else {

--- a/src/main/java/redis/clients/jedis/JedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSub.java
@@ -1,12 +1,12 @@
 package redis.clients.jedis;
 
-import static redis.clients.jedis.Protocol.Keyword.MESSAGE;
-import static redis.clients.jedis.Protocol.Keyword.PMESSAGE;
-import static redis.clients.jedis.Protocol.Keyword.PSUBSCRIBE;
-import static redis.clients.jedis.Protocol.Keyword.PUNSUBSCRIBE;
-import static redis.clients.jedis.Protocol.Keyword.SUBSCRIBE;
-import static redis.clients.jedis.Protocol.Keyword.UNSUBSCRIBE;
-import static redis.clients.jedis.Protocol.Keyword.PONG;
+import static redis.clients.jedis.Protocol.Keyword.message;
+import static redis.clients.jedis.Protocol.Keyword.pmessage;
+import static redis.clients.jedis.Protocol.Keyword.pong;
+import static redis.clients.jedis.Protocol.Keyword.psubscribe;
+import static redis.clients.jedis.Protocol.Keyword.punsubscribe;
+import static redis.clients.jedis.Protocol.Keyword.subscribe;
+import static redis.clients.jedis.Protocol.Keyword.unsubscribe;
 
 import java.util.Arrays;
 import java.util.List;
@@ -134,23 +134,23 @@ public abstract class JedisPubSub {
         throw new JedisException("Unknown message type: " + firstObj);
       }
       final byte[] resp = (byte[]) firstObj;
-      if (Arrays.equals(SUBSCRIBE.raw, resp)) {
+      if (Arrays.equals(subscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bchannel = (byte[]) reply.get(1);
         final String strchannel = (bchannel == null) ? null : SafeEncoder.encode(bchannel);
         onSubscribe(strchannel, subscribedChannels);
-      } else if (Arrays.equals(UNSUBSCRIBE.raw, resp)) {
+      } else if (Arrays.equals(unsubscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bchannel = (byte[]) reply.get(1);
         final String strchannel = (bchannel == null) ? null : SafeEncoder.encode(bchannel);
         onUnsubscribe(strchannel, subscribedChannels);
-      } else if (Arrays.equals(MESSAGE.raw, resp)) {
+      } else if (Arrays.equals(message.raw, resp)) {
         final byte[] bchannel = (byte[]) reply.get(1);
         final byte[] bmesg = (byte[]) reply.get(2);
         final String strchannel = (bchannel == null) ? null : SafeEncoder.encode(bchannel);
         final String strmesg = (bmesg == null) ? null : SafeEncoder.encode(bmesg);
         onMessage(strchannel, strmesg);
-      } else if (Arrays.equals(PMESSAGE.raw, resp)) {
+      } else if (Arrays.equals(pmessage.raw, resp)) {
         final byte[] bpattern = (byte[]) reply.get(1);
         final byte[] bchannel = (byte[]) reply.get(2);
         final byte[] bmesg = (byte[]) reply.get(3);
@@ -158,17 +158,17 @@ public abstract class JedisPubSub {
         final String strchannel = (bchannel == null) ? null : SafeEncoder.encode(bchannel);
         final String strmesg = (bmesg == null) ? null : SafeEncoder.encode(bmesg);
         onPMessage(strpattern, strchannel, strmesg);
-      } else if (Arrays.equals(PSUBSCRIBE.raw, resp)) {
+      } else if (Arrays.equals(psubscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bpattern = (byte[]) reply.get(1);
         final String strpattern = (bpattern == null) ? null : SafeEncoder.encode(bpattern);
         onPSubscribe(strpattern, subscribedChannels);
-      } else if (Arrays.equals(PUNSUBSCRIBE.raw, resp)) {
+      } else if (Arrays.equals(punsubscribe.raw, resp)) {
         subscribedChannels = ((Long) reply.get(2)).intValue();
         final byte[] bpattern = (byte[]) reply.get(1);
         final String strpattern = (bpattern == null) ? null : SafeEncoder.encode(bpattern);
         onPUnsubscribe(strpattern, subscribedChannels);
-      } else if (Arrays.equals(PONG.raw, resp)) {
+      } else if (Arrays.equals(pong.raw, resp)) {
         final byte[] bpattern = (byte[]) reply.get(1);
         final String strpattern = (bpattern == null) ? null : SafeEncoder.encode(bpattern);
         onPong(strpattern);

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -3,7 +3,6 @@ package redis.clients.jedis;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.*;
@@ -275,13 +274,15 @@ public final class Protocol {
   }
 
   public static enum Keyword {
-    AGGREGATE, ALPHA, ASC, BY, DESC, GET, LIMIT, MESSAGE, NO, NOSORT, PMESSAGE, PSUBSCRIBE,
-    PUNSUBSCRIBE, OK, ONE, QUEUED, SET, STORE, SUBSCRIBE, UNSUBSCRIBE, WEIGHTS, WITHSCORES,
+    // Request keywords
+    AGGREGATE, ALPHA, ASC, BY, DESC, GET, LIMIT, NO, NOSORT, ONE, SET, STORE, WEIGHTS, WITHSCORES,
     RESETSTAT, REWRITE, RESET, FLUSH, EXISTS, LOAD, KILL, LEN, REFCOUNT, ENCODING, IDLETIME,
-    GETNAME, SETNAME, LIST, MATCH, COUNT, PING, PONG, UNLOAD, REPLACE, KEYS, PAUSE, DOCTOR,
-    BLOCK, NOACK, STREAMS, KEY, CREATE, MKSTREAM, SETID, DESTROY, DELCONSUMER, MAXLEN, GROUP,
-    ID, IDLE, TIME, RETRYCOUNT, FORCE, USAGE, SAMPLES, STREAM, GROUPS, CONSUMERS, HELP, FREQ,
-    SETUSER, GETUSER, DELUSER, WHOAMI, CAT, GENPASS, USERS, LOG;
+    GETNAME, SETNAME, LIST, MATCH, COUNT, PING, @Deprecated PONG, UNLOAD, REPLACE, KEYS, PAUSE,
+    DOCTOR, BLOCK, NOACK, STREAMS, KEY, CREATE, MKSTREAM, SETID, DESTROY, DELCONSUMER, MAXLEN,
+    GROUP, ID, IDLE, TIME, RETRYCOUNT, FORCE, USAGE, SAMPLES, STREAM, GROUPS, CONSUMERS, HELP, FREQ,
+    SETUSER, GETUSER, DELUSER, WHOAMI, CAT, GENPASS, USERS, LOG,
+    // Response keywords
+    OK, QUEUED, message, pmessage, psubscribe, punsubscribe, subscribe, unsubscribe, pong;
 
     /**
      * @deprecated This will be private in future. Use {@link #getRaw()}.
@@ -289,7 +290,7 @@ public final class Protocol {
     public final byte[] raw;
 
     Keyword() {
-      raw = SafeEncoder.encode(this.name().toLowerCase(Locale.ENGLISH));
+      raw = SafeEncoder.encode(this.name());
     }
 
     public byte[] getRaw() {


### PR DESCRIPTION
There was already an issue in #1319. Having the opportunity, may it be better to skip it entirely?

Note: Introduction of `toLowerCase()` is dated back to #37.