### PR TITLE
Update ACL tests and modify JedisPool tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ daemonize yes
 protected-mode no
 port 6379
 requirepass foobared
+user acljedis on allcommands allkeys >fizzbuzz
 pidfile /tmp/redis1.pid
 logfile /tmp/redis1.log
 save ""

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -76,6 +76,15 @@ public class JedisPool extends JedisPoolAbstract {
     this(poolConfig, host, port, timeout, password, Protocol.DEFAULT_DATABASE);
   }
 
+  public JedisPool(final String host, int port, String user, final String password) {
+    this(new GenericObjectPoolConfig(), host, port, user, password);
+  }
+
+  public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
+      String user, final String password) {
+    this(poolConfig, host, port, Protocol.DEFAULT_TIMEOUT, user, password, Protocol.DEFAULT_DATABASE);
+  }
+
   public JedisPool(final GenericObjectPoolConfig poolConfig, final String host, int port,
       int timeout, final String user, final String password) {
     this(poolConfig, host, port, timeout, user, password, Protocol.DEFAULT_DATABASE);

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -66,7 +66,8 @@ public class JedisPoolTest {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared", 0, "closable-resuable-pool");
+    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared", 0,
+        "closable-resuable-pool", false, null, null, null);
 
     Jedis jedis = pool.getResource();
     try {

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -62,7 +62,7 @@ public class JedisPoolTest {
   }
 
   @Test
-  public void checkResourceIsClosebleAndReusable() {
+  public void checkResourceIsClosableAndReusable() {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
@@ -88,15 +88,16 @@ public class JedisPoolTest {
   @Test
   public void checkPoolRepairedWhenJedisIsBroken() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort());
-    Jedis jedis = pool.getResource();
-    jedis.auth("foobared");
-    jedis.quit();
-    jedis.close();
+    try (Jedis jedis = pool.getResource()) {
+      jedis.auth("foobared");
+      jedis.set("foo", "0");
+      jedis.quit();
+    }
 
-    jedis = pool.getResource();
-    jedis.auth("foobared");
-    jedis.incr("foo");
-    jedis.close();
+    try (Jedis jedis = pool.getResource()) {
+      jedis.auth("foobared");
+      jedis.incr("foo");
+    }
     pool.destroy();
     assertTrue(pool.isClosed());
   }

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolTest.java
@@ -23,17 +23,17 @@ import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.jedis.exceptions.JedisExhaustedPoolException;
 
 public class JedisPoolTest {
-  private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
+  private static final HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
 
   @Test
   public void checkConnections() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
-    Jedis jedis = pool.getResource();
-    jedis.auth("foobared");
-    jedis.set("foo", "bar");
-    assertEquals("bar", jedis.get("foo"));
-    jedis.close();
-    pool.destroy();
+    try (Jedis jedis = pool.getResource()) {
+      jedis.auth("foobared");
+      jedis.set("foo", "bar");
+      assertEquals("bar", jedis.get("foo"));
+    }
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
@@ -57,7 +57,7 @@ public class JedisPoolTest {
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
-    pool.destroy();
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
@@ -66,21 +66,16 @@ public class JedisPoolTest {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared", 0,
-        "closable-resuable-pool", false, null, null, null);
+    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared", 0,
+        "closable-resuable-pool", false, null, null, null)) {
 
-    Jedis jedis = pool.getResource();
-    try {
+      Jedis jedis = pool.getResource();
       jedis.set("hello", "jedis");
-    } finally {
       jedis.close();
-    }
 
-    Jedis jedis2 = pool.getResource();
-    try {
+      Jedis jedis2 = pool.getResource();
       assertEquals(jedis, jedis2);
       assertEquals("jedis", jedis2.get("hello"));
-    } finally {
       jedis2.close();
     }
   }
@@ -98,7 +93,7 @@ public class JedisPoolTest {
       jedis.auth("foobared");
       jedis.incr("foo");
     }
-    pool.destroy();
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
@@ -107,14 +102,14 @@ public class JedisPoolTest {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
-    Jedis jedis = pool.getResource();
-    jedis.auth("foobared");
-    jedis.set("foo", "0");
+    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
+        Jedis jedis = pool.getResource()) {
+      jedis.auth("foobared");
 
-    Jedis newJedis = pool.getResource();
-    newJedis.auth("foobared");
-    newJedis.incr("foo");
+      try (Jedis jedis2 = pool.getResource()) {
+        jedis2.auth("foobared");
+      }
+    }
   }
 
   @Test
@@ -122,107 +117,96 @@ public class JedisPoolTest {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
     JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared");
-    Jedis jedis = pool.getResource();
-    jedis.set("foo", "bar");
-    jedis.close();
-    pool.destroy();
+    try (Jedis jedis = pool.getResource()) {
+      jedis.set("foo", "bar");
+    }
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
   @Test
   public void nonDefaultDatabase() {
-    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared");
-    Jedis jedis0 = pool0.getResource();
-    jedis0.set("foo", "bar");
-    assertEquals("bar", jedis0.get("foo"));
-    jedis0.close();
-    pool0.destroy();
-    assertTrue(pool0.isClosed());
+    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "foobared");
+        Jedis jedis0 = pool0.getResource()) {
+      jedis0.set("foo", "bar");
+      assertEquals("bar", jedis0.get("foo"));
+    }
 
-    JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared", 1);
-    Jedis jedis1 = pool1.getResource();
-    assertNull(jedis1.get("foo"));
-    jedis1.close();
-    pool1.destroy();
-    assertTrue(pool1.isClosed());
+    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "foobared", 1);
+        Jedis jedis1 = pool1.getResource()) {
+      assertNull(jedis1.get("foo"));
+    }
   }
 
   @Test
   public void startWithUrlString() {
-    Jedis j = new Jedis("localhost", 6380);
-    j.auth("foobared");
-    j.select(2);
-    j.set("foo", "bar");
-    j.close();
+    try (Jedis j = new Jedis("localhost", 6380)) {
+      j.auth("foobared");
+      j.select(2);
+      j.set("foo", "bar");
+    }
 
-    JedisPool pool = new JedisPool("redis://:foobared@localhost:6380/2");
-    Jedis jedis = pool.getResource();
-    assertEquals("PONG", jedis.ping());
-    assertEquals("bar", jedis.get("foo"));
-    jedis.close();
+    try (JedisPool pool = new JedisPool("redis://:foobared@localhost:6380/2");
+        Jedis jedis = pool.getResource()) {
+      assertEquals("PONG", jedis.ping());
+      assertEquals("bar", jedis.get("foo"));
+    }
   }
 
   @Test
   public void startWithUrl() throws URISyntaxException {
-    Jedis j = new Jedis("localhost", 6380);
-    j.auth("foobared");
-    j.select(2);
-    j.set("foo", "bar");
-    j.close();
+    try (Jedis j = new Jedis("localhost", 6380)) {
+      j.auth("foobared");
+      j.select(2);
+      j.set("foo", "bar");
+    }
 
-    JedisPool pool = new JedisPool(new URI("redis://:foobared@localhost:6380/2"));
-    Jedis jedis = pool.getResource();
-    assertEquals("PONG", jedis.ping());
-    assertEquals("bar", jedis.get("foo"));
+    try (JedisPool pool = new JedisPool(new URI("redis://:foobared@localhost:6380/2"));
+        Jedis jedis = pool.getResource()) {
+      assertEquals("bar", jedis.get("foo"));
+    }
   }
 
   @Test(expected = InvalidURIException.class)
   public void shouldThrowInvalidURIExceptionForInvalidURI() throws URISyntaxException {
-    JedisPool pool = new JedisPool(new URI("localhost:6380"));
+    new JedisPool(new URI("localhost:6380")).close();
   }
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() throws URISyntaxException {
-    new JedisPool("redis://localhost:6380");
-    new JedisPool(new URI("redis://localhost:6380"));
+    new JedisPool("redis://localhost:6380").close();
+    new JedisPool(new URI("redis://localhost:6380")).close();
   }
 
   @Test
   public void selectDatabaseOnActivation() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared");
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+        "foobared")) {
 
-    Jedis jedis0 = pool.getResource();
-    assertEquals(0, jedis0.getDB());
-
-    jedis0.select(1);
-    assertEquals(1, jedis0.getDB());
-
-    jedis0.close();
-
-    Jedis jedis1 = pool.getResource();
-    assertTrue("Jedis instance was not reused", jedis1 == jedis0);
-    assertEquals(0, jedis1.getDB());
-
-    jedis1.close();
-    pool.destroy();
-    assertTrue(pool.isClosed());
+      Jedis jedis0 = pool.getResource();
+      assertEquals(0, jedis0.getDB());
+      
+      jedis0.select(1);
+      assertEquals(1, jedis0.getDB());
+      
+      jedis0.close();
+      
+      Jedis jedis1 = pool.getResource();
+      assertTrue("Jedis instance was not reused", jedis1 == jedis0);
+      assertEquals(0, jedis1.getDB());
+      
+      jedis1.close();
+    }
   }
 
   @Test
   public void customClientName() {
-    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
         "foobared", 0, "my_shiny_client_name");
