### PR TITLE
Implement ability to connect to Sentinel with TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,12 @@ pid = /tmp/stunnel.pid
 [redis]
 accept = 127.0.0.1:6390
 connect = 127.0.0.1:6379
+[redis_3]
+accept = 127.0.0.1:16381
+connect = 127.0.0.1:6381
+[redis_4]
+accept = 127.0.0.1:16382
+connect = 127.0.0.1:6382
 [redis_cluster_1]
 accept = 127.0.0.1:8379
 connect = 127.0.0.1:7379
@@ -243,6 +249,18 @@ connect = 127.0.0.1:7382
 [redis_cluster_5]
 accept = 127.0.0.1:8383
 connect = 127.0.0.1:7383
+[redis_sentinel_1]
+accept = 127.0.0.1:36379
+connect = 127.0.0.1:26379
+[redis_sentinel_2]
+accept = 127.0.0.1:36380
+connect = 127.0.0.1:26380
+[redis_sentinel_3]
+accept = 127.0.0.1:36381
+connect = 127.0.0.1:26381
+[redis_sentinel_4]
+accept = 127.0.0.1:36382
+connect = 127.0.0.1:26382
 endef
 
 export REDIS1_CONF

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisSentinelPoolTest.java
@@ -1,0 +1,91 @@
+package redis.clients.jedis.tests;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisSentinelPool;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
+
+public class SSLJedisSentinelPoolTest {
+  private static final String MASTER_NAME = "mymaster";
+
+  protected Set<String> sentinels = new HashSet<String>();
+
+  @Before
+  public void setUp() throws Exception {
+    HostAndPort sentinel2 = HostAndPortUtil.getSentinelServers().get(1);
+    HostAndPort sentinel4 = HostAndPortUtil.getSentinelServers().get(3);
+    sentinels.add(sentinel2.getHost() + ":" + (sentinel2.getPort() + 10000));
+    sentinels.add(sentinel4.getHost() + ":" + (sentinel4.getPort() + 10000));
+  }
+
+  @BeforeClass
+  public static void setupTrustStore() {
+    setJvmTrustStore("src/test/resources/truststore.jceks", "jceks");
+  }
+
+  private static void setJvmTrustStore(String trustStoreFilePath, String trustStoreType) {
+    assertTrue(String.format("Could not find trust store at '%s'.", trustStoreFilePath), new File(
+        trustStoreFilePath).exists());
+    System.setProperty("javax.net.ssl.trustStore", trustStoreFilePath);
+    System.setProperty("javax.net.ssl.trustStoreType", trustStoreType);
+  }
+
+  @Test
+  public void sentinelWithSslConnectsToRedisWithoutSsl() {
+    boolean redisSsl = false;
+    boolean sentinelSsl = true;
+    GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+    JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, poolConfig, 1000, 1000,
+        "foobared", 0, "clientName", 1000, 1000, null, "sentinelClientName", redisSsl, sentinelSsl, null, null, null);
+    pool.getResource().close();
+    pool.destroy();
+  }
+
+  @Test
+  public void sentinelWithSslConnectsToRedisWithSsl() {
+    boolean redisSsl = true;
+    boolean sentinelSsl = true;
+    GenericObjectPoolConfig poolConfig = new GenericObjectPoolConfig();
+
+    class PortSwizzlingJedisSentinelPool extends JedisSentinelPool {
+      public PortSwizzlingJedisSentinelPool(String masterName, Set<String> sentinels,
+          GenericObjectPoolConfig poolConfig, int connectionTimeout, int soTimeout, String password, int database,
+          String clientName, int sentinelConnectionTimeout, int sentinelSoTimeout, String sentinelPassword,
+          String sentinelClientName, boolean isRedisSslEnabled, boolean isSentinelSslEnabled,
+          SSLSocketFactory sslSocketFactory, SSLParameters sslParameters, HostnameVerifier hostnameVerifier) {
+        super(masterName, sentinels, poolConfig, connectionTimeout, soTimeout, password, database, clientName,
+            sentinelConnectionTimeout, sentinelSoTimeout, sentinelPassword, sentinelClientName, isRedisSslEnabled,
+            isSentinelSslEnabled, sslSocketFactory, sslParameters, hostnameVerifier);
+      }
+
+      @Override
+      protected HostAndPort toHostAndPort(List<String> getMasterAddrByNameResult) {
+        // Sentinel broadcasts the non-ssl port number of redis, this swizzles it to the ssl port.
+        HashMap<Integer, Integer> portMapping = new HashMap<Integer, Integer>();
+        portMapping.put(6381, 16381);
+        portMapping.put(6382, 16382);
+        HostAndPort original = super.toHostAndPort(getMasterAddrByNameResult);
+        int swizzled = portMapping.get(original.getPort());
+        return new HostAndPort(original.getHost(), swizzled);
+      }
+    }
+    JedisSentinelPool pool = new PortSwizzlingJedisSentinelPool(MASTER_NAME, sentinels, poolConfig, 1000, 1000,
+            "foobared", 0, "clientName", 1000, 1000, null, "sentinelClientName", redisSsl, sentinelSsl, null, null, null);
+    pool.getResource().close();
+    pool.destroy();
+  }
+
+}


### PR DESCRIPTION
This change allows connecting to sentinel via TLS. Additionally, you can specify if you want to connect to the redis master with TLS or not.

When connecting to sentinel with TLS, it will still broadcast the non-TLS ports for redis. For this scenario to work, `toHostAndPort` was modified to be protected so consumers can sub-class JedisSentinelPool and implement your own port mapping behavior.