### PR TITLE
Wait strategies (2.10)

### DIFF
--- a/src/main/java/redis/clients/util/wait/ExponentialWait.java
+++ b/src/main/java/redis/clients/util/wait/ExponentialWait.java
@@ -1,0 +1,83 @@
+package redis.clients.util.wait;
+
+/**
+ * Performs an exponential wait by taking the result of an evaluator into account.
+ * So it waits until a maximum number of retries is reached or until the evaluator is returning a positive result.
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
+public class ExponentialWait implements IWaitStrategy {
+
+
+    //Default
+    //Wait for max. 4 mins: 1000 + 2000 + 4000 + 8000 + 16000 + 32000 + 64000 + 128000 = 255000ms
+    public static final long WAIT_TIME = 1000;
+    public static final int RETRY_FACTOR = 2;
+    public static final int MAX_RETRIES = 8;
+
+
+    //Members
+    private IEvaluator eval;
+    private long waitTime;
+    private int retryFactor;
+    private int maxRetries;
+
+    /**
+     * The Ctor which uses the default values
+     *
+     * @param eval
+     */
+    public ExponentialWait(IEvaluator eval) {
+
+        this(WAIT_TIME, RETRY_FACTOR, MAX_RETRIES, eval);
+    }
+
+    /**
+     * Full Ctor
+     * @param waitTime
+     * @param retryFactor
+     * @param maxRetries
+     * @param eval
+     */
+    public ExponentialWait(long waitTime, int retryFactor, int maxRetries, IEvaluator eval) {
+
+        this.waitTime = waitTime;
+        this.retryFactor = retryFactor;
+        this.maxRetries = maxRetries;
+        this.eval = eval;
+    }
+
+    /**
+     * Wait until the max. number of retries is reached or until the evaluator returns a success.
+     *
+     * @throws InterruptedException
+     */
+    @Override
+    public void waitFor() throws InterruptedException {
+
+        //Init
+        int numTries = 0;
+        boolean isWaiting = true;
+        long currWait = waitTime;
+
+        //While none of the conditions was met
+        while (isWaiting) {
+
+            //If the evaluator returns true then waiting is over
+            if (eval.check()) {
+
+                isWaiting = false;
+
+            } else {
+
+                //Continue waiting by increasing the next wait time by the given retry factor
+                numTries++;
+                Thread.sleep(currWait);
+                currWait = currWait*retryFactor;
+
+                //Don't wait anymore if the maximum number of retries is reached
+                if (numTries == maxRetries) isWaiting = false;
+            }
+        }
+    }
+}

--- a/src/main/java/redis/clients/util/wait/IEvaluator.java
+++ b/src/main/java/redis/clients/util/wait/IEvaluator.java
@@ -1,0 +1,18 @@
+package redis.clients.util.wait;
+
+/**
+ * An Evaluator has a single method in order to check
+ * if an external condition is true.
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
+public interface IEvaluator {
+
+    /**
+     * Check if the condition is true
+     *
+     * @return
+     */
+    boolean check();
+
+}

--- a/src/main/java/redis/clients/util/wait/IWaitStrategy.java
+++ b/src/main/java/redis/clients/util/wait/IWaitStrategy.java
@@ -1,0 +1,19 @@
+package redis.clients.util.wait;
+
+/**
+ * Describes a Wait strategy. A wait strategy is implemented by implementing the method 'waitFor'.
+ * All relevant parameters should be passed to the constructor.
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
+public interface IWaitStrategy {
+
+    /**
+     * Wait based on the wait strategy.
+     * Waiting might be interrupted for some reason.
+     * In this case an InterruptedException is thrown
+     *
+     * @throws InterruptedException
+     */
+    void waitFor() throws InterruptedException;
+}