+        Jedis jedis = pool.getResource()) {
 
-    Jedis jedis = pool0.getResource();
-
-    assertEquals("my_shiny_client_name", jedis.clientGetname());
-
-    jedis.close();
-    pool0.destroy();
-    assertTrue(pool0.isClosed());
+      assertEquals("my_shiny_client_name", jedis.clientGetname());
+    }
   }
 
   @Test
@@ -301,7 +285,7 @@ public class JedisPoolTest {
       jedis2.close();
     }
 
-    pool.destroy();
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
@@ -310,84 +294,88 @@ public class JedisPoolTest {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
         "foobared", 0, "my_shiny_client_name");
 
-    pool.destroy();
+    try (Jedis j = pool.getResource()) {
+      j.ping();
+    }
+
+    pool.close();
     assertTrue(pool.getNumActive() < 0);
   }
 
   @Test
   public void getNumActiveReturnsTheCorrectNumber() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
-    Jedis jedis = pool.getResource();
-    jedis.auth("foobared");
-    jedis.set("foo", "bar");
-    assertEquals("bar", jedis.get("foo"));
-
-    assertEquals(1, pool.getNumActive());
-
-    Jedis jedis2 = pool.getResource();
-    jedis.auth("foobared");
-    jedis.set("foo", "bar");
-
-    assertEquals(2, pool.getNumActive());
-
-    jedis.close();
-    assertEquals(1, pool.getNumActive());
-
-    jedis2.close();
-
-    assertEquals(0, pool.getNumActive());
-
-    pool.destroy();
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+      Jedis jedis = pool.getResource();
+      jedis.auth("foobared");
+      jedis.set("foo", "bar");
+      assertEquals("bar", jedis.get("foo"));
+      
+      assertEquals(1, pool.getNumActive());
+      
+      Jedis jedis2 = pool.getResource();
+      jedis.auth("foobared");
+      jedis.set("foo", "bar");
+      
+      assertEquals(2, pool.getNumActive());
+      
+      jedis.close();
+      assertEquals(1, pool.getNumActive());
+      
+      jedis2.close();
+      
+      assertEquals(0, pool.getNumActive());
+    }
   }
 
   @Test
   public void testAddObject() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
-    pool.addObjects(1);
-    assertEquals(1, pool.getNumIdle());
-    pool.destroy();
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+      pool.addObjects(1);
+      assertEquals(1, pool.getNumIdle());
+    }
   }
 
   @Test
   public void closeResourceTwice() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
-    Jedis j = pool.getResource();
-    j.auth("foobared");
-    j.ping();
-    j.close();
-    j.close();
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+      Jedis j = pool.getResource();
+      j.auth("foobared");
+      j.ping();
+      j.close();
+      j.close();
+    }
   }
 
   @Test
   public void closeBrokenResourceTwice() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
-    Jedis j = pool.getResource();
-    try {
-      // make connection broken
-      j.getClient().getOne();
-      fail();
-    } catch (Exception e) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+      Jedis j = pool.getResource();
+      try {
+        // make connection broken
+        j.getClient().getOne();
+        fail();
+      } catch (Exception e) {
+      }
+      assertTrue(j.getClient().isBroken());
+      j.close();
+      j.close();
     }
-    assertTrue(j.getClient().isBroken());
-    j.close();
-    j.close();
   }
 
   @Test
   public void testCloseConnectionOnMakeObject() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "wrong pass");
-    Jedis jedis = new Jedis("redis://:foobared@localhost:6379/");
-    int currentClientCount = getClientCount(jedis.clientList());
-    try {
-      pool.getResource();
-      fail("Should throw exception as password is incorrect.");
-    } catch (Exception e) {
-      assertEquals(currentClientCount, getClientCount(jedis.clientList()));
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "wrong pass");
+        Jedis jedis = new Jedis("redis://:foobared@localhost:6379/")) {
+      int currentClientCount = getClientCount(jedis.clientList());
+      try {
+        pool.getResource();
+        fail("Should throw exception as password is incorrect.");
+      } catch (Exception e) {
+        assertEquals(currentClientCount, getClientCount(jedis.clientList()));
+      }
     }
