### PR TITLE
Bump JDK version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Inspired by #1334 where this went real easy :).

Would have made #2355 shorter.

Free public updates for **JDK 7 ended in 2015**:
<https://en.wikipedia.org/wiki/Java_version_history>

For **JDK 8**, free public support is available from non-Oracle vendors **until at least 2026** according to the same table.

And JDK 8 is what Jedis is being tested on anyway:
<https://github.com/redis/jedis/blob/ac0969315655180c09b8139c16bded09c068d498/.circleci/config.yml#L67-L74>