--- a/src/main/java/redis/clients/util/wait/LinearWait.java
+++ b/src/main/java/redis/clients/util/wait/LinearWait.java
@@ -1,0 +1,39 @@
+package redis.clients.util.wait;
+
+
+/**
+ * A linear wait is an exponential with with a retry factor of 1
+ *
+ *  @author nosqlgeek (david.maier@redislabs.com)
+ */
+public class LinearWait extends ExponentialWait {
+
+
+    //Default
+    //Wait for max. 4mins: 2000 * 120 = 240000ms
+    public static final long WAIT_TIME = 2000;
+    public static final int MAX_RETRIES = 120;
+
+
+    /**
+     * Default Ctor
+     *
+     * @param eval
+     */
+    public LinearWait(IEvaluator eval) {
+        super(WAIT_TIME, 1, MAX_RETRIES, eval);
+    }
+
+    /**
+     * Full Ctor
+     *
+     * @param waitTime
+     * @param maxRetries
+     * @param eval
+     */
+    public LinearWait(long waitTime, int maxRetries, IEvaluator eval) {
+
+        super(waitTime, 1, maxRetries, eval);
+    }
+
+}

--- a/src/main/java/redis/clients/util/wait/SentinelUpEvaluator.java
+++ b/src/main/java/redis/clients/util/wait/SentinelUpEvaluator.java
@@ -1,0 +1,87 @@
+package redis.clients.util.wait;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+/**
+ * An evaluator which checks if it is possible to connect to Sentinel.
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
+public class SentinelUpEvaluator implements IEvaluator {
+
+    public static final int CONN_TIMEOUT = 1000;
+
+    /**
+     * The Sentinel host
+     */
+    private String host;
+
+    /**
+     * The Sentinel port
+     */
+    private int port;
+
+    /**
+     * Redis client
+     */
+    private Jedis client;
+
+
+    /**
+     * Connection timeout
+     */
+    private int timeout;
+
+
+    /**
+     * Default Ctor
+     *
+     * @param host
+     * @param port
+     */
+    public SentinelUpEvaluator(String host, int port) {
+
+       this(host,port, CONN_TIMEOUT);
+    }
+
+    /**
+     * Full Ctor
+     *
+     * @param host
+     * @param port
+     * @param timeout
+     */
+    public SentinelUpEvaluator(String host, int port, int timeout) {
+
+        this.host = host;
+        this.port = port;
+        this.timeout = timeout;
+        this.client = new Jedis(host, port);
+    }
+
+
+
+    /**
+     * Check if it's possible to connect to Sentinel.
+     *
+     * @return True if a connection was possible
+     */
+    @Override
+    public boolean check() {
+
+        try {
+
+            client = new Jedis(this.host, this.port, this.timeout);
+            client.connect();
+            client.disconnect();
+            return true;
+
+        } catch (JedisConnectionException e) {
+
+            return false;
+        }
+
+
+    }
+}

--- a/src/main/java/redis/clients/util/wait/SimpleWait.java
+++ b/src/main/java/redis/clients/util/wait/SimpleWait.java
@@ -1,0 +1,34 @@
+package redis.clients.util.wait;
+
+/**
+ * A simple wait allows you to just wait for a specific amount of time.
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
+public class SimpleWait implements IWaitStrategy {
+
+
+    /**
+     * Time to wait for in ms
+     */
+    private long time;
+
+
+    /**
+     * Default Ctor
+     *
+     * @param time in ms
+     */
+    public SimpleWait(long time) {
+
+        this.time = time;
+    }
+
+
+    @Override
+    public void waitFor() throws InterruptedException {
+
+        Thread.sleep(time);
+
+    }
+}

--- a/src/main/java/redis/clients/util/wait/TimerEvaluator.java
+++ b/src/main/java/redis/clients/util/wait/TimerEvaluator.java
@@ -1,0 +1,52 @@
+package redis.clients.util.wait;
+
+
+/**
+ * This evaluator checks if a specific duration is over. We will use this evaluator for testing purposes.
+ * It allows to validate if one of the Wait strategies works as expected from a timing point of view.
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
+public class TimerEvaluator implements IEvaluator {
+
+
+    //Attributes
+    private long startTime;
+    private long endTime;
+    private long duration;
+
+
+    /**
+     * Default Ctor
+     */
+    public TimerEvaluator(long duration) {
+
+        startTime = -1;
+        endTime = -1;
+        this.duration = duration;
+    }
+
+
+    /**
+     * Check if the duration was reached since you checked the last time
+     *
+     * @return
+     */
+    @Override
+    public boolean check() {
+
+        if (startTime == -1) {
+
+            startTime = System.currentTimeMillis();
+
+        } else {
+
+            endTime = System.currentTimeMillis();
+
+            if (endTime - startTime >= duration) return true;
+        }
+
+        //Return false by default
+        return false;
+    }
+}