-    jedis.close();
   }
 
   private int getClientCount(final String clientList) {

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
@@ -92,6 +92,23 @@ public class JedisPoolWithCompleteCredentialsTest {
     }
   }
 
+  @Test
+  public void checkPoolRepairedWhenJedisIsBroken() {
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(),
+        Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, 0 /*infinite*/, "acljedis", "fizzbuzz",
+        Protocol.DEFAULT_DATABASE, "repairable-pool");
+    try (Jedis jedis = pool.getResource()) {
+      jedis.set("foo", "0");
+      jedis.quit();
+    }
+
+    try (Jedis jedis = pool.getResource()) {
+      jedis.incr("foo");
+    }
+    pool.destroy();
+    assertTrue(pool.isClosed());
+  }
+
   @Test(expected = JedisExhaustedPoolException.class)
   public void checkPoolOverflow() {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
@@ -73,7 +73,8 @@ public class JedisPoolWithCompleteCredentialsTest {
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
     JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), Protocol.DEFAULT_TIMEOUT,
-        Protocol.DEFAULT_TIMEOUT, 0, "acljedis", "fizzbuzz", Protocol.DEFAULT_DATABASE, "closable-resuable-pool");
+        Protocol.DEFAULT_TIMEOUT, 0 /*infinite*/, "acljedis", "fizzbuzz", Protocol.DEFAULT_DATABASE,
+        "closable-resuable-pool", false, null, null, null);
 
     Jedis jedis = pool.getResource();
     try {

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
@@ -26,7 +26,7 @@ import redis.clients.jedis.tests.utils.RedisVersionUtil;
  * This test is only executed when the server/cluster is Redis 6. or more.
  */
 public class JedisPoolWithCompleteCredentialsTest {
-  private static HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
+  private static final HostAndPort hnp = HostAndPortUtil.getRedisServers().get(0);
 
   /**
    * Use to check if the ACL test should be ran. ACL are available only in 6.0 and later
@@ -52,7 +52,7 @@ public class JedisPoolWithCompleteCredentialsTest {
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
-    pool.destroy();
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
@@ -72,22 +72,17 @@ public class JedisPoolWithCompleteCredentialsTest {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), Protocol.DEFAULT_TIMEOUT,
-        Protocol.DEFAULT_TIMEOUT, 0 /*infinite*/, "acljedis", "fizzbuzz", Protocol.DEFAULT_DATABASE,
-        "closable-resuable-pool", false, null, null, null);
+    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(),
+        Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, 0 /*infinite*/, "acljedis", "fizzbuzz",
+        Protocol.DEFAULT_DATABASE, "closable-resuable-pool", false, null, null, null)) {
 
-    Jedis jedis = pool.getResource();
-    try {
+      Jedis jedis = pool.getResource();
       jedis.set("hello", "jedis");
-    } finally {
       jedis.close();
-    }
 
-    Jedis jedis2 = pool.getResource();
-    try {
+      Jedis jedis2 = pool.getResource();
       assertEquals(jedis, jedis2);
       assertEquals("jedis", jedis2.get("hello"));
-    } finally {
       jedis2.close();
     }
   }
@@ -105,7 +100,7 @@ public class JedisPoolWithCompleteCredentialsTest {
     try (Jedis jedis = pool.getResource()) {
       jedis.incr("foo");
     }
-    pool.destroy();
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
@@ -114,12 +109,14 @@ public class JedisPoolWithCompleteCredentialsTest {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
-    Jedis jedis = pool.getResource();
-    jedis.auth("acljedis", "fizzbuzz");
-    jedis.set("foo", "0");
-
-    pool.getResource();
+    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
+        Jedis jedis = pool.getResource()) {
+      jedis.auth("acljedis", "fizzbuzz");
+      
+      try (Jedis jedis2 = pool.getResource()) {
+        jedis2.auth("acljedis", "fizzbuzz");
+      }
+    }
   }
 
   @Test
@@ -127,10 +124,10 @@ public class JedisPoolWithCompleteCredentialsTest {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
     JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz");
-    Jedis jedis = pool.getResource();
-    jedis.set("foo", "bar");
-    jedis.close();
-    pool.destroy();
+    try (Jedis jedis = pool.getResource()) {
+      jedis.set("foo", "bar");
+    }
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
@@ -139,149 +136,129 @@ public class JedisPoolWithCompleteCredentialsTest {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
     JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz", false);
-    Jedis jedis = pool.getResource();
-    jedis.set("foo", "bar");
-    jedis.close();
-    pool.destroy();
+    try (Jedis jedis = pool.getResource()) {
+      jedis.set("foo", "bar");
+    }
+    pool.close();
     assertTrue(pool.isClosed());
   }
 
   @Test
   public void nonDefaultDatabase() {
-    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz");
-    Jedis jedis0 = pool0.getResource();
-    jedis0.set("foo", "bar");
-    assertEquals("bar", jedis0.get("foo"));
-    jedis0.close();
-    pool0.destroy();
-    assertTrue(pool0.isClosed());
+    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+        "acljedis", "fizzbuzz");
+        Jedis jedis0 = pool0.getResource()) {
+      jedis0.set("foo", "bar");
+      assertEquals("bar", jedis0.get("foo"));
+    }
 
