### PR TITLE
Split JedisClusterCommand into multiple methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -110,9 +110,7 @@ public abstract class JedisClusterCommand<T> {
       } catch (JedisRedirectionException e) {
         redirected = handleRedirection(connection, e);
       } finally {
-        if (connection != null) {
-          releaseConnection(connection);
-        }
+        releaseConnection(connection);
       }
     }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -130,8 +130,6 @@ public abstract class JedisClusterCommand<T> {
       this.connectionHandler.renewSlotCache(connection);
     }
 
-    // release current connection before iteration
-    releaseConnection(connection);
 
     return () -> {
       Jedis redirectedConnection = connectionHandler.getConnectionFromNode(jre.getTargetNode());

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -109,7 +109,9 @@ public abstract class JedisClusterCommand<T> {
       }
     }
 
-    throw new JedisClusterMaxAttemptsException("No more cluster attempts left.", lastException);
+    JedisClusterMaxAttemptsException maxAttemptsException =  new JedisClusterMaxAttemptsException("No more cluster attempts left.");
+    maxAttemptsException.addSuppressed(lastException);
+    throw maxAttemptsException;
   }
 
   private Supplier<Jedis> handleConnectionProblem(final int slot, int currentAttempt) {


### PR DESCRIPTION
No behavior changes, just a refactoring.

Changes:
* Replaces recursion with a `for` loop
* Extract redirection handling into its own method
* Extract connection-failed handling into its own method

I did try to keep the order of the new methods the same order as the previous `catch` blocks.

Note that `tryWithRandomNode` is gone, it was never `true` so it and its code didn't survive the refactoring.

I think redirection handling looks a bit strange, but it didn't change from before. If it *is* wrong then that should be fixed in another PR, this one is just a refactoring.

# Reviewer notes
The `git diff` isn't great for this change.

If you want to see what changed it's probably easier to bring the old and the new code up side by side and compare that way instead.

Here's the old version for reference: <https://github.com/redis/jedis/blob/master/src/main/java/redis/clients/jedis/JedisClusterCommand.java>