### PR TITLE
(#2120) GeoRadius support store and storedist option

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1213,6 +1213,12 @@ public class BinaryClient extends Connection {
       toByteArray(radius), unit.raw));
   }
 
+  public void georadiusStore(final byte[] key, final double longitude, final double latitude, final double radius, final GeoUnit unit,
+      final GeoRadiusParam param) {
+    sendCommand(GEORADIUS, param.getByteParams(key, toByteArray(longitude), toByteArray(latitude),
+        toByteArray(radius), unit.raw));
+  }
+
   public void georadiusReadonly(final byte[] key, final double longitude, final double latitude, final double radius, final GeoUnit unit,
       final GeoRadiusParam param) {
     sendCommand(GEORADIUS_RO, param.getByteParams(key, toByteArray(longitude), toByteArray(latitude),
@@ -1228,6 +1234,11 @@ public class BinaryClient extends Connection {
   }
 
   public void georadiusByMember(final byte[] key, final byte[] member, final double radius, final GeoUnit unit,
+      final GeoRadiusParam param) {
+    sendCommand(GEORADIUSBYMEMBER, param.getByteParams(key, member, toByteArray(radius), unit.raw));
+  }
+
+  public void georadiusByMemberStore(final byte[] key, final byte[] member, final double radius, final GeoUnit unit,
       final GeoRadiusParam param) {
     sendCommand(GEORADIUSBYMEMBER, param.getByteParams(key, member, toByteArray(radius), unit.raw));
   }

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -3815,6 +3815,14 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   @Override
+  public Long georadiusStore(final byte[] key, final double longitude, final double latitude,
+      final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    checkIsInMultiOrPipeline();
+    client.georadiusStore(key, longitude, latitude, radius, unit, param);
+    return client.getIntegerReply();
+  }
+
+  @Override
   public List<GeoRadiusResponse> georadiusReadonly(final byte[] key, final double longitude, final double latitude,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
     checkIsInMultiOrPipeline();
@@ -3844,6 +3852,14 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     checkIsInMultiOrPipeline();
     client.georadiusByMember(key, member, radius, unit, param);
     return BuilderFactory.GEORADIUS_WITH_PARAMS_RESULT.build(client.getObjectMultiBulkReply());
+  }
+
+  @Override
+  public Long georadiusByMemberStore(final byte[] key, final byte[] member, final double radius,
+      final GeoUnit unit, final GeoRadiusParam param) {
+    checkIsInMultiOrPipeline();
+    client.georadiusByMemberStore(key, member, radius, unit, param);
+    return client.getIntegerReply();
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -1897,6 +1897,18 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   }
 
   @Override
+  public Long georadiusStore(final byte[] key, final double longitude,
+      final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    byte[][] keys = param.getByteKeys(key);
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+      @Override
+      public Long execute(Jedis connection) {
+        return connection.georadiusStore(key, longitude, latitude, radius, unit, param);
+      }
+    }.runBinary(keys.length, keys);
+  }
+
+  @Override
   public List<GeoRadiusResponse> georadiusReadonly(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
     return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
@@ -1938,6 +1950,18 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
         return connection.georadiusByMember(key, member, radius, unit, param);
       }
     }.runBinary(key);
+  }
+
+  @Override
+  public Long georadiusByMemberStore(final byte[] key, final byte[] member,
+      final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    byte[][] keys = param.getByteKeys(key);
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+      @Override
+      public Long execute(Jedis connection) {
+        return connection.georadiusByMemberStore(key, member, radius, unit, param);
+      }
+    }.runBinary(keys.length, keys);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -1120,6 +1120,11 @@ public class Client extends BinaryClient implements Commands {
     georadius(SafeEncoder.encode(key), longitude, latitude, radius, unit, param);
   }
 
