### PR TITLE
Add support to the use of JedisSocketFactory using a pool

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -279,9 +279,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   /**
-   * @deprecated This will constructor will be removed in future releases
+   * @deprecated This constructor will be removed in future major release.
    *
-   * Use {@link BinaryJedis#BinaryJedis(redis.clients.jedis.JedisSocketFactory, redis.clients.jedis.JedisClientConfig)}
+   * Use {@link BinaryJedis#BinaryJedis(redis.clients.jedis.JedisSocketFactory, redis.clients.jedis.JedisClientConfig)}.
    */
   @Deprecated
   public BinaryJedis(final JedisSocketFactory jedisSocketFactory) {

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -278,8 +278,19 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     }
   }
 
+  /**
+   * @deprecated This will constructor will be removed in future releases
+   *
+   * Use {@link BinaryJedis#BinaryJedis(redis.clients.jedis.JedisSocketFactory, redis.clients.jedis.JedisClientConfig)}
+   */
+  @Deprecated
   public BinaryJedis(final JedisSocketFactory jedisSocketFactory) {
     client = new Client(jedisSocketFactory);
+  }
+
+  public BinaryJedis(final JedisSocketFactory jedisSocketFactory, final JedisClientConfig clientConfig) {
+    client = new Client(jedisSocketFactory);
+    initializeFromClientConfig(clientConfig);
   }
 
   public boolean isConnected() {

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -105,6 +105,21 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
     }
   }
 