-    JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared", 1);
-    Jedis jedis1 = pool1.getResource();
-    assertNull(jedis1.get("foo"));
-    jedis1.close();
-    pool1.destroy();
-    assertTrue(pool1.isClosed());
+    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+        "acljedis", "fizzbuzz", 1);
+        Jedis jedis1 = pool1.getResource()) {
+      assertNull(jedis1.get("foo"));
+    }
   }
 
   @Test
   public void startWithUrlString() {
-    Jedis j = new Jedis("localhost", 6379);
-    j.auth("acljedis", "fizzbuzz");
-    j.select(2);
-    j.set("foo", "bar");
-    JedisPool pool = new JedisPool("redis://acljedis:fizzbuzz@localhost:6379/2");
-    Jedis jedis = pool.getResource();
-    assertEquals("PONG", jedis.ping());
-    assertEquals("bar", jedis.get("foo"));
+    try (Jedis j = new Jedis("localhost", 6379)) {
+      j.auth("acljedis", "fizzbuzz");
+      j.select(2);
+      j.set("foo", "bar");
+    }
+
+    try (JedisPool pool = new JedisPool("redis://acljedis:fizzbuzz@localhost:6379/2");
+        Jedis jedis = pool.getResource()) {
+      assertEquals("bar", jedis.get("foo"));
+    }
   }
 
   @Test
   public void startWithUrl() throws URISyntaxException {
-    Jedis j = new Jedis("localhost", 6379);
-    j.auth("acljedis", "fizzbuzz");
-    j.select(2);
-    j.set("foo", "bar");
-    JedisPool pool = new JedisPool(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"));
-    Jedis jedis = pool.getResource();
-    assertEquals("PONG", jedis.ping());
-    assertEquals("bar", jedis.get("foo"));
+    try (Jedis j = new Jedis("localhost", 6379)) {
+      j.auth("acljedis", "fizzbuzz");
+      j.select(2);
+      j.set("foo", "bar");
+    }
+
+    try (JedisPool pool = new JedisPool(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"));
+        Jedis jedis = pool.getResource()) {
+      assertEquals("bar", jedis.get("foo"));
+    }
+
+    try (JedisPool pool = new JedisPool(new URI("redis://default:foobared@localhost:6379/2"));
+        Jedis jedis = pool.getResource()) {
+      assertEquals("bar", jedis.get("foo"));
+    }
   }
 
   @Test(expected = InvalidURIException.class)
   public void shouldThrowInvalidURIExceptionForInvalidURI() throws URISyntaxException {
-    JedisPool pool = new JedisPool(new URI("localhost:6379"));
-  }
-
-  @Test
-  public void connectWithURICredentials() throws URISyntaxException {
-    JedisPool pool = new JedisPool("localhost", 6379);
-    Jedis j = pool.getResource();
-
-    j.auth("foobared");
-    j.set("foo", "bar");
-
-    Jedis jedis = new Jedis(new URI("redis://default:foobared@localhost:6379"));
-    assertEquals("PONG", jedis.ping());
-    assertEquals("bar", jedis.get("foo"));
-
-    Jedis jedis2 = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379"));
-    assertEquals("PONG", jedis2.ping());
-    assertEquals("bar", jedis2.get("foo"));
+    new JedisPool(new URI("localhost:6379")).close();
   }
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() throws URISyntaxException {
-    new JedisPool("redis://localhost:6379");
-    new JedisPool(new URI("redis://localhost:6379"));
+    new JedisPool("redis://localhost:6379").close();
+    new JedisPool(new URI("redis://localhost:6379")).close();
   }
 
   @Test
   public void selectDatabaseOnActivation() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "acljedis", "fizzbuzz");
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+        "acljedis", "fizzbuzz")) {
 
-    Jedis jedis0 = pool.getResource();
-    assertEquals(0, jedis0.getDB());
-
-    jedis0.select(1);
-    assertEquals(1, jedis0.getDB());
-
-    jedis0.close();
-
-    Jedis jedis1 = pool.getResource();
-    assertTrue("Jedis instance was not reused", jedis1 == jedis0);
-    assertEquals(0, jedis1.getDB());
-
-    jedis1.close();
-    pool.destroy();
-    assertTrue(pool.isClosed());
+      Jedis jedis0 = pool.getResource();
+      assertEquals(0, jedis0.getDB());
+      
+      jedis0.select(1);
+      assertEquals(1, jedis0.getDB());
+      
+      jedis0.close();
+      
+      Jedis jedis1 = pool.getResource();
+      assertTrue("Jedis instance was not reused", jedis1 == jedis0);
+      assertEquals(0, jedis1.getDB());
+      
+      jedis1.close();
+    }
   }
 
   @Test
   public void customClientName() {
-    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
         "acljedis", "fizzbuzz", 0, "my_shiny_client_name");
+        Jedis jedis = pool.getResource()) {
 
-    Jedis jedis = pool0.getResource();
-
-    assertEquals("my_shiny_client_name", jedis.clientGetname());
-
-    jedis.close();
-    pool0.destroy();
-    assertTrue(pool0.isClosed());
+      assertEquals("my_shiny_client_name", jedis.clientGetname());
+    }
   }
 
   @Test
   public void customClientNameNoSSL() {
-    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-           "acljedis", "fizzbuzz", 0, "my_shiny_client_name_no_ssl", false);
-
-    Jedis jedis = pool0.getResource();
-
-    assertEquals("my_shiny_client_name_no_ssl", jedis.clientGetname());
-
-    jedis.close();
-    pool0.destroy();
-    assertTrue(pool0.isClosed());
+    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+        "acljedis", "fizzbuzz", 0, "my_shiny_client_name_no_ssl", false);
+        Jedis jedis = pool0.getResource()) {
+      
+      assertEquals("my_shiny_client_name_no_ssl", jedis.clientGetname());
+    }
   }
 
   @Test
   public void testCloseConnectionOnMakeObject() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
         "acljedis", "foobared");
-    Jedis jedis = new Jedis("redis://:foobared@localhost:6379/");
-    int currentClientCount = getClientCount(jedis.clientList());
-    try {
-      pool.getResource();
-      fail("Should throw exception as password is incorrect.");
-    } catch (Exception e) {
-      assertEquals(currentClientCount, getClientCount(jedis.clientList()));
+        Jedis jedis = new Jedis("redis://:foobared@localhost:6379/")) {
+      int currentClientCount = getClientCount(jedis.clientList());
+      try {
+        pool.getResource();
+        fail("Should throw exception as password is incorrect.");
+      } catch (Exception e) {
+        assertEquals(currentClientCount, getClientCount(jedis.clientList()));
+      }
     }