+  public void georadiusStore(final String key, final double longitude, final double latitude, final double radius, final GeoUnit unit,
+      final GeoRadiusParam param) {
+    georadiusStore(SafeEncoder.encode(key), longitude, latitude, radius, unit, param);
+  }
+
   public void georadiusReadonly(final String key, final double longitude, final double latitude, final double radius, final GeoUnit unit,
       final GeoRadiusParam param) {
     georadiusReadonly(SafeEncoder.encode(key), longitude, latitude, radius, unit, param);
@@ -1136,6 +1141,11 @@ public class Client extends BinaryClient implements Commands {
   public void georadiusByMember(final String key, final String member, final double radius, final GeoUnit unit,
       final GeoRadiusParam param) {
     georadiusByMember(SafeEncoder.encode(key), SafeEncoder.encode(member), radius, unit, param);
+  }
+
+  public void georadiusByMemberStore(final String key, final String member, final double radius, final GeoUnit unit,
+      final GeoRadiusParam param) {
+    georadiusByMemberStore(SafeEncoder.encode(key), SafeEncoder.encode(member), radius, unit, param);
   }
 
   public void georadiusByMemberReadonly(final String key, final String member, final double radius, final GeoUnit unit,

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3620,6 +3620,14 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   @Override
+  public Long georadiusStore(final String key, double longitude, double latitude, double radius, GeoUnit unit,
+      GeoRadiusParam param) {
+    checkIsInMultiOrPipeline();
+    client.georadiusStore(key, longitude, latitude, radius, unit, param);
+    return client.getIntegerReply();
+  }
+
+  @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude, final double latitude,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
     checkIsInMultiOrPipeline();
@@ -3649,6 +3657,14 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     checkIsInMultiOrPipeline();
     client.georadiusByMember(key, member, radius, unit, param);
     return BuilderFactory.GEORADIUS_WITH_PARAMS_RESULT.build(client.getObjectMultiBulkReply());
+  }
+
+  @Override
+  public Long georadiusByMemberStore(final String key, String member, double radius, GeoUnit unit,
+      GeoRadiusParam param) {
+    checkIsInMultiOrPipeline();
+    client.georadiusByMemberStore(key, member, radius, unit, param);
+    return client.getIntegerReply();
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -2018,6 +2018,18 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   @Override
+  public Long georadiusStore(final String key, final double longitude,
+      final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    String[] keys = param.getStringKeys(key);
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+      @Override
+      public Long execute(Jedis connection) {
+        return connection.georadiusStore(key, longitude, latitude, radius, unit, param);
+      }
+    }.run(keys.length, keys);
+  }
+
+  @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
     return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
@@ -2059,6 +2071,18 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
         return connection.georadiusByMember(key, member, radius, unit, param);
       }
     }.run(key);
+  }
+
+  @Override
+  public Long georadiusByMemberStore(final String key, final String member,
+      final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    String[] keys = param.getStringKeys(key);
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+      @Override
+      public Long execute(Jedis connection) {
+        return connection.georadiusByMemberStore(key, member, radius, unit, param);
+      }
+    }.run(keys.length, keys);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiKeyPipelineBase.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis;
 
 import redis.clients.jedis.commands.*;
+import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.MigrateParams;
 
 import java.util.List;
@@ -719,4 +720,31 @@ public abstract class MultiKeyPipelineBase extends PipelineBase implements
     return getResponse(BuilderFactory.OBJECT);
   }
 
+  @Override
+  public Response<Long> georadiusStore(final String key, final double longitude, final double latitude,
+      final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    client.georadiusStore(key, longitude, latitude, radius, unit, param);
+    return getResponse(BuilderFactory.LONG);
+  }
+
+  @Override
+  public Response<Long> georadiusStore(final byte[] key, final double longitude, final double latitude,
+      final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    client.georadiusStore(key, longitude, latitude, radius, unit, param);
+    return getResponse(BuilderFactory.LONG);
+  }
+
+  @Override
+  public Response<Long> georadiusByMemberStore(final byte[] key, final byte[] member,
+      final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    client.georadiusByMemberStore(key, member, radius, unit, param);
+    return getResponse(BuilderFactory.LONG);
+  }
+
+  @Override
+  public Response<Long> georadiusByMemberStore(final String key, final String member,
+      final double radius, final GeoUnit unit, final GeoRadiusParam param) {
+    client.georadiusByMemberStore(key, member, radius, unit, param);
+    return getResponse(BuilderFactory.LONG);
+  }
 }