+  @Override
+  public JedisSocketFactory copyWith(HostAndPort hostAndPort) {
+    JedisClientConfig config =
+            DefaultJedisClientConfig.builder()
+                                    .connectionTimeoutMillis(this.connectionTimeout)
+                                    .socketTimeoutMillis(this.socketTimeout)
+                                    .ssl(this.ssl)
+                                    .sslSocketFactory(this.sslSocketFactory)
+                                    .sslParameters(this.sslParameters)
+                                    .hostnameVerifier(this.hostnameVerifier)
+                                    .hostAndPortMapper(this.hostAndPortMapper)
+                                    .build();
+    return new DefaultJedisSocketFactory(hostAndPort, config);
+  }
+
   public HostAndPort getSocketHostAndPort() {
     HostAndPortMapper mapper = getHostAndPortMapper();
     HostAndPort hostAndPort = getHostAndPort();

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -3,7 +3,6 @@ package redis.clients.jedis;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
@@ -17,7 +16,7 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
   protected static final HostAndPort DEFAULT_HOST_AND_PORT = new HostAndPort(Protocol.DEFAULT_HOST,
       Protocol.DEFAULT_PORT);
 
-  private final AtomicReference<HostAndPort> hostAndPort = new AtomicReference<>(DEFAULT_HOST_AND_PORT);
+  private volatile HostAndPort hostAndPort = DEFAULT_HOST_AND_PORT;
   private int connectionTimeout = Protocol.DEFAULT_TIMEOUT;
   private int socketTimeout = Protocol.DEFAULT_TIMEOUT;
   private boolean ssl = false;
@@ -41,7 +40,7 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
   public DefaultJedisSocketFactory(String host, int port, int connectionTimeout, int socketTimeout,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier) {
-    this.hostAndPort.set(new HostAndPort(host, port));
+    this.hostAndPort = new HostAndPort(host, port);
     this.connectionTimeout = connectionTimeout;
     this.socketTimeout = socketTimeout;
     this.ssl = ssl;
@@ -52,7 +51,7 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
 
   public DefaultJedisSocketFactory(HostAndPort hostAndPort, JedisClientConfig config) {
     if (hostAndPort != null) {
-      this.hostAndPort.set(hostAndPort);
+      this.hostAndPort = hostAndPort;
     }
     if (config != null) {
       this.connectionTimeout = config.getConnectionTimeoutMillis();
@@ -114,7 +113,7 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
 
   @Override
   public void updateHostAndPort(HostAndPort hostAndPort) {
-    this.hostAndPort.set(hostAndPort);
+    this.hostAndPort = hostAndPort;
   }
 
   public HostAndPort getSocketHostAndPort() {
@@ -130,11 +129,11 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
   }
 
   public HostAndPort getHostAndPort() {
-    return this.hostAndPort.get();
+    return this.hostAndPort;
   }
 
   public void setHostAndPort(HostAndPort hostAndPort) {
-    this.hostAndPort.set(hostAndPort);
+    this.hostAndPort = hostAndPort;
   }
 
   @Override
@@ -144,22 +143,22 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
 
   @Override
   public String getHost() {
-    return this.hostAndPort.get().getHost();
+    return this.hostAndPort.getHost();
   }
 
   @Override
   public void setHost(String host) {
-    this.hostAndPort.set(new HostAndPort(host, this.hostAndPort.get().getPort()));
+    this.hostAndPort = new HostAndPort(host, this.hostAndPort.getPort());
   }
 
   @Override
   public int getPort() {
-    return this.hostAndPort.get().getPort();
+    return this.hostAndPort.getPort();
   }
 
   @Override
   public void setPort(int port) {
-    this.hostAndPort.set(new HostAndPort(this.hostAndPort.get().getHost(), port));
+    this.hostAndPort = new HostAndPort(this.hostAndPort.getHost(), port);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -51,7 +51,9 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
   }
 
   public DefaultJedisSocketFactory(HostAndPort hostAndPort, JedisClientConfig config) {
-    this.hostAndPort.set(hostAndPort);
+    if (hostAndPort != null) {
+      this.hostAndPort.set(hostAndPort);
+    }
     if (config != null) {
       this.connectionTimeout = config.getConnectionTimeoutMillis();
       this.socketTimeout = config.getSocketTimeoutMillis();

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -33,6 +33,10 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
     this(hostAndPort, null);
   }
 
+  public DefaultJedisSocketFactory(JedisClientConfig config) {
+    this(null, config);
+  }
+
   @Deprecated
   public DefaultJedisSocketFactory(String host, int port, int connectionTimeout, int socketTimeout,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -154,9 +154,9 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   /**
-   * @deprecated This will constructor will be removed in future releases
+   * @deprecated This constructor will be removed in future major release.
    *
-   * Use {@link Jedis#Jedis(redis.clients.jedis.JedisSocketFactory, redis.clients.jedis.JedisClientConfig)}
+   * Use {@link Jedis#Jedis(redis.clients.jedis.JedisSocketFactory, redis.clients.jedis.JedisClientConfig)}.
    */
   @Deprecated
   public Jedis(final JedisSocketFactory jedisSocketFactory) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -153,8 +153,18 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     super(uri, config);
   }
 
+  /**
+   * @deprecated This will constructor will be removed in future releases
+   *
+   * Use {@link Jedis#Jedis(redis.clients.jedis.JedisSocketFactory, redis.clients.jedis.JedisClientConfig)}
+   */
+  @Deprecated
   public Jedis(final JedisSocketFactory jedisSocketFactory) {
     super(jedisSocketFactory);
+  }
+
+  public Jedis(final JedisSocketFactory jedisSocketFactory, final JedisClientConfig clientConfig) {
+    super(jedisSocketFactory, clientConfig);
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -135,18 +135,16 @@ public class JedisFactory implements PooledObjectFactory<Jedis> {
   }
 
   public void setHostAndPort(final HostAndPort hostAndPort) {
-    JedisSocketFactory factory = jedisSocketFactory.get();
     // This can only happen if we use a constructor that requires setHostAndPort to be called after,
     // in that case we need to give it an initial value, so we use the default socket factory
-    if (factory == null) {
-      factory = new DefaultJedisSocketFactory(hostAndPort, this.clientConfig);
+    if (jedisSocketFactory.get() == null) {
+      JedisSocketFactory factory = new DefaultJedisSocketFactory(hostAndPort, this.clientConfig);
       // If someone has some logic that can call this code twice in parallel (highly unlikely!)
       // this should protect against setting it with the default twice
-      if (this.jedisSocketFactory.compareAndSet(null, factory)) {
-        return;
+      if (!this.jedisSocketFactory.compareAndSet(null, factory)) {
+        this.jedisSocketFactory.get().updateHostAndPort(hostAndPort);
       }
     }
-    this.jedisSocketFactory.set(this.jedisSocketFactory.get().copyWith(hostAndPort));
   }
 
   public void setPassword(final String password) {

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -261,6 +261,11 @@ public class JedisPool extends JedisPoolAbstract {
     super(poolConfig, new JedisFactory(hostAndPort, clientConfig));
   }
 
+  public JedisPool(final GenericObjectPoolConfig<Jedis> poolConfig, final JedisSocketFactory jedisSocketFactory,
+      final JedisClientConfig clientConfig) {
+    super(poolConfig, new JedisFactory(jedisSocketFactory, clientConfig));
+  }
+
   public JedisPool(final GenericObjectPoolConfig<Jedis> poolConfig) {
     this(poolConfig, Protocol.DEFAULT_HOST, Protocol.DEFAULT_PORT);
   }

--- a/src/main/java/redis/clients/jedis/JedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisSocketFactory.java
@@ -24,7 +24,7 @@ public interface JedisSocketFactory {
    */
   Socket createSocket() throws IOException, JedisConnectionException;
 
-  JedisSocketFactory copyWith(HostAndPort hostAndPort);
+  void updateHostAndPort(HostAndPort hostAndPort);
 
   @Deprecated
   String getDescription();

--- a/src/main/java/redis/clients/jedis/JedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisSocketFactory.java
@@ -24,6 +24,8 @@ public interface JedisSocketFactory {
    */
   Socket createSocket() throws IOException, JedisConnectionException;
 
+  JedisSocketFactory copyWith(HostAndPort hostAndPort);
+
   @Deprecated
   String getDescription();
 

--- a/src/test/java/redis/clients/jedis/tests/UdsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/UdsTest.java
@@ -40,8 +40,8 @@ public class UdsTest {
     }
 
     @Override
-    public JedisSocketFactory copyWith(HostAndPort hostAndPort) {
-      return this;
+    public void updateHostAndPort(HostAndPort hostAndPort) {
+      throw new UnsupportedOperationException("UDS cannot update host and port");
     }
 
     @Override

--- a/src/test/java/redis/clients/jedis/tests/UdsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/UdsTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.newsclub.net.unix.AFUNIXSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
 
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisSocketFactory;
 import redis.clients.jedis.Protocol;
@@ -36,6 +37,11 @@ public class UdsTest {
       } catch (IOException ioe) {
         throw new JedisConnectionException("Failed to create UDS connection.", ioe);
       }
+    }
+
+    @Override
+    public JedisSocketFactory copyWith(HostAndPort hostAndPort) {
+      return this;
     }
 
     @Override


### PR DESCRIPTION
- Support for JedisSocketFactory has already been added to the lowest level Jedis to support adding any custom socket factory (e.g. UDS), this propagates the support in the JedisPool too