### PR TITLE
Document JedisClusterCommand.releaseConnection() as Nullable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -1,5 +1,7 @@
 package redis.clients.jedis;
 
+import javax.annotation.Nullable;
+
 import redis.clients.jedis.exceptions.JedisAskDataException;
 import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
@@ -137,7 +139,7 @@ public abstract class JedisClusterCommand<T> {
     }
   }
 
-  private void releaseConnection(Jedis connection) {
+  private void releaseConnection(@Nullable Jedis connection) {
     if (connection != null) {
       connection.close();
     }


### PR DESCRIPTION
This helps both people (me!) and machines (IntelliJ) know how to call this method.

Also, for IntelliJ users, if you find the `Constant conditions & exceptions` inspection and enable `Suggest @Nullable annotation ... where nullable values are used` you will be informed about potential runtime `NullPointerException`s.

A lot of things could probably be annotated, but I wanted to start with *something* to encourage future PRs to add nullability annotations where appropriate.