--- a/src/main/java/redis/clients/jedis/commands/MultiKeyBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/MultiKeyBinaryCommands.java
@@ -2,8 +2,10 @@ package redis.clients.jedis.commands;
 
 import redis.clients.jedis.BinaryJedisPubSub;
 import redis.clients.jedis.BitOP;
+import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.GeoRadiusParam;
 
 import java.util.List;
 import java.util.Map;
@@ -89,4 +91,10 @@ public interface MultiKeyBinaryCommands {
   List<byte[]> xread(final int count, final long block, final Map<byte[], byte[]> streams);
   
   List<byte[]> xreadGroup(byte[] groupname, byte[] consumer, int count, long block, boolean noAck, Map<byte[], byte[]> streams);
+
+  Long georadiusStore(byte[] key, double longitude, double latitude, double radius,
+      GeoUnit unit, GeoRadiusParam param);
+
+  Long georadiusByMemberStore(byte[] key, byte[] member, double radius, GeoUnit unit,
+      GeoRadiusParam param);
 }

--- a/src/main/java/redis/clients/jedis/commands/MultiKeyBinaryJedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/MultiKeyBinaryJedisClusterCommands.java
@@ -2,10 +2,12 @@ package redis.clients.jedis.commands;
 
 import redis.clients.jedis.BinaryJedisPubSub;
 import redis.clients.jedis.BitOP;
+import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.GeoRadiusParam;
 
 import java.util.List;
 import java.util.Map;
@@ -83,4 +85,10 @@ public interface MultiKeyBinaryJedisClusterCommands {
   List<byte[]> xread(final int count, final long block, final Map<byte[], byte[]> streams);
   
   List<byte[]> xreadGroup(byte[] groupname, byte[] consumer, int count, long block, boolean noAck, Map<byte[], byte[]> streams);
+
+  Long georadiusStore(byte[] key, double longitude, double latitude, double radius,
+      GeoUnit unit, GeoRadiusParam param);
+
+  Long georadiusByMemberStore(byte[] key, byte[] member, double radius, GeoUnit unit,
+      GeoRadiusParam param);
 }

--- a/src/main/java/redis/clients/jedis/commands/MultiKeyBinaryRedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/MultiKeyBinaryRedisPipeline.java
@@ -1,9 +1,11 @@
 package redis.clients.jedis.commands;
 
 import redis.clients.jedis.BitOP;
+import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.MigrateParams;
 
 import java.util.List;
@@ -83,4 +85,10 @@ public interface MultiKeyBinaryRedisPipeline {
   Response<Long> touch(byte[]... keys);
 
   Response<String> migrate(String host, int port, int destinationDB, int timeout, MigrateParams params, byte[]... keys);
+
+  Response<Long> georadiusStore(byte[] key, double longitude, double latitude,
+      double radius, GeoUnit unit, GeoRadiusParam param);
+
+  Response<Long> georadiusByMemberStore(byte[] key, byte[] member, double radius,
+      GeoUnit unit, GeoRadiusParam param);
 }

--- a/src/main/java/redis/clients/jedis/commands/MultiKeyCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/MultiKeyCommands.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.commands;
 
 import redis.clients.jedis.BitOP;
+import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.StreamEntryID;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.ScanParams;
@@ -8,6 +9,7 @@ import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.StreamEntry;
 import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.GeoRadiusParam;
 
 import java.util.List;
 import java.util.Map;
@@ -190,4 +192,10 @@ public interface MultiKeyCommands {
    * @return
    */
   List<Map.Entry<String, List<StreamEntry>>> xreadGroup(String groupname, String consumer, int count, long block, final boolean noAck, Map.Entry<String, StreamEntryID>... streams);
+
+  Long georadiusStore(String key, double longitude, double latitude, double radius,
+      GeoUnit unit, GeoRadiusParam param);
+
+  Long georadiusByMemberStore(String key, String member, double radius, GeoUnit unit,
+      GeoRadiusParam param);
 }

--- a/src/main/java/redis/clients/jedis/commands/MultiKeyCommandsPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/MultiKeyCommandsPipeline.java
@@ -1,9 +1,11 @@
 package redis.clients.jedis.commands;
 
 import redis.clients.jedis.BitOP;
+import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.MigrateParams;
 
 import java.util.List;
