### PR TITLE
Providing JedisPool to be created with abandon config

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -6,6 +6,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.apache.commons.pool2.impl.AbandonedConfig;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
@@ -51,6 +52,15 @@ public class JedisPool extends JedisPoolAbstract {
           Protocol.DEFAULT_DATABASE, null, false, null, null, null), new GenericObjectPoolConfig());
     }
   }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+			final int connectionTimeout, final int soTimeout, final String password, final int database,
+			final String clientName, final boolean ssl, AbandonedConfig abandonedConfig) {
+		this.internalPool = new GenericObjectPool<Jedis>(
+					new JedisFactory(host, port, connectionTimeout, soTimeout,
+							password, database, clientName, ssl, null, null, null),
+					poolConfig, abandonedConfig);
+	}
 
   public JedisPool(final URI uri) {
     this(new GenericObjectPoolConfig(), uri);


### PR DESCRIPTION
There are a lot of discussions and forums indicating connection issues, maxing out over period of time, connections leakage and not returning to pool.

This abandon config will give the client an option to abandon connections which are not returned back in a specified time - making the connection pool steady and available for app all the time