-
   }
 
   private int getClientCount(final String clientList) {

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
@@ -18,8 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.*;
 
 /**
- * This test class is a copy of @JedisPoolTest where all authentications are made with
- * default:foobared credentialsinformation
+ * This test class is a copy of {@link JedisPoolTest}.
  *
  * This test is only executed when the server/cluster is Redis 6. or more.
  */
@@ -47,7 +46,7 @@ public class JedisPoolWithCompleteCredentialsTest {
   public void checkConnections() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
     Jedis jedis = pool.getResource();
-    jedis.auth("default","foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
     jedis.close();
@@ -59,7 +58,7 @@ public class JedisPoolWithCompleteCredentialsTest {
   public void checkCloseableConnections() throws Exception {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
     Jedis jedis = pool.getResource();
-    jedis.auth("default","foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
     jedis.close();
@@ -71,7 +70,7 @@ public class JedisPoolWithCompleteCredentialsTest {
   public void checkConnectionWithDefaultPort() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort());
     Jedis jedis = pool.getResource();
-    jedis.auth("default","foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
     jedis.close();
@@ -84,12 +83,11 @@ public class JedisPoolWithCompleteCredentialsTest {
 
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort());
     Jedis jedis = pool.getResource();
-    jedis.auth("default","foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.set("foo", "0");
     jedis.close();
 
     jedis = pool.getResource();
-    jedis.auth("foobared");
     jedis.incr("foo");
     jedis.close();
     pool.destroy();
@@ -100,12 +98,12 @@ public class JedisPoolWithCompleteCredentialsTest {
   public void checkPoolRepairedWhenJedisIsBroken() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort());
     Jedis jedis = pool.getResource();
-    jedis.auth("default","foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.quit();
     jedis.close();
 
     jedis = pool.getResource();
-    jedis.auth("default", "foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.incr("foo");
     jedis.close();
     pool.destroy();
@@ -119,19 +117,17 @@ public class JedisPoolWithCompleteCredentialsTest {
     config.setBlockWhenExhausted(false);
     JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
     Jedis jedis = pool.getResource();
-    jedis.auth("default", "foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.set("foo", "0");
 
-    Jedis newJedis = pool.getResource();
-    newJedis.auth("default", "foobared");
-    newJedis.incr("foo");
+    pool.getResource();
   }
 
   @Test
   public void securePool() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "default","foobared");
+    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz");
     Jedis jedis = pool.getResource();
     jedis.set("foo", "bar");
     jedis.close();
@@ -143,7 +139,7 @@ public class JedisPoolWithCompleteCredentialsTest {
   public void securePoolNonSSL() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "default","foobared", false);
+    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz", false);
     Jedis jedis = pool.getResource();
     jedis.set("foo", "bar");
     jedis.close();
@@ -153,8 +149,7 @@ public class JedisPoolWithCompleteCredentialsTest {
 
   @Test
   public void nonDefaultDatabase() {
-    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "default",
-        "foobared");
+    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz");
     Jedis jedis0 = pool0.getResource();
     jedis0.set("foo", "bar");
     assertEquals("bar", jedis0.get("foo"));
@@ -173,8 +168,7 @@ public class JedisPoolWithCompleteCredentialsTest {
 
   @Test
   public void nonDefaultDatabaseNonSSL() {
-    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "default",
-            "foobared", false);
+    JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz", false);
     Jedis jedis0 = pool0.getResource();
     jedis0.set("foo", "bar");
     assertEquals("bar", jedis0.get("foo"));
@@ -193,11 +187,11 @@ public class JedisPoolWithCompleteCredentialsTest {
 
   @Test
   public void startWithUrlString() {
-    Jedis j = new Jedis("localhost", 6380);
-    j.auth("default", "foobared");
+    Jedis j = new Jedis("localhost", 6379);
+    j.auth("acljedis", "fizzbuzz");
     j.select(2);
     j.set("foo", "bar");
-    JedisPool pool = new JedisPool("redis://default:foobared@localhost:6380/2");
+    JedisPool pool = new JedisPool("redis://acljedis:fizzbuzz@localhost:6379/2");
     Jedis jedis = pool.getResource();
     assertEquals("PONG", jedis.ping());
     assertEquals("bar", jedis.get("foo"));
@@ -205,11 +199,11 @@ public class JedisPoolWithCompleteCredentialsTest {
 
   @Test
   public void startWithUrl() throws URISyntaxException {
-    Jedis j = new Jedis("localhost", 6380);
-    j.auth("default", "foobared");
+    Jedis j = new Jedis("localhost", 6379);
+    j.auth("acljedis", "fizzbuzz");
     j.select(2);
     j.set("foo", "bar");
-    JedisPool pool = new JedisPool(new URI("redis://default:foobared@localhost:6380/2"));
+    JedisPool pool = new JedisPool(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"));
     Jedis jedis = pool.getResource();
     assertEquals("PONG", jedis.ping());
     assertEquals("bar", jedis.get("foo"));
@@ -217,42 +211,36 @@ public class JedisPoolWithCompleteCredentialsTest {
 
   @Test(expected = InvalidURIException.class)
   public void shouldThrowInvalidURIExceptionForInvalidURI() throws URISyntaxException {
-    JedisPool pool = new JedisPool(new URI("localhost:6380"));
+    JedisPool pool = new JedisPool(new URI("localhost:6379"));
   }
 
   @Test
   public void connectWithURICredentials() throws URISyntaxException {
-    JedisPool pool = new JedisPool("localhost", 6380);
+    JedisPool pool = new JedisPool("localhost", 6379);
     Jedis j = pool.getResource();
 
-    j.auth("default", "foobared");
+    j.auth("foobared");
     j.set("foo", "bar");
 
-    // create new user
-    j.aclSetUser("alice", "on", ">alicePassword", "~*", "+@all");
-
-    Jedis jedis = new Jedis(new URI("redis://default:foobared@localhost:6380"));
+    Jedis jedis = new Jedis(new URI("redis://default:foobared@localhost:6379"));
     assertEquals("PONG", jedis.ping());
     assertEquals("bar", jedis.get("foo"));
 
-    Jedis jedis2 = new Jedis(new URI("redis://alice:alicePassword@localhost:6380"));
+    Jedis jedis2 = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379"));
     assertEquals("PONG", jedis2.ping());
     assertEquals("bar", jedis2.get("foo"));
-
-    // delete user
-    j.aclDelUser("alice");
   }
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() throws URISyntaxException {
-    new JedisPool("redis://localhost:6380");
-    new JedisPool(new URI("redis://localhost:6380"));
+    new JedisPool("redis://localhost:6379");
+    new JedisPool(new URI("redis://localhost:6379"));
   }
 
   @Test
   public void selectDatabaseOnActivation() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "default", "foobared");
+        "acljedis", "fizzbuzz");
 
     Jedis jedis0 = pool.getResource();
     assertEquals(0, jedis0.getDB());
@@ -274,7 +262,7 @@ public class JedisPoolWithCompleteCredentialsTest {
   @Test
   public void customClientName() {
     JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "default", "foobared", 0, "my_shiny_client_name");
+        "acljedis", "fizzbuzz", 0, "my_shiny_client_name");
 
     Jedis jedis = pool0.getResource();
 
@@ -288,7 +276,7 @@ public class JedisPoolWithCompleteCredentialsTest {
   @Test
   public void customClientNameNoSSL() {
     JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-           "default", "foobared", 0, "my_shiny_client_name_no_ssl", false);
+           "acljedis", "fizzbuzz", 0, "my_shiny_client_name_no_ssl", false);
 
     Jedis jedis = pool0.getResource();
 
@@ -356,7 +344,7 @@ public class JedisPoolWithCompleteCredentialsTest {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "default", "foobared");
+    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz");
 
     Jedis jedis = pool.getResource();
     try {
@@ -384,7 +372,7 @@ public class JedisPoolWithCompleteCredentialsTest {
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "default", "foobared");
+    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis", "fizzbuzz");
 
     Jedis jedis = pool.getResource();
     try {
@@ -414,14 +402,14 @@ public class JedisPoolWithCompleteCredentialsTest {
   public void getNumActiveReturnsTheCorrectNumber() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
     Jedis jedis = pool.getResource();
-    jedis.auth("default","foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
 
     assertEquals(1, pool.getNumActive());
 
     Jedis jedis2 = pool.getResource();
-    jedis.auth("default","foobared");
+    jedis.auth("acljedis", "fizzbuzz");
     jedis.set("foo", "bar");
 
     assertEquals(2, pool.getNumActive());
@@ -448,7 +436,7 @@ public class JedisPoolWithCompleteCredentialsTest {
   public void closeResourceTwice() {
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
     Jedis j = pool.getResource();
-    j.auth("default", "foobared");
+    j.auth("acljedis", "fizzbuzz");
     j.ping();
     j.close();
     j.close();
@@ -460,8 +448,8 @@ public class JedisPoolWithCompleteCredentialsTest {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
     JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "default", "wrong pass");
-    Jedis jedis = new Jedis("redis://default:foobared@localhost:6379/");
+        "acljedis", "foobared");
+    Jedis jedis = new Jedis("redis://acljedis:fizzbuzz@localhost:6379/");
     int currentClientCount = getClientCount(jedis.clientList());
     try {
       pool.getResource();

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -28,10 +28,10 @@ public class JedisTest extends JedisCommandTestBase {
 
   @Test
   public void useWithoutConnecting() {
-    Jedis jedis = new Jedis("localhost");
-    jedis.auth("foobared");
-    jedis.dbSize();
-    jedis.close();
+    try (Jedis j = new Jedis()) {
+      j.auth("foobared");
+      j.dbSize();
+    }
   }
 
   @Test
@@ -135,16 +135,16 @@ public class JedisTest extends JedisCommandTestBase {
 
   @Test
   public void startWithUrlString() {
-    Jedis j = new Jedis("localhost", 6380);
-    j.auth("foobared");
-    j.select(2);
-    j.set("foo", "bar");
-    j.close();
+    try (Jedis j = new Jedis("localhost", 6380)) {
+      j.auth("foobared");
+      j.select(2);
+      j.set("foo", "bar");
+    }
 
-    Jedis jedis = new Jedis("redis://:foobared@localhost:6380/2");
-    assertEquals("PONG", jedis.ping());
-    assertEquals("bar", jedis.get("foo"));
-    jedis.close();
+    try (Jedis j2 = new Jedis("redis://:foobared@localhost:6380/2")) {
+      assertEquals("PONG", j2.ping());
+      assertEquals("bar", j2.get("foo"));
+    }
   }
 
   @Test
@@ -175,19 +175,19 @@ public class JedisTest extends JedisCommandTestBase {
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() {
-    Jedis jedis = new Jedis("redis://localhost:6380");
-    jedis.auth("foobared");
-    assertEquals("localhost", jedis.getClient().getHost());
-    assertEquals(6380, jedis.getClient().getPort());
-    assertEquals(0, jedis.getDB());
-    jedis.close();
+    try (Jedis j1 = new Jedis("redis://localhost:6380")) {
+      j1.auth("foobared");
+      assertEquals("localhost", j1.getClient().getHost());
+      assertEquals(6380, j1.getClient().getPort());
+      assertEquals(0, j1.getDB());
+    }
 
-    jedis = new Jedis("redis://localhost:6380/");
-    jedis.auth("foobared");
-    assertEquals("localhost", jedis.getClient().getHost());
-    assertEquals(6380, jedis.getClient().getPort());
-    assertEquals(0, jedis.getDB());
-    jedis.close();
+    try (Jedis j2 = new Jedis("redis://localhost:6380/")) {
+      j2.auth("foobared");
+      assertEquals("localhost", j2.getClient().getHost());
+      assertEquals(6380, j2.getClient().getPort());
+      assertEquals(0, j2.getDB());
+    }
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
@@ -1,26 +1,17 @@
 package redis.clients.jedis.tests;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.BinaryJedis;
+
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.InvalidURIException;
-import redis.clients.jedis.exceptions.JedisConnectionException;
-import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.tests.commands.JedisCommandTestBase;
 import redis.clients.jedis.tests.utils.RedisVersionUtil;
-import redis.clients.jedis.util.SafeEncoder;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.*;
 
 /**
  * This test class is a copy of {@link JedisTest}.
@@ -44,24 +35,10 @@ public class JedisWithCompleteCredentialsTest extends JedisCommandTestBase {
 
   @Test
   public void useWithoutConnecting() {
-    try(Jedis jedis = new Jedis("localhost")){
-      assertEquals("OK", jedis.auth("acljedis", "fizzbuzz"));
-      jedis.dbSize();
+    try(Jedis j = new Jedis()){
+      assertEquals("OK", j.auth("acljedis", "fizzbuzz"));
+      j.dbSize();
     }
-  }
-
-  @Test
-  public void checkBinaryData() {
-    byte[] bigdata = new byte[1777];
-    for (int b = 0; b < bigdata.length; b++) {
-      bigdata[b] = (byte) ((byte) b % 255);
-    }
-    Map<String, String> hash = new HashMap<>();
-    hash.put("data", SafeEncoder.encode(bigdata));
-
-    String status = jedis.hmset("foo", hash);
-    assertEquals("OK", status);
-    assertEquals(hash, jedis.hgetAll("foo"));
   }
 
   @Test
@@ -75,80 +52,15 @@ public class JedisWithCompleteCredentialsTest extends JedisCommandTestBase {
   }
 
   @Test
-  public void timeoutConnection() throws Exception {
-    
-    String timeout = null;
-    try (Jedis jedis = new Jedis("localhost", 6379, 15000)){
-      assertEquals("OK", jedis.auth("acljedis", "fizzbuzz"));
-      timeout = jedis.configGet("timeout").get(1);
-      assertEquals("OK", jedis.configSet("timeout", "1"));
-      Thread.sleep(2000);
-    
-      jedis.hmget("foobar", "foo");
-      fail("Operation should throw JedisConnectionException");
-    } catch(JedisConnectionException jce) {
-      // expected
-    }
-
-    // reset config
-    try(Jedis jedis2 = new Jedis("localhost", 6379)){
-      assertEquals("OK", jedis2.auth("acljedis", "fizzbuzz"));
-      assertEquals("OK", jedis2.configSet("timeout", timeout));
-    }
-  }
-
-  @Test
-  public void timeoutConnectionWithURI() throws Exception {
-    
-    String timeout = null;
-    try (Jedis jedis = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"), 15000)){
-      timeout = jedis.configGet("timeout").get(1);
-      jedis.configSet("timeout", "1");
-      Thread.sleep(2000);
-    
-      jedis.hmget("foobar", "foo");
-      fail("Operation should throw JedisConnectionException");
-    } catch(JedisConnectionException jce) {
-      // expected
-    }
-
-    // reset config
-    try(Jedis jedis2 = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"))){
-      jedis2.configSet("timeout", timeout);
-    }
-  }
-
-  @Test(expected = JedisDataException.class)
-  public void failWhenSendingNullValues() {
-    jedis.set("foo", null);
-  }
-
-  @Test(expected = InvalidURIException.class)
-  public void shouldThrowInvalidURIExceptionForInvalidURI() throws URISyntaxException {
-    try(Jedis j = new Jedis(new URI("localhost:6380"))){
-      j.ping();
-    }
-  }
-
-  @Test
-  public void shouldReconnectToSameDB() throws IOException {
-    jedis.select(1);
-    jedis.set("foo", "bar");
-    jedis.getClient().getSocket().shutdownInput();
-    jedis.getClient().getSocket().shutdownOutput();
-    assertEquals("bar", jedis.get("foo"));
-  }
-
-  @Test
   public void startWithUrlString() {
     try(Jedis j = new Jedis("localhost", 6379)){
       assertEquals("OK", j.auth("acljedis", "fizzbuzz"));
       assertEquals("OK", j.select(2));
       j.set("foo", "bar");
     }
-    try(Jedis jedis = new Jedis("redis://acljedis:fizzbuzz@localhost:6379/2")){
-      assertEquals("PONG", jedis.ping());
-      assertEquals("bar", jedis.get("foo"));
+    try(Jedis j2 = new Jedis("redis://acljedis:fizzbuzz@localhost:6379/2")){
+      assertEquals("PONG", j2.ping());
+      assertEquals("bar", j2.get("foo"));
     }
   }
 
@@ -159,71 +71,42 @@ public class JedisWithCompleteCredentialsTest extends JedisCommandTestBase {
       assertEquals("OK", j.select(2));
       j.set("foo", "bar");
     }
-    try(Jedis jedis = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"))){
-      assertEquals("PONG", jedis.ping());
-      assertEquals("bar", jedis.get("foo"));
-    }
-  }
-
-  @Test
-  public void shouldNotUpdateDbIndexIfSelectFails() throws URISyntaxException {
-    int currentDb = jedis.getDB();
-    try {
-      int invalidDb = -1;
-      jedis.select(invalidDb);
-
-      fail("Should throw an exception if tried to select invalid db");
-    } catch (JedisException e) {
-      assertEquals(currentDb, jedis.getDB());
+    try(Jedis j2 = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"))){
+      assertEquals("PONG", j2.ping());
+      assertEquals("bar", j2.get("foo"));
     }
   }
 
   @Test
   public void connectWithURICredentials() throws URISyntaxException {
-    try (Jedis j = new Jedis("localhost")) {
-      j.auth("foobared");
-      j.set("foo", "bar");
+    jedis.set("foo", "bar");
+    
+    try (Jedis j1 = new Jedis(new URI("redis://default:foobared@localhost:6379"))) {
+      assertEquals("PONG", j1.ping());
+      assertEquals("bar", j1.get("foo"));
     }
 
-    try (Jedis jedis = new Jedis(new URI("redis://default:foobared@localhost:6379"))) {
-      assertEquals("PONG", jedis.ping());
-      assertEquals("bar", jedis.get("foo"));
-    }
-
-    try (Jedis jedis = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379"))) {
-      assertEquals("PONG", jedis.ping());
-      assertEquals("bar", jedis.get("foo"));
+    try (Jedis j2 = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379"))) {
+      assertEquals("PONG", j2.ping());
+      assertEquals("bar", j2.get("foo"));
     }
   }
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() {
-    try(Jedis jedis = new Jedis("redis://localhost:6379")){
-      assertEquals("OK", jedis.auth("acljedis", "fizzbuzz"));
-      assertEquals("localhost", jedis.getClient().getHost());
-      assertEquals(6379, jedis.getClient().getPort());
-      assertEquals(0, jedis.getDB());
+    try(Jedis j1 = new Jedis("redis://localhost:6379")){
+      assertEquals("OK", j1.auth("acljedis", "fizzbuzz"));
+      assertEquals("localhost", j1.getClient().getHost());
+      assertEquals(6379, j1.getClient().getPort());
+      assertEquals(0, j1.getDB());
     }
-    try(Jedis jedis = new Jedis("redis://localhost:6379/")) {
-      assertEquals("OK", jedis.auth("acljedis", "fizzbuzz"));
-      assertEquals("localhost", jedis.getClient().getHost());
-      assertEquals(6379, jedis.getClient().getPort());
-      assertEquals(0, jedis.getDB());
-    }
-  }
 
-  @Test
-  public void checkCloseable() {
-    jedis.close();
-    try(BinaryJedis bj = new BinaryJedis("localhost")){
-      bj.connect();
+    try(Jedis j2 = new Jedis("redis://localhost:6379/")) {
+      assertEquals("OK", j2.auth("acljedis", "fizzbuzz"));
+      assertEquals("localhost", j2.getClient().getHost());
+      assertEquals(6379, j2.getClient().getPort());
+      assertEquals(0, j2.getDB());
     }
-  }
-
-  @Test
-  public void checkDisconnectOnQuit() {
-    jedis.quit();
-    assertFalse(jedis.getClient().isConnected());
   }
 
 }

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
@@ -53,10 +53,10 @@ public class SSLJedisTest {
   @Test
   public void connectWithUrl() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    Jedis jedis = new Jedis("rediss://localhost:6390");
-    jedis.auth("foobared");
-    assertEquals("PONG", jedis.ping());
-    jedis.close();
+    try (Jedis jedis = new Jedis("rediss://localhost:6390")) {
+      jedis.auth("foobared");
+      assertEquals("PONG", jedis.ping());
+    }
   }
 
   /**
@@ -65,10 +65,10 @@ public class SSLJedisTest {
   @Test
   public void connectWithoutShardInfo() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    Jedis jedis = new Jedis(URI.create("rediss://localhost:6390"));
-    jedis.auth("foobared");
-    assertEquals("PONG", jedis.ping());
-    jedis.close();
+    try (Jedis jedis = new Jedis(URI.create("rediss://localhost:6390"))) {
+      jedis.auth("foobared");
+      assertEquals("PONG", jedis.ping());
+    }
   }
 
   /**

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisWithCompleteCredentialsTest.java
@@ -23,9 +23,7 @@ import java.security.cert.X509Certificate;
 import static org.junit.Assert.*;
 
 /**
- * This test class is a copy of @SSLJedisTest
- * where all authentications are made with
- * default:foobared credentialsinformation
+ * This test class is a copy of {@link SSLJedisTest}.
  *
  * This test is only executed when the server/cluster is Redis 6. or more.
  */
@@ -67,10 +65,14 @@ public class SSLJedisWithCompleteCredentialsTest {
   @Test
   public void connectWithUrl() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    Jedis jedis = new Jedis("rediss://localhost:6390");
-    jedis.auth("default", "foobared");
-    assertEquals("PONG", jedis.ping());
-    jedis.close();
+    try (Jedis jedis = new Jedis("rediss://localhost:6390")) {
+      jedis.auth("default", "foobared");
+      assertEquals("PONG", jedis.ping());
+    }
+    try (Jedis jedis = new Jedis("rediss://localhost:6390")) {
+      jedis.auth("acljedis", "fizzbuzz");
+      assertEquals("PONG", jedis.ping());
+    }
   }
 
   /**
@@ -79,17 +81,12 @@ public class SSLJedisWithCompleteCredentialsTest {
   @Test
   public void connectWithUrlAndCompleteCredentials() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    Jedis jedis = new Jedis("rediss://default:foobared@localhost:6390");
-    assertEquals("PONG", jedis.ping());
-
-    // create user
-    jedis.aclSetUser("alice", "on", ">alicePassword", "~*", "+@all");
-
-    Jedis jedis2 = new Jedis("rediss://alice:alicePassword@localhost:6390");
-    assertEquals("PONG", jedis2.ping());
-
-    jedis.aclDelUser("alice");
-    jedis.close();
+    try (Jedis jedis = new Jedis("rediss://default:foobared@localhost:6390")) {
+      assertEquals("PONG", jedis.ping());
+    }
+    try (Jedis jedis = new Jedis("rediss://acljedis:fizzbuzz@localhost:6390")) {
+      assertEquals("PONG", jedis.ping());
+    }
   }
 
 
@@ -99,10 +96,10 @@ public class SSLJedisWithCompleteCredentialsTest {
   @Test
   public void connectWithoutShardInfo() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    Jedis jedis = new Jedis(URI.create("rediss://localhost:6390"));
-    jedis.auth("default", "foobared");
-    assertEquals("PONG", jedis.ping());
-    jedis.close();
+    try (Jedis jedis = new Jedis(URI.create("rediss://localhost:6390"))) {
+      jedis.auth("acljedis", "fizzbuzz");
+      assertEquals("PONG", jedis.ping());
+    }
   }
 
   /**
@@ -122,8 +119,8 @@ public class SSLJedisWithCompleteCredentialsTest {
     sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
 
     JedisShardInfo shardInfo = new JedisShardInfo(uri, sslSocketFactory, sslParameters, null);
-    shardInfo.setUser("default");
-    shardInfo.setPassword("foobared");
+    shardInfo.setUser("acljedis");
+    shardInfo.setPassword("fizzbuzz");
 
     Jedis jedis = new Jedis(shardInfo);
     assertEquals("PONG", jedis.ping());
@@ -152,8 +149,8 @@ public class SSLJedisWithCompleteCredentialsTest {
     sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
 
     JedisShardInfo shardInfo = new JedisShardInfo(uri, sslSocketFactory, sslParameters, null);
-    shardInfo.setUser("default");
-    shardInfo.setPassword("foobared");
+    shardInfo.setUser("acljedis");
+    shardInfo.setPassword("fizzbuzz");
 
     Jedis jedis = new Jedis(shardInfo);
     try {
@@ -185,8 +182,8 @@ public class SSLJedisWithCompleteCredentialsTest {
 
     HostnameVerifier hostnameVerifier = new BasicHostnameVerifier();
     JedisShardInfo shardInfo = new JedisShardInfo(uri, sslSocketFactory, sslParameters, hostnameVerifier);
-    shardInfo.setUser("default");
-    shardInfo.setPassword("foobared");
+    shardInfo.setUser("acljedis");
+    shardInfo.setPassword("fizzbuzz");
 
     Jedis jedis = new Jedis(shardInfo);
     assertEquals("PONG", jedis.ping());
@@ -205,8 +202,8 @@ public class SSLJedisWithCompleteCredentialsTest {
 
     HostnameVerifier hostnameVerifier = new BasicHostnameVerifier();
     JedisShardInfo shardInfo = new JedisShardInfo(uri, sslSocketFactory, sslParameters, hostnameVerifier);
-    shardInfo.setUser("default");
-    shardInfo.setPassword("foobared");
+    shardInfo.setUser("acljedis");
+    shardInfo.setPassword("fizzbuzz");
 
     Jedis jedis = new Jedis(shardInfo);
     assertEquals("PONG", jedis.ping());
@@ -228,8 +225,8 @@ public class SSLJedisWithCompleteCredentialsTest {
 
     HostnameVerifier hostnameVerifier = new BasicHostnameVerifier();
     JedisShardInfo shardInfo = new JedisShardInfo(uri, sslSocketFactory, sslParameters, hostnameVerifier);
-    shardInfo.setUser("default");
-    shardInfo.setPassword("foobared");
+    shardInfo.setUser("acljedis");
+    shardInfo.setPassword("fizzbuzz");
 
     Jedis jedis = new Jedis(shardInfo);
     try {
@@ -261,8 +258,8 @@ public class SSLJedisWithCompleteCredentialsTest {
     final SSLSocketFactory sslSocketFactory = createTrustNoOneSslSocketFactory();
 
     JedisShardInfo shardInfo = new JedisShardInfo(uri, sslSocketFactory, null, null);
-    shardInfo.setUser("default");
-    shardInfo.setPassword("foobared");
+    shardInfo.setUser("acljedis");
+    shardInfo.setPassword("fizzbuzz");
 
     Jedis jedis = new Jedis(shardInfo);
     try {


### PR DESCRIPTION
- Test ACL with non-default user for standalone Redis instance (Jedis, Jedis with SSL, JedisPool)
- Removed Jedis with ACL tests where ACL feature was not being used and will not bring anything new even if used
- Removed JedisPool with ACL tests where ACL feature was not being used and will not bring anything new even if used
- Modify JedisPool (with/without ACL) tests
- Used try-with-resources in JedisPool (with/without ACL) tests
- Added a test related to issue #2318 and PR #2319 
- Added two minimal JedisPool constructor with user and password params (also testing those)