@@ -82,4 +84,10 @@ public interface MultiKeyCommandsPipeline {
   Response<Long> touch(String... keys);
 
   Response<String> migrate(String host, int port, int destinationDB, int timeout, MigrateParams params, String... keys);
+
+  Response<Long> georadiusStore(String key, double longitude, double latitude,
+      double radius, GeoUnit unit, GeoRadiusParam param);
+
+  Response<Long> georadiusByMemberStore(String key, String member, double radius,
+      GeoUnit unit, GeoRadiusParam param);
 }

--- a/src/main/java/redis/clients/jedis/commands/MultiKeyJedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/MultiKeyJedisClusterCommands.java
@@ -1,11 +1,13 @@
 package redis.clients.jedis.commands;
 
 import redis.clients.jedis.BitOP;
+import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.JedisPubSub;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.GeoRadiusParam;
 
 import java.util.List;
 import java.util.Set;
@@ -78,4 +80,10 @@ public interface MultiKeyJedisClusterCommands {
   ScanResult<String> scan(String cursor, ScanParams params);
 
   Set<String> keys(String pattern);
+
+  Long georadiusStore(String key, double longitude, double latitude, double radius,
+      GeoUnit unit, GeoRadiusParam param);
+
+  Long georadiusByMemberStore(String key, String member, double radius, GeoUnit unit,
+      GeoRadiusParam param);
 }