--- a/src/test/java/redis/clients/jedis/tests/utils/wait/ExponentialWaitTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/wait/ExponentialWaitTest.java
@@ -1,4 +1,116 @@
 package redis.clients.jedis.tests.utils.wait;
 
-public class ExponentialWaitTest {
+import static org.junit.Assert.*;
+import org.junit.*;
+import redis.clients.util.wait.ExponentialWait;
+import redis.clients.util.wait.IWaitStrategy;
+import redis.clients.util.wait.TimerEvaluator;
+
+
+/**
+ * Test the exponential wait strategy
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
+public class ExponentialWaitTest  {
+
+    //To wait max. this amount of time. Huge value which is passed over to wait forever
+    public static final long MAX_TIME = 300000;
+
+    /**
+     * Test the exponential wait in general
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testExponentialWait() throws InterruptedException {
+
+        /*
+         * We expect to wait 50 + 250 + 1250 = 1550ms
+         * But we would anyway stop waiting after MAX_TIME
+         */
+        IWaitStrategy w = new ExponentialWait(50, 5, 3, new TimerEvaluator(MAX_TIME));
+
+        long expected = 1550;
+        long tolerance = (expected / 10)*2;
+
+        System.out.println("Expecting to wait for: " + expected + " ms");
+
+        long start = System.currentTimeMillis();
+        w.waitFor();
+        long end = System.currentTimeMillis();
+
+        long timeWaited = end - start;
+
+        System.out.println("Waited for: " + timeWaited + " ms");
+
+        assertTrue(timeWaited <= (expected + tolerance));
+    }
+
+    /**
+     * Test the exponential wait with the default settings
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testExponentialWaitDefault() throws InterruptedException {
+
+        IWaitStrategy w = new ExponentialWait(new TimerEvaluator(MAX_TIME));
+
+        //4 mins
+        long expected = 255000;
+        long tolerance = (expected / 10)*2;
+
+        long start = System.currentTimeMillis();
+        w.waitFor();
+        long end = System.currentTimeMillis();
+
+        System.out.println("Waited for: " + (end - start) + " ms");
+
+        assertTrue((end - start) <= (expected + tolerance));
+    }
+
+    /**
+     * Test if waiting completes as expected
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testExponentialWaitCompleted() throws InterruptedException {
+
+        //100 + 200 + 400 + 800 = 1500ms
+        IWaitStrategy w = new ExponentialWait(100, 2, 4, new TimerEvaluator(3000));
+
+        long start = System.currentTimeMillis();
+        w.waitFor();
+        long end = System.currentTimeMillis();
+
+        System.out.println("Waited for: " + (end - start) + " ms");
+
+        //Waiting ends after the exponential wait time is over (approx. 1500ms)
+        assertTrue(end - start <= 2000);
+    }
+
+
+    /**
+     * Test if the evaluator is interupting the wait as expected
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testExponentialWaitEvalSuccess() throws InterruptedException {
+
+        //100 + 200 + 400 + 800 = 1500ms
+        IWaitStrategy w = new ExponentialWait(100, 2, 4, new TimerEvaluator(500));
+
+        long start = System.currentTimeMillis();
+        w.waitFor();
+        long end = System.currentTimeMillis();
+
+        System.out.println("Waited for: " + (end - start) + " ms");
+
+        //Waiting ends before the exponential wait time is over (approx. 1500ms)
+        assertTrue(end - start <= 1200);
+    }
+
 }

--- a/src/test/java/redis/clients/jedis/tests/utils/wait/ExponentialWaitTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/wait/ExponentialWaitTest.java
@@ -1,0 +1,4 @@
+package redis.clients.jedis.tests.utils.wait;
+
+public class ExponentialWaitTest {
+}

--- a/src/test/java/redis/clients/jedis/tests/utils/wait/LinearWaitTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/wait/LinearWaitTest.java
@@ -1,4 +1,72 @@
 package redis.clients.jedis.tests.utils.wait;
 
+import static org.junit.Assert.*;
+import org.junit.*;
+import redis.clients.util.wait.LinearWait;
+import redis.clients.util.wait.IWaitStrategy;
+import redis.clients.util.wait.TimerEvaluator;
+
+/**
+ * Test the linear wait strategy
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
 public class LinearWaitTest {
+
+    public static final long MAX_TIME = 300000;
+
+
+    /**
+     * Test linear wait in general
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testLinearWait() throws InterruptedException {
+
+        /*
+         * We expect to wait 100 * 10 = 1000ms
+         * But we would anyway stop waiting after MAX_TIME
+         */
+        IWaitStrategy w = new LinearWait(100, 10, new TimerEvaluator(MAX_TIME));
+
+        long expected = 1000;
+        long tolerance = (expected / 10)*2;
+
+        System.out.println("Expecting to wait for: " + expected + " ms");
+
+        long start = System.currentTimeMillis();
+        w.waitFor();
+        long end = System.currentTimeMillis();
+
+        long timeWaited = end - start;
+
+        System.out.println("Waited for: " + timeWaited + " ms");
+
+        assertTrue(timeWaited <= (expected + tolerance));
+    }
+
+    /**
+     * Test linear wait with default settings
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testLinearWaitDefault() throws InterruptedException {
+
+        IWaitStrategy w = new LinearWait(new TimerEvaluator(MAX_TIME));
+
+        //4 mins
+        long expected = 240000;
+        long tolerance = (expected / 10)*2;
+
+        long start = System.currentTimeMillis();
+        w.waitFor();
+        long end = System.currentTimeMillis();
+
+        long timeWaited = end - start;
+        System.out.println("Waited for: " + timeWaited + " ms");
+
+        assertTrue(timeWaited <= (expected + tolerance));
+    }
 }

--- a/src/test/java/redis/clients/jedis/tests/utils/wait/LinearWaitTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/wait/LinearWaitTest.java
@@ -1,0 +1,4 @@
+package redis.clients.jedis.tests.utils.wait;
+
+public class LinearWaitTest {
+}

--- a/src/test/java/redis/clients/jedis/tests/utils/wait/SimpleWaitTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/wait/SimpleWaitTest.java
@@ -1,0 +1,4 @@
+package redis.clients.jedis.tests.utils.wait;
+
+public class SimpleWaitTest {
+}

--- a/src/test/java/redis/clients/jedis/tests/utils/wait/SimpleWaitTest.java
+++ b/src/test/java/redis/clients/jedis/tests/utils/wait/SimpleWaitTest.java
@@ -1,4 +1,31 @@
 package redis.clients.jedis.tests.utils.wait;
 
+import static org.junit.Assert.*;
+import org.junit.*;
+import redis.clients.util.wait.IWaitStrategy;
+import redis.clients.util.wait.SimpleWait;
+
+/**
+ * Test the simple wait strategy
+ *
+ * @author nosqlgeek (david.maier@redislabs.com)
+ */
 public class SimpleWaitTest {
+
+    /**
+     * Test if a simple wait is waiting for the specified duration
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void testSimpleWait() throws InterruptedException {
+
+        long start = System.currentTimeMillis();
+        IWaitStrategy w = new SimpleWait(1000);
+        w.waitFor();
+        long end = System.currentTimeMillis();
+        assertTrue(end - start >= 1000);
+
+    }
+
 }


### PR DESCRIPTION
Hi, this is adding some wait strategies to Jedis 2.10.x . The main purpose was to have a smarter way to wait in case that a Sentinel is unavailable for a specific period of time. This especially useful if it's not possible to pass multiple Sentinel endpoints over for the initial connection. Here an example:

1. Let's assume that Redis is provided as DBaaS by exposing exactly one endpoint
2. Let's further assume that we can reach a Sentinel behind the FQN of this endpoint (on a different port than the DB endpoint itself)

We would like to be able to survive the failover of such a DB endpoint by then being able to fetch the DB master again via Sentinel. Such a failover can take longer than the default amount of time in the original source code which is the reason why we decided to replace the simple Thread.sleep by a wait strategy.