### PR TITLE
throw exception if JedisCluster cannot connect to any host-port

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/JedisClusterFailStartupTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterFailStartupTest.java
@@ -1,0 +1,16 @@
+package redis.clients.jedis.tests;
+
+import org.junit.Test;
+
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
+
+public class JedisClusterFailStartupTest {
+    
+    @Test(expected=JedisNoReachableClusterNodeException.class)
+    public void test() {
+        new JedisCluster(new HostAndPort("localhost", 16093));
+    }
+
+}


### PR DESCRIPTION
```
new JedisCluster(startNodes)
```
If none of the `startNodes` works:
+ JedisCluster does not work.
+ No message/exception comes up.
+ JedisCluster does not `retry` later.

---
`Throwing exception` seems to be a good solution.