--- a/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
+++ b/src/main/java/redis/clients/jedis/params/GeoRadiusParam.java
@@ -4,6 +4,8 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.SafeEncoder;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 public class GeoRadiusParam extends Params {
   private static final String WITHCOORD = "withcoord";
@@ -15,6 +17,9 @@ public class GeoRadiusParam extends Params {
   private static final String ASC = "asc";
   private static final String DESC = "desc";
   private static final String COUNT = "count";
+
+  private static final String STORE = "store";
+  private static final String STOREDIST = "storedist";
 
   public GeoRadiusParam() {
   }
@@ -50,6 +55,48 @@ public class GeoRadiusParam extends Params {
     return this;
   }
 
+  public GeoRadiusParam store(String key) {
+    if (key != null) {
+      addParam(STORE, key);
+    }
+    return this;
+  }
+
+  public GeoRadiusParam storeDist(String key) {
+    if (key != null) {
+      addParam(STOREDIST, key);
+    }
+    return this;
+  }
+
+  public String[] getStringKeys(String key) {
+    List<String> keys = new LinkedList<>();
+    keys.add(key);
+
+    if (contains(STORE)) {
+      keys.add((String)getParam(STORE));
+    }
+
+    if (contains(STOREDIST)) {
+      keys.add((String)getParam(STOREDIST));
+    }
+    return keys.toArray(new String[keys.size()]);
+  }
+
+  public byte[][] getByteKeys(byte[] key) {
+    List<byte[]> keys = new LinkedList<>();
+    keys.add(key);
+
+    if (contains(STORE)) {
+      keys.add(SafeEncoder.encode((String)getParam(STORE)));
+    }
+
+    if (contains(STOREDIST)) {
+      keys.add(SafeEncoder.encode((String)getParam(STOREDIST)));
+    }
+    return keys.toArray(new byte[keys.size()][]);
+  }
+
   public byte[][] getByteParams(byte[]... args) {
     ArrayList<byte[]> byteParams = new ArrayList<byte[]>();
     for (byte[] arg : args) {
@@ -66,6 +113,16 @@ public class GeoRadiusParam extends Params {
     if (contains(COUNT)) {
       byteParams.add(SafeEncoder.encode(COUNT));
       byteParams.add(Protocol.toByteArray((int) getParam(COUNT)));
+    }
+
+    if (contains(STORE)) {
+      byteParams.add(SafeEncoder.encode(STORE));
+      byteParams.add(SafeEncoder.encode((String)getParam(STORE)));
+    }
+
+    if (contains(STOREDIST)) {
+      byteParams.add(SafeEncoder.encode(STOREDIST));
+      byteParams.add(SafeEncoder.encode((String)getParam(STOREDIST)));
     }
 
     if (contains(ASC)) {

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static redis.clients.jedis.tests.utils.AssertUtil.assertByteArraySetEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -30,6 +32,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import redis.clients.jedis.GeoCoordinate;
+import redis.clients.jedis.GeoUnit;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
@@ -38,6 +42,7 @@ import redis.clients.jedis.JedisClusterInfoCache;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.exceptions.*;
+import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.tests.utils.ClientKillerUtil;
 import redis.clients.jedis.tests.utils.JedisClusterTestUtil;
 import redis.clients.jedis.util.JedisClusterCRC16;
@@ -682,6 +687,54 @@ public class JedisClusterTest {
     } catch (JedisClusterOperationException coe) {
       // expected
     }
+  }
+
+  @Test
+  public void georadiusStore() {
+    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
+    jedisClusterNode.add(nodeInfo1);
+    jedisClusterNode.add(nodeInfo2);
+    jedisClusterNode.add(nodeInfo3);
+    JedisCluster cluster = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
+
+    // prepare datas
+    Map<String, GeoCoordinate> coordinateMap = new HashMap<String, GeoCoordinate>();
+    coordinateMap.put("Palermo", new GeoCoordinate(13.361389, 38.115556));
+    coordinateMap.put("Catania", new GeoCoordinate(15.087269, 37.502669));
+    cluster.geoadd("{Sicily}", coordinateMap);
+
+    long size = cluster.georadiusStore("{Sicily}", 15, 37, 200, GeoUnit.KM,
+        GeoRadiusParam.geoRadiusParam().store("{Sicily}Store"));
+    assertEquals(2, size);
+    Set<String> expected = new LinkedHashSet<String>();
+    expected.add("Palermo");
+    expected.add("Catania");
+    assertEquals(expected, cluster.zrange("{Sicily}Store", 0, -1));
+  }
+
+  @Test
+  public void georadiusStoreBinary() {
+    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
+    jedisClusterNode.add(nodeInfo1);
+    jedisClusterNode.add(nodeInfo2);
+    jedisClusterNode.add(nodeInfo3);
+    JedisCluster cluster = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, "cluster", DEFAULT_CONFIG);
+
+    // prepare datas
+    Map<byte[], GeoCoordinate> bcoordinateMap = new HashMap<byte[], GeoCoordinate>();
+    bcoordinateMap.put("Palermo".getBytes(), new GeoCoordinate(13.361389, 38.115556));
+    bcoordinateMap.put("Catania".getBytes(), new GeoCoordinate(15.087269, 37.502669));
+    cluster.geoadd("{Sicily}".getBytes(), bcoordinateMap);
+
+    long size = cluster.georadiusStore("{Sicily}".getBytes(), 15, 37, 200, GeoUnit.KM,
+        GeoRadiusParam.geoRadiusParam().store("{Sicily}Store"));
+    assertEquals(2, size);
+    Set<byte[]> bexpected = new LinkedHashSet<byte[]>();
+    bexpected.add("Palermo".getBytes());
+    bexpected.add("Palermo".getBytes());
+    assertByteArraySetEquals(bexpected, cluster.zrange("{Sicily}Store".getBytes(), 0, -1));
   }
 
   private static String getNodeServingSlotRange(String infoOutput) {

--- a/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/GeoCommandsTest.java
@@ -4,10 +4,13 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static redis.clients.jedis.tests.utils.AssertUtil.assertByteArraySetEquals;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -158,6 +161,23 @@ public class GeoCommandsTest extends JedisCommandTestBase {
   }
 
   @Test
+  public void georadiusStore() {
+    // prepare datas
+    Map<String, GeoCoordinate> coordinateMap = new HashMap<String, GeoCoordinate>();
+    coordinateMap.put("Palermo", new GeoCoordinate(13.361389, 38.115556));
+    coordinateMap.put("Catania", new GeoCoordinate(15.087269, 37.502669));
+    jedis.geoadd("Sicily", coordinateMap);
+
+    long size = jedis.georadiusStore("Sicily", 15, 37, 200, GeoUnit.KM,
+        GeoRadiusParam.geoRadiusParam().store("SicilyStore"));
+    assertEquals(2, size);
+    Set<String> expected = new LinkedHashSet<String>();
+    expected.add("Palermo");
+    expected.add("Catania");
+    assertEquals(expected, jedis.zrange("SicilyStore", 0, -1));
+  }
+
+  @Test
   public void georadiusReadonly() {
     // prepare datas
     Map<String, GeoCoordinate> coordinateMap = new HashMap<String, GeoCoordinate>();
@@ -224,6 +244,23 @@ public class GeoCommandsTest extends JedisCommandTestBase {
   }
 
   @Test
+  public void georadiusStoreBinary() {
+    // prepare datas
+    Map<byte[], GeoCoordinate> bcoordinateMap = new HashMap<byte[], GeoCoordinate>();
+    bcoordinateMap.put(bA, new GeoCoordinate(13.361389, 38.115556));
+    bcoordinateMap.put(bB, new GeoCoordinate(15.087269, 37.502669));
+    jedis.geoadd(bfoo, bcoordinateMap);
+
+    long size = jedis.georadiusStore(bfoo, 15, 37, 200, GeoUnit.KM,
+        GeoRadiusParam.geoRadiusParam().store("SicilyStore"));
+    assertEquals(2, size);
+    Set<byte[]> bexpected = new LinkedHashSet<byte[]>();
+    bexpected.add(bA);
+    bexpected.add(bB);
+    assertByteArraySetEquals(bexpected, jedis.zrange("SicilyStore".getBytes(), 0, -1));
+  }
+
+  @Test
   public void georadiusReadonlyBinary() {
     // prepare datas
     Map<byte[], GeoCoordinate> bcoordinateMap = new HashMap<byte[], GeoCoordinate>();
@@ -284,6 +321,21 @@ public class GeoCommandsTest extends JedisCommandTestBase {
   }
 
   @Test
+  public void georadiusByMemberStore() {
+    jedis.geoadd("Sicily", 13.583333, 37.316667, "Agrigento");
+    jedis.geoadd("Sicily", 13.361389, 38.115556, "Palermo");
+    jedis.geoadd("Sicily", 15.087269, 37.502669, "Catania");
+
+    long size = jedis.georadiusByMemberStore("Sicily", "Agrigento", 100,
+        GeoUnit.KM, GeoRadiusParam.geoRadiusParam().store("SicilyStore"));
+    assertEquals(2, size);
+    Set<String> expected = new LinkedHashSet<String>();
+    expected.add("Agrigento");
+    expected.add("Palermo");
+    assertEquals(expected, jedis.zrange("SicilyStore", 0, -1));
+  }
+
+  @Test
   public void georadiusByMemberReadonly() {
     jedis.geoadd("Sicily", 13.583333, 37.316667, "Agrigento");
     jedis.geoadd("Sicily", 13.361389, 38.115556, "Palermo");
@@ -334,6 +386,21 @@ public class GeoCommandsTest extends JedisCommandTestBase {
     assertTrue(equalsWithinEpsilon(0, member.getDistance()));
     assertTrue(equalsWithinEpsilon(13.583333, member.getCoordinate().getLongitude()));
     assertTrue(equalsWithinEpsilon(37.316667, member.getCoordinate().getLatitude()));
+  }
+
+  @Test
+  public void georadiusByMemberStoreBinary() {
+    jedis.geoadd(bfoo, 13.583333, 37.316667, bA);
+    jedis.geoadd(bfoo, 13.361389, 38.115556, bB);
+    jedis.geoadd(bfoo, 15.087269, 37.502669, bC);
+
+    long size = jedis.georadiusByMemberStore(bfoo, bA, 100, GeoUnit.KM,
+        GeoRadiusParam.geoRadiusParam().store("SicilyStore"));
+    assertEquals(2, size);
+    Set<byte[]> bexpected = new LinkedHashSet<byte[]>();
+    bexpected.add(bA);
+    bexpected.add(bB);
+    assertByteArraySetEquals(bexpected, jedis.zrange("SicilyStore".getBytes(), 0, -1));
   }
 
   @Test


### PR DESCRIPTION
Resolves #2120 
Because `STORE` and` STOREDIST` return `Integer`, they are not compatible with` GEORADIUS` return `MultiBulk`, so new commands` georadiusStore` and `georadiusByMemberStore` have been added.