### PR TITLE
Retry with backoff on cluster connection failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
 			<version>2.3.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.7.7</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -195,7 +195,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String set(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value);
@@ -205,7 +205,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String set(final String key, final String value, final SetParams params) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.set(key, value, params);
@@ -215,7 +215,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String get(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.get(key);
@@ -225,7 +225,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean exists(final String key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.exists(key);
@@ -235,7 +235,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long exists(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.exists(keys);
@@ -245,7 +245,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long persist(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.persist(key);
@@ -255,7 +255,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String type(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.type(key);
@@ -265,7 +265,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public byte[] dump(final String key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public byte[] execute(Jedis connection) {
         return connection.dump(key);
@@ -275,7 +275,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String restore(final String key, final int ttl, final byte[] serializedValue) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.restore(key, ttl, serializedValue);
@@ -285,7 +285,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long expire(final String key, final int seconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expire(key, seconds);
@@ -295,7 +295,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long pexpire(final String key, final long milliseconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpire(key, milliseconds);
@@ -305,7 +305,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long expireAt(final String key, final long unixTime) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.expireAt(key, unixTime);
@@ -315,7 +315,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long pexpireAt(final String key, final long millisecondsTimestamp) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pexpireAt(key, millisecondsTimestamp);
@@ -325,7 +325,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long ttl(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.ttl(key);
@@ -335,7 +335,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long pttl(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pttl(key);
@@ -345,7 +345,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long touch(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.touch(key);
@@ -355,7 +355,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long touch(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.touch(keys);
@@ -365,7 +365,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean setbit(final String key, final long offset, final boolean value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -375,7 +375,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean setbit(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.setbit(key, offset, value);
@@ -385,7 +385,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean getbit(final String key, final long offset) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.getbit(key, offset);
@@ -395,7 +395,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long setrange(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setrange(key, offset, value);
@@ -405,7 +405,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String getrange(final String key, final long startOffset, final long endOffset) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.getrange(key, startOffset, endOffset);
@@ -415,7 +415,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String getSet(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.getSet(key, value);
@@ -425,7 +425,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long setnx(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.setnx(key, value);
@@ -435,7 +435,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String setex(final String key, final int seconds, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.setex(key, seconds, value);
@@ -445,7 +445,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String psetex(final String key, final long milliseconds, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.psetex(key, milliseconds, value);
@@ -455,7 +455,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long decrBy(final String key, final long decrement) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decrBy(key, decrement);
@@ -465,7 +465,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long decr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.decr(key);
@@ -475,7 +475,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long incrBy(final String key, final long increment) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incrBy(key, increment);
@@ -485,7 +485,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double incrByFloat(final String key, final double increment) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Double execute(Jedis connection) {
         return connection.incrByFloat(key, increment);
@@ -495,7 +495,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long incr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.incr(key);
@@ -505,7 +505,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long append(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.append(key, value);
@@ -515,7 +515,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String substr(final String key, final int start, final int end) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.substr(key, start, end);
@@ -525,7 +525,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hset(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hset(key, field, value);
@@ -535,7 +535,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hset(final String key, final Map<String, String> hash) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hset(key, hash);
@@ -545,7 +545,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String hget(final String key, final String field) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.hget(key, field);
@@ -555,7 +555,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hsetnx(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hsetnx(key, field, value);
@@ -565,7 +565,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String hmset(final String key, final Map<String, String> hash) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.hmset(key, hash);
@@ -575,7 +575,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> hmget(final String key, final String... fields) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hmget(key, fields);
@@ -585,7 +585,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hincrBy(final String key, final String field, final long value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hincrBy(key, field, value);
@@ -595,7 +595,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double hincrByFloat(final String key, final String field, final double value) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Double execute(Jedis connection) {
         return connection.hincrByFloat(key, field, value);
@@ -605,7 +605,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean hexists(final String key, final String field) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.hexists(key, field);
@@ -615,7 +615,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hdel(final String key, final String... field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hdel(key, field);
@@ -625,7 +625,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hlen(key);
@@ -635,7 +635,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> hkeys(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.hkeys(key);
@@ -645,7 +645,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> hvals(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.hvals(key);
@@ -655,7 +655,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Map<String, String> hgetAll(final String key) {
-    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Map<String, String> execute(Jedis connection) {
         return connection.hgetAll(key);
@@ -665,7 +665,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long rpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpush(key, string);
@@ -675,7 +675,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpush(key, string);
@@ -685,7 +685,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long llen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.llen(key);
@@ -695,7 +695,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> lrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.lrange(key, start, stop);
@@ -705,7 +705,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String ltrim(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.ltrim(key, start, stop);
@@ -715,7 +715,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String lindex(final String key, final long index) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.lindex(key, index);
@@ -725,7 +725,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String lset(final String key, final long index, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.lset(key, index, value);
@@ -735,7 +735,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lrem(final String key, final long count, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lrem(key, count, value);
@@ -745,7 +745,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String lpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.lpop(key);
@@ -755,7 +755,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> lpop(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.lpop(key, count);
@@ -765,7 +765,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lpos(final String key, final String element) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpos(key, element);
@@ -775,7 +775,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lpos(final String key, final String element, final LPosParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpos(key, element, params);
@@ -785,7 +785,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Long> lpos(final String key, final String element, final LPosParams params, final long count) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Long> execute(Jedis connection) {
         return connection.lpos(key, element, params, count);
@@ -795,7 +795,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String rpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.rpop(key);
@@ -805,7 +805,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> rpop(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.rpop(key, count);
@@ -815,7 +815,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long sadd(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sadd(key, member);
@@ -825,7 +825,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> smembers(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.smembers(key);
@@ -835,7 +835,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long srem(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.srem(key, member);
@@ -845,7 +845,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String spop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.spop(key);
@@ -855,7 +855,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> spop(final String key, final long count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.spop(key, count);
@@ -865,7 +865,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long scard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.scard(key);
@@ -875,7 +875,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean sismember(final String key, final String member) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.sismember(key, member);
@@ -885,7 +885,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Boolean> smismember(final String key, final String... members) {
-    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Boolean> execute(Jedis connection) {
         return connection.smismember(key, members);
@@ -895,7 +895,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String srandmember(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.srandmember(key);
@@ -905,7 +905,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> srandmember(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.srandmember(key, count);
@@ -915,7 +915,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long strlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.strlen(key);
@@ -925,7 +925,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zadd(final String key, final double score, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, score, member);
@@ -936,7 +936,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Long zadd(final String key, final double score, final String member,
       final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, score, member, params);
@@ -946,7 +946,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, scoreMembers);
@@ -956,7 +956,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers, final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zadd(key, scoreMembers, params);
@@ -966,7 +966,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrange(key, start, stop);
@@ -976,7 +976,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrem(final String key, final String... members) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrem(key, members);
@@ -986,7 +986,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double zincrby(final String key, final double increment, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zincrby(key, increment, member);
@@ -997,7 +997,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Double zincrby(final String key, final double increment, final String member,
       final ZIncrByParams params) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zincrby(key, increment, member, params);
@@ -1007,7 +1007,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrank(key, member);
@@ -1017,7 +1017,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zrevrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zrevrank(key, member);
@@ -1027,7 +1027,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrange(key, start, stop);
@@ -1037,7 +1037,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeWithScores(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeWithScores(key, start, stop);
@@ -1047,7 +1047,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeWithScores(key, start, stop);
@@ -1057,7 +1057,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcard(key);
@@ -1067,7 +1067,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double zscore(final String key, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Double execute(Jedis connection) {
         return connection.zscore(key, member);
@@ -1077,7 +1077,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Double> zmscore(final String key, final String... members) {
-    return new JedisClusterCommand<List<Double>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Double>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Double> execute(Jedis connection) {
         return connection.zmscore(key, members);
@@ -1087,7 +1087,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Tuple zpopmax(final String key) {
-    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Tuple execute(Jedis connection) {
         return connection.zpopmax(key);
@@ -1097,7 +1097,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zpopmax(final String key, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zpopmax(key, count);
@@ -1107,7 +1107,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Tuple zpopmin(final String key) {
-    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Tuple execute(Jedis connection) {
         return connection.zpopmin(key);
@@ -1117,7 +1117,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zpopmin(final String key, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zpopmin(key, count);
@@ -1127,7 +1127,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> sort(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.sort(key);
@@ -1137,7 +1137,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> sort(final String key, final SortingParams sortingParameters) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.sort(key, sortingParameters);
@@ -1147,7 +1147,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcount(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -1157,7 +1157,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zcount(key, min, max);
@@ -1167,7 +1167,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -1177,7 +1177,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max);
@@ -1187,7 +1187,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -1198,7 +1198,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -1208,7 +1208,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min);
@@ -1219,7 +1219,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByScore(key, min, max, offset, count);
@@ -1230,7 +1230,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -1240,7 +1240,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -1250,7 +1250,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -1261,7 +1261,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -1272,7 +1272,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByScore(key, max, min, offset, count);
@@ -1282,7 +1282,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max);
@@ -1292,7 +1292,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min);
@@ -1303,7 +1303,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrangeByScoreWithScores(key, min, max, offset, count);
@@ -1314,7 +1314,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max,
       final double min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1325,7 +1325,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max,
       final String min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<Tuple> execute(Jedis connection) {
         return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
@@ -1335,7 +1335,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByRank(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByRank(key, start, stop);
@@ -1345,7 +1345,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByScore(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, min, max);
@@ -1355,7 +1355,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByScore(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByScore(key, min, max);
@@ -1365,7 +1365,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zlexcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zlexcount(key, min, max);
@@ -1375,7 +1375,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max);
@@ -1386,7 +1386,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrangeByLex(key, min, max, offset, count);
@@ -1396,7 +1396,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min);
@@ -1407,7 +1407,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.zrevrangeByLex(key, max, min, offset, count);
@@ -1417,7 +1417,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long zremrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zremrangeByLex(key, min, max);
@@ -1428,7 +1428,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Long linsert(final String key, final ListPosition where, final String pivot,
       final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.linsert(key, where, pivot, value);
@@ -1438,7 +1438,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long lpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.lpushx(key, string);
@@ -1448,7 +1448,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long rpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.rpushx(key, string);
@@ -1458,7 +1458,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long del(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.del(key);
@@ -1468,7 +1468,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long unlink(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.unlink(key);
@@ -1478,7 +1478,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long unlink(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.unlink(keys);
@@ -1489,7 +1489,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public String echo(final String string) {
     // note that it'll be run from arbitrary node
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.echo(string);
@@ -1499,7 +1499,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long bitcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key);
@@ -1509,7 +1509,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long bitcount(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitcount(key, start, end);
@@ -1527,7 +1527,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       throw new IllegalArgumentException(this.getClass().getSimpleName()
           + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.keys(pattern);
@@ -1550,7 +1550,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
           + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
 
-    return new JedisClusterCommand< ScanResult<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand< ScanResult<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public ScanResult<String> execute(Jedis connection) {
         return connection.scan(cursor, params);
@@ -1561,7 +1561,8 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public ScanResult<Entry<String, String>> hscan(final String key, final String cursor) {
     return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler,
-                                                                      maxAttempts) {
+                                                                      maxAttempts,
+                                                                      this.timeout) {
       @Override
       public ScanResult<Entry<String, String>> execute(Jedis connection) {
         return connection.hscan(key, cursor);
@@ -1571,7 +1572,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public ScanResult<String> sscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public ScanResult<String> execute(Jedis connection) {
         return connection.sscan(key, cursor);
@@ -1581,7 +1582,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public ScanResult<Tuple> zscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public ScanResult<Tuple> execute(Jedis connection) {
         return connection.zscan(key, cursor);
@@ -1591,7 +1592,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long pfadd(final String key, final String... elements) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfadd(key, elements);
@@ -1601,7 +1602,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public long pfcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(key);
@@ -1611,7 +1612,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> blpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.blpop(timeout, key);
@@ -1621,7 +1622,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> brpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.brpop(timeout, key);
@@ -1631,7 +1632,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long del(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.del(keys);
@@ -1641,7 +1642,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> blpop(final int timeout, final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.blpop(timeout, keys);
@@ -1652,7 +1653,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> brpop(final int timeout, final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.brpop(timeout, keys);
@@ -1662,7 +1663,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> mget(final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.mget(keys);
@@ -1678,7 +1679,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.mset(keysvalues);
@@ -1694,7 +1695,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.msetnx(keysvalues);
@@ -1704,7 +1705,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String rename(final String oldkey, final String newkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.rename(oldkey, newkey);
@@ -1714,7 +1715,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long renamenx(final String oldkey, final String newkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.renamenx(oldkey, newkey);
@@ -1724,7 +1725,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String rpoplpush(final String srckey, final String dstkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.rpoplpush(srckey, dstkey);
@@ -1734,7 +1735,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> sdiff(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.sdiff(keys);
@@ -1746,7 +1747,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long sdiffstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sdiffstore(dstkey, keys);
@@ -1756,7 +1757,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> sinter(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.sinter(keys);
@@ -1768,7 +1769,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long sinterstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sinterstore(dstkey, keys);
@@ -1778,7 +1779,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long smove(final String srckey, final String dstkey, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.smove(srckey, dstkey, member);
@@ -1788,7 +1789,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long sort(final String key, final SortingParams sortingParameters, final String dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sort(key, sortingParameters, dstkey);
@@ -1798,7 +1799,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long sort(final String key, final String dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sort(key, dstkey);
@@ -1808,7 +1809,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Set<String> sunion(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Set<String> execute(Jedis connection) {
         return connection.sunion(keys);
@@ -1820,7 +1821,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long sunionstore(final String dstkey, final String... keys) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.sunionstore(dstkey, keys);
@@ -1832,7 +1833,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zinterstore(final String dstkey, final String... sets) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zinterstore(dstkey, sets);
@@ -1844,7 +1845,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zinterstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zinterstore(dstkey, params, sets);
@@ -1856,7 +1857,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zunionstore(final String dstkey, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zunionstore(dstkey, sets);
@@ -1868,7 +1869,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long zunionstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.zunionstore(dstkey, params, sets);
@@ -1878,7 +1879,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String brpoplpush(final String source, final String destination, final int timeout) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.brpoplpush(source, destination, timeout);
@@ -1888,7 +1889,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long publish(final String channel, final String message) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.publish(channel, message);
@@ -1898,7 +1899,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public void subscribe(final JedisPubSub jedisPubSub, final String... channels) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
+    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Integer execute(Jedis connection) {
         connection.subscribe(jedisPubSub, channels);
@@ -1909,7 +1910,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public void psubscribe(final JedisPubSub jedisPubSub, final String... patterns) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
+    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Integer execute(Jedis connection) {
         connection.psubscribe(jedisPubSub, patterns);
@@ -1922,7 +1923,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long bitop(final BitOP op, final String destKey, final String... srcKeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destKey, srcKeys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.bitop(op, destKey, srcKeys);
@@ -1934,7 +1935,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public String pfmerge(final String destkey, final String... sourcekeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destkey, sourcekeys);
 
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.pfmerge(destkey, sourcekeys);
@@ -1944,7 +1945,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public long pfcount(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.pfcount(keys);
@@ -1954,7 +1955,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object eval(final String script, final int keyCount, final String... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script, keyCount, params);
@@ -1964,7 +1965,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object eval(final String script, final String sampleKey) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script);
@@ -1974,7 +1975,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object eval(final String script, final List<String> keys, final List<String> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection) {
         return connection.eval(script, keys, args);
@@ -1984,7 +1985,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object evalsha(final String sha1, final int keyCount, final String... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(sha1, keyCount, params);
@@ -1994,7 +1995,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object evalsha(final String sha1, final List<String> keys, final List<String> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(sha1, keys, args);
@@ -2004,7 +2005,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Object evalsha(final String sha1, final String sampleKey) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection) {
         return connection.evalsha(sha1);
@@ -2014,7 +2015,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Boolean scriptExists(final String sha1, final String sampleKey) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Boolean execute(Jedis connection) {
         return connection.scriptExists(sha1);
@@ -2024,7 +2025,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Boolean> scriptExists(final String sampleKey, final String... sha1) {
-    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Boolean> execute(Jedis connection) {
         return connection.scriptExists(sha1);
@@ -2034,7 +2035,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String scriptLoad(final String script, final String sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.scriptLoad(script);
@@ -2044,7 +2045,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String scriptFlush(final String sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.scriptFlush();
@@ -2054,7 +2055,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String scriptKill(final String sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.scriptKill();
@@ -2065,7 +2066,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Long geoadd(final String key, final double longitude, final double latitude,
       final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.geoadd(key, longitude, latitude, member);
@@ -2075,7 +2076,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long geoadd(final String key, final Map<String, GeoCoordinate> memberCoordinateMap) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.geoadd(key, memberCoordinateMap);
@@ -2085,7 +2086,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Double geodist(final String key, final String member1, final String member2) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Double execute(Jedis connection) {
         return connection.geodist(key, member1, member2);
@@ -2096,7 +2097,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public Double geodist(final String key, final String member1, final String member2,
       final GeoUnit unit) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Double execute(Jedis connection) {
         return connection.geodist(key, member1, member2, unit);
@@ -2106,7 +2107,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<String> geohash(final String key, final String... members) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<String> execute(Jedis connection) {
         return connection.geohash(key, members);
@@ -2116,7 +2117,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<GeoCoordinate> geopos(final String key, final String... members) {
-    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoCoordinate> execute(Jedis connection) {
         return connection.geopos(key, members);
@@ -2127,7 +2128,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadius(key, longitude, latitude, radius, unit);
@@ -2138,7 +2139,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusReadonly(key, longitude, latitude, radius, unit);
@@ -2149,7 +2150,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadius(key, longitude, latitude, radius, unit, param);
@@ -2161,7 +2162,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long georadiusStore(final String key, final double longitude, final double latitude,
       final double radius, final GeoUnit unit, final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     String[] keys = storeParam.getStringKeys(key);
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam);
@@ -2172,7 +2173,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusReadonly(key, longitude, latitude, radius, unit, param);
@@ -2183,7 +2184,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMember(key, member, radius, unit);
@@ -2194,7 +2195,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final String key, final String member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMemberReadonly(key, member, radius, unit);
@@ -2205,7 +2206,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMember(key, member, radius, unit, param);
@@ -2217,7 +2218,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long georadiusByMemberStore(final String key, final String member, final double radius, final GeoUnit unit,
       final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     String[] keys = storeParam.getStringKeys(key);
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam);
@@ -2228,7 +2229,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final String key, final String member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<GeoRadiusResponse> execute(Jedis connection) {
         return connection.georadiusByMemberReadonly(key, member, radius, unit, param);
@@ -2238,7 +2239,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Long> bitfield(final String key, final String... arguments) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Long> execute(Jedis connection) {
         return connection.bitfield(key, arguments);
@@ -2248,7 +2249,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<Long> bitfieldReadonly(final String key, final String... arguments) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Long> execute(Jedis connection) {
         return connection.bitfieldReadonly(key, arguments);
@@ -2258,7 +2259,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long hstrlen(final String key, final String field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.hstrlen(key, field);
@@ -2269,7 +2270,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   
   @Override
   public Long memoryUsage(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.memoryUsage(key);
@@ -2279,7 +2280,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   
   @Override
   public Long memoryUsage(final String key, final int samples) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.memoryUsage(key, samples);
@@ -2289,7 +2290,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   
   @Override
   public StreamEntryID xadd(final String key, final StreamEntryID id, final Map<String, String> hash) {
-    return new JedisClusterCommand<StreamEntryID>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<StreamEntryID>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public StreamEntryID execute(Jedis connection) {
         return connection.xadd(key, id, hash);
@@ -2299,7 +2300,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public StreamEntryID xadd(final String key, final StreamEntryID id, final Map<String, String> hash, final long maxLen, final boolean approximateLength) {
-    return new JedisClusterCommand<StreamEntryID>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<StreamEntryID>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public StreamEntryID execute(Jedis connection) {
         return connection.xadd(key, id, hash, maxLen, approximateLength);
@@ -2309,7 +2310,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long xlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.xlen(key);
@@ -2319,7 +2320,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<StreamEntry> xrange(final String key, final StreamEntryID start, final StreamEntryID end, final int count) {
-    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<StreamEntry> execute(Jedis connection) {
         return connection.xrange(key, start, end, count);
@@ -2329,7 +2330,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public List<StreamEntry> xrevrange(final String key, final StreamEntryID end, final StreamEntryID start, final int count) {
-    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<StreamEntry> execute(Jedis connection) {
         return connection.xrevrange(key, end, start, count);
@@ -2344,7 +2345,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[i] = streams[i].getKey();
     }
     
-    return new JedisClusterCommand<List<Entry<String, List<StreamEntry>>>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Entry<String, List<StreamEntry>>>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Entry<String, List<StreamEntry>>> execute(Jedis connection) {
         return connection.xread(count, block, streams);
@@ -2354,7 +2355,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long xack(final String key, final String group, final StreamEntryID... ids) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.xack(key, group, ids);
@@ -2364,7 +2365,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String xgroupCreate(final String key, final String groupname, final StreamEntryID id, final boolean makeStream) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.xgroupCreate(key, groupname, id, makeStream);
@@ -2374,7 +2375,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String xgroupSetID(final String key, final String groupname, final StreamEntryID id) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<String>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public String execute(Jedis connection) {
         return connection.xgroupSetID(key, groupname, id);
@@ -2384,7 +2385,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long xgroupDestroy(final String key, final String groupname) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.xgroupDestroy(key, groupname);
@@ -2394,7 +2395,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long xgroupDelConsumer(final String key, final String groupname, final String consumername) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.xgroupDelConsumer(key, groupname, consumername);
@@ -2411,7 +2412,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[i] = streams[i].getKey();
     }
     
-    return new JedisClusterCommand<List<Entry<String, List<StreamEntry>>>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<Entry<String, List<StreamEntry>>>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<Entry<String, List<StreamEntry>>> execute(Jedis connection) {
         return connection.xreadGroup(groupname, consumer, count, block, noAck, streams);
@@ -2422,7 +2423,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<StreamPendingEntry> xpending(final String key, final String groupname, final StreamEntryID start, final StreamEntryID end, final int count,
       final String consumername) {
-    return new JedisClusterCommand<List<StreamPendingEntry>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<StreamPendingEntry>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<StreamPendingEntry> execute(Jedis connection) {
         return connection.xpending(key, groupname, start, end, count, consumername);
@@ -2432,7 +2433,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long xdel(final String key, final StreamEntryID... ids) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.xdel(key, ids);
@@ -2442,7 +2443,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public Long xtrim(final  String key, final long maxLen, final boolean approximateLength) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.xtrim(key, maxLen, approximateLength);
@@ -2453,7 +2454,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   @Override
   public List<StreamEntry> xclaim(final String key, final String group, final String consumername, final long minIdleTime, final long newIdleTime,
       final int retries, final boolean force, final StreamEntryID... ids) {
-    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public List<StreamEntry> execute(Jedis connection) {
         return connection.xclaim(key, group, consumername, minIdleTime, newIdleTime, retries, force, ids);
@@ -2462,7 +2463,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public Long waitReplicas(final String key, final int replicas, final long timeout) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Long execute(Jedis connection) {
         return connection.waitReplicas(replicas, timeout);
@@ -2471,7 +2472,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public Object sendCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection){
         return connection.sendCommand(cmd, args);
@@ -2480,7 +2481,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   public Object sendBlockingCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
+    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts, this.timeout) {
       @Override
       public Object execute(Jedis connection){
         return connection.sendBlockingCommand(cmd, args);

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -1,5 +1,8 @@
 package redis.clients.jedis;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import redis.clients.jedis.exceptions.JedisAskDataException;
 import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
@@ -12,12 +15,33 @@ import redis.clients.jedis.util.JedisClusterCRC16;
 
 public abstract class JedisClusterCommand<T> {
 
+  /**
+   * Default cluster-node-timeout is 15s according to
+   * https://www.programmersought.com/article/40076100313/,
+   * add some on top of that and we get to 20.
+   *
+   * @see #JedisClusterCommand(JedisClusterConnectionHandler, int, Duration)
+   */
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(20);
+
   private final JedisClusterConnectionHandler connectionHandler;
   private final int maxAttempts;
+  private final Duration timeout;
 
-  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts) {
+  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts,
+      Duration timeout) {
     this.connectionHandler = connectionHandler;
     this.maxAttempts = maxAttempts;
+    this.timeout = timeout;
+  }
+
+  /**
+   * Create a cluster command with a default timeout of {@link #DEFAULT_TIMEOUT}. To override the
+   * timeout, call {@link #JedisClusterCommand(JedisClusterConnectionHandler, int, Duration)}
+   * instead.
+   */
+  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts) {
+    this(connectionHandler, maxAttempts, DEFAULT_TIMEOUT);
   }
 
   public abstract T execute(Jedis connection);
@@ -80,7 +104,26 @@ public abstract class JedisClusterCommand<T> {
     }
   }
 
+  private boolean shouldBackOff(int attemptsLeft) {
+    int attemptsDone = maxAttempts - attemptsLeft;
+    return attemptsDone >= maxAttempts / 3;
+  }
+
+  private static long getBackoffSleepMillis(int attemptsLeft, Instant deadline) {
+    if (attemptsLeft <= 0) {
+      return 0;
+    }
+
+    long millisLeft = Duration.between(Instant.now(), deadline).toMillis();
+    if (millisLeft <= 0) {
+      return 0;
+    }
+
+    return millisLeft / (attemptsLeft * attemptsLeft);
+  }
+
   private T runWithRetries(final int slot) {
+    Instant deadline = Instant.now().plus(timeout);
     Supplier<Jedis> connectionSupplier = () -> connectionHandler.getConnectionFromSlot(slot);
 
     // If we got one redirection, stick with that and don't try anything else
@@ -94,11 +137,19 @@ public abstract class JedisClusterCommand<T> {
         } else {
           connection = connectionSupplier.get();
         }
+
+        if (shouldBackOff(maxAttempts - currentAttempt)) {
+          // Don't just stick to this any more, start asking around
+          redirectionSupplier = null;
+        }
+
         return execute(connection);
       } catch (JedisNoReachableClusterNodeException e) {
         throw e;
       } catch (JedisConnectionException e) {
-        connectionSupplier = handleConnectionProblem(slot, currentAttempt);
+        // "- 1" because we just did one, but the currentAttempt counter hasn't increased yet
+        int attemptsLeft = maxAttempts - currentAttempt - 1;
+        connectionSupplier = handleConnectionProblem(slot, attemptsLeft, deadline);
       } catch (JedisRedirectionException e) {
         redirectionSupplier = handleRedirection(connection, e);
       } finally {
@@ -109,18 +160,31 @@ public abstract class JedisClusterCommand<T> {
     throw new JedisClusterMaxAttemptsException("No more cluster attempts left.");
   }
 
-  private Supplier<Jedis> handleConnectionProblem(final int slot, int currentAttempt) {
-    int attemptsLeft = (maxAttempts - currentAttempt) - 1;
-    if (attemptsLeft <= 1) {
-      //We need this because if node is not reachable anymore - we need to finally initiate slots
-      //renewing, or we can stuck with cluster state without one node in opposite case.
-      //But now if maxAttempts = [1 or 2] we will do it too often.
-      //TODO make tracking of successful/unsuccessful operations for node - do renewing only
-      //if there were no successful responses from this node last few seconds
-      this.connectionHandler.renewSlotCache();
+  protected void sleep(long sleepMillis) {
+    try {
+      TimeUnit.MILLISECONDS.sleep(sleepMillis);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Supplier<Jedis> handleConnectionProblem(final int slot, int attemptsLeft,
+      Instant doneDeadline) {
+    if (!shouldBackOff(attemptsLeft)) {
+      return () -> connectionHandler.getConnectionFromSlot(slot);
     }
 
-    return () -> connectionHandler.getConnectionFromSlot(slot);
+    //We need this because if node is not reachable anymore - we need to finally initiate slots
+    //renewing, or we can stuck with cluster state without one node in opposite case.
+    //TODO make tracking of successful/unsuccessful operations for node - do renewing only
+    //if there were no successful responses from this node last few seconds
+    this.connectionHandler.renewSlotCache();
+
+    return () -> {
+      sleep(getBackoffSleepMillis(attemptsLeft, doneDeadline));
+      // Get a random connection, it will redirect us if it's not the right one
+      return connectionHandler.getConnection();
+    };
   }
 
   private Supplier<Jedis> handleRedirection(Jedis connection, final JedisRedirectionException jre) {

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -15,15 +15,6 @@ import redis.clients.jedis.util.JedisClusterCRC16;
 
 public abstract class JedisClusterCommand<T> {
 
-  /**
-   * Default cluster-node-timeout is 15s according to
-   * https://www.programmersought.com/article/40076100313/,
-   * add some on top of that and we get to 20.
-   *
-   * @see #JedisClusterCommand(JedisClusterConnectionHandler, int, Duration)
-   */
-  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(20);
-
   private final JedisClusterConnectionHandler connectionHandler;
   private final int maxAttempts;
   private final Duration timeout;
@@ -33,15 +24,6 @@ public abstract class JedisClusterCommand<T> {
     this.connectionHandler = connectionHandler;
     this.maxAttempts = maxAttempts;
     this.timeout = timeout;
-  }
-
-  /**
-   * Create a cluster command with a default timeout of {@link #DEFAULT_TIMEOUT}. To override the
-   * timeout, call {@link #JedisClusterCommand(JedisClusterConnectionHandler, int, Duration)}
-   * instead.
-   */
-  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts) {
-    this(connectionHandler, maxAttempts, DEFAULT_TIMEOUT);
   }
 
   public abstract T execute(Jedis connection);

--- a/src/main/java/redis/clients/jedis/JedisClusterCommand.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterCommand.java
@@ -110,9 +110,7 @@ public abstract class JedisClusterCommand<T> {
       } catch (JedisRedirectionException e) {
         redirected = handleRedirection(connection, e);
       } finally {
-        if (connection != null) {
-          releaseConnection(connection);
-        }
+        releaseConnection(connection);
       }
     }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/JedisClusterCommandTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/JedisClusterCommandTest.java
@@ -1,0 +1,285 @@
+package redis.clients.jedis.tests.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.function.LongConsumer;
+import org.junit.Test;
+import org.mockito.InOrder;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisClusterCommand;
+import redis.clients.jedis.JedisClusterConnectionHandler;
+import redis.clients.jedis.JedisSlotBasedConnectionHandler;
+import redis.clients.jedis.exceptions.JedisAskDataException;
+import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisMovedDataException;
+import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
+
+public class JedisClusterCommandTest {
+
+  @Test(expected = JedisClusterMaxAttemptsException.class)
+  public void runZeroAttempts() {
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(null, 0, Duration.ZERO) {
+      @Override
+      public String execute(Jedis connection) {
+        return null;
+      }
+
+      @Override
+      protected void sleep(long ignored) {
+        throw new RuntimeException("This test should never sleep");
+      }
+    };
+
+    testMe.run("");
+  }
+
+  @Test
+  public void runSuccessfulExecute() {
+    JedisClusterConnectionHandler connectionHandler = mock(JedisClusterConnectionHandler.class);
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(connectionHandler, 10,
+        Duration.ZERO) {
+      @Override
+      public String execute(Jedis connection) {
+        return "foo";
+      }
+
+      @Override
+      protected void sleep(long ignored) {
+        throw new RuntimeException("This test should never sleep");
+      }
+    };
+    String actual = testMe.run("");
+    assertEquals("foo", actual);
+  }
+
+  @Test
+  public void runFailOnFirstExecSuccessOnSecondExec() {
+    JedisClusterConnectionHandler connectionHandler = mock(JedisClusterConnectionHandler.class);
+
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(connectionHandler, 10,
+        Duration.ZERO) {
+      boolean isFirstCall = true;
+
+      @Override
+      public String execute(Jedis connection) {
+        if (isFirstCall) {
+          isFirstCall = false;
+          throw new JedisConnectionException("Borkenz");
+        }
+
+        return "foo";
+      }
+
+      @Override
+      protected void sleep(long ignored) {
+        throw new RuntimeException("This test should never sleep");
+      }
+    };
+
+    String actual = testMe.run("");
+    assertEquals("foo", actual);
+  }
+
+  @Test
+  public void runAlwaysFailing() {
+    JedisSlotBasedConnectionHandler connectionHandler = mock(JedisSlotBasedConnectionHandler.class);
+
+    final LongConsumer sleep = mock(LongConsumer.class);
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(connectionHandler, 3,
+        Duration.ofSeconds(1)) {
+      @Override
+      public String execute(Jedis connection) {
+        throw new JedisConnectionException("Connection failed");
+      }
+
+      @Override
+      protected void sleep(long sleepMillis) {
+        sleep.accept(sleepMillis);
+      }
+    };
+
+    try {
+      testMe.run("");
+      fail("cluster command did not fail");
+    } catch (JedisClusterMaxAttemptsException e) {
+      // expected
+    }
+    InOrder inOrder = inOrder(connectionHandler, sleep);
+    inOrder.verify(connectionHandler).getConnectionFromSlot(anyInt());
+    inOrder.verify(connectionHandler).renewSlotCache();
+    inOrder.verify(sleep).accept(anyLong());
+    inOrder.verify(connectionHandler).getConnection();
+    inOrder.verify(connectionHandler).renewSlotCache();
+    inOrder.verify(sleep).accept(anyLong());
+    inOrder.verify(connectionHandler).getConnection();
+    inOrder.verify(connectionHandler).renewSlotCache();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void runMovedSuccess() {
+    JedisSlotBasedConnectionHandler connectionHandler = mock(JedisSlotBasedConnectionHandler.class);
+
+    final HostAndPort movedTarget = new HostAndPort(null, 0);
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(connectionHandler, 10,
+        Duration.ZERO) {
+      boolean isFirstCall = true;
+
+      @Override
+      public String execute(Jedis connection) {
+        if (isFirstCall) {
+          isFirstCall = false;
+
+          // Slot 0 moved
+          throw new JedisMovedDataException("", movedTarget, 0);
+        }
+
+        return "foo";
+      }
+
+      @Override
+      protected void sleep(long ignored) {
+        throw new RuntimeException("This test should never sleep");
+      }
+    };
+
+    String actual = testMe.run("");
+    assertEquals("foo", actual);
+
+    InOrder inOrder = inOrder(connectionHandler);
+    inOrder.verify(connectionHandler).getConnectionFromSlot(anyInt());
+    inOrder.verify(connectionHandler).renewSlotCache(any());
+    inOrder.verify(connectionHandler).getConnectionFromNode(movedTarget);
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void runAskSuccess() {
+    JedisSlotBasedConnectionHandler connectionHandler = mock(JedisSlotBasedConnectionHandler.class);
+    Jedis connection = mock(Jedis.class);
+    final HostAndPort askTarget = new HostAndPort(null, 0);
+    when(connectionHandler.getConnectionFromNode(askTarget)).thenReturn(connection);
+
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(connectionHandler, 10,
+        Duration.ZERO) {
+      boolean isFirstCall = true;
+
+      @Override
+      public String execute(Jedis connection) {
+        if (isFirstCall) {
+          isFirstCall = false;
+
+          // Slot 0 moved
+          throw new JedisAskDataException("", askTarget, 0);
+        }
+
+        return "foo";
+      }
+
+      @Override
+      protected void sleep(long ignored) {
+        throw new RuntimeException("This test should never sleep");
+      }
+    };
+
+    String actual = testMe.run("");
+    assertEquals("foo", actual);
+
+    InOrder inOrder = inOrder(connectionHandler, connection);
+    inOrder.verify(connectionHandler).getConnectionFromSlot(anyInt());
+    inOrder.verify(connectionHandler).getConnectionFromNode(askTarget);
+    inOrder.verify(connection).asking();
+    inOrder.verify(connection).close(); // From the finally clause in runWithRetries()
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void runMovedThenAllNodesFailing() {
+    // Test:
+    // First attempt is a JedisMovedDataException() move, because we asked the wrong node.
+    // All subsequent attempts are JedisConnectionExceptions, because all nodes are now down.
+    // In response to the JedisConnectionExceptions, run() retries random nodes until maxAttempts is
+    // reached.
+    JedisSlotBasedConnectionHandler connectionHandler = mock(JedisSlotBasedConnectionHandler.class);
+
+    final Jedis redirecter = mock(Jedis.class);
+    when(connectionHandler.getConnectionFromSlot(anyInt())).thenReturn(redirecter);
+
+    final Jedis failer = mock(Jedis.class);
+    when(connectionHandler.getConnectionFromNode(any(HostAndPort.class))).thenReturn(failer);
+    when(connectionHandler.getConnection()).thenReturn(failer);
+
+    final LongConsumer sleep = mock(LongConsumer.class);
+    final HostAndPort movedTarget = new HostAndPort(null, 0);
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(connectionHandler, 3,
+        Duration.ZERO) {
+      @Override
+      public String execute(Jedis connection) {
+        if (redirecter == connection) {
+          // First attempt, report moved
+          throw new JedisMovedDataException("Moved", movedTarget, 0);
+        }
+
+        if (failer == connection) {
+          // Second attempt in response to the move, report failure
+          throw new JedisConnectionException("Connection failed");
+        }
+
+        throw new IllegalStateException("Should have thrown jedis exception");
+      }
+
+      @Override
+      protected void sleep(long sleepMillis) {
+        sleep.accept(sleepMillis);
+      }
+    };
+
+    try {
+      testMe.run("");
+      fail("cluster command did not fail");
+    } catch (JedisClusterMaxAttemptsException e) {
+      // expected
+    }
+    InOrder inOrder = inOrder(connectionHandler, sleep);
+    inOrder.verify(connectionHandler).getConnectionFromSlot(anyInt());
+    inOrder.verify(connectionHandler).renewSlotCache(redirecter);
+    inOrder.verify(connectionHandler).getConnectionFromNode(movedTarget);
+    inOrder.verify(connectionHandler).renewSlotCache();
+    inOrder.verify(sleep).accept(anyLong());
+    inOrder.verify(connectionHandler).getConnection();
+    inOrder.verify(connectionHandler).renewSlotCache();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test(expected = JedisNoReachableClusterNodeException.class)
+  public void runRethrowsJedisNoReachableClusterNodeException() {
+    JedisSlotBasedConnectionHandler connectionHandler = mock(JedisSlotBasedConnectionHandler.class);
+    when(connectionHandler.getConnectionFromSlot(anyInt())).thenThrow(
+      JedisNoReachableClusterNodeException.class);
+
+    JedisClusterCommand<String> testMe = new JedisClusterCommand<String>(connectionHandler, 10,
+        Duration.ZERO) {
+      @Override
+      public String execute(Jedis connection) {
+        return null;
+      }
+
+      @Override
+      protected void sleep(long ignored) {
+        throw new RuntimeException("This test should never sleep");
+      }
+    };
+
+    testMe.run("");
+  }
+}


### PR DESCRIPTION
Before this change, if there were connection failures to the cluster, we did all our retries without any backoff.

With this change in place:
* We first do the previous no-backoff tactic for one third of our `maxAttempts` (see the `shouldBackOff()` method)
* Then we start backing off as determined by the `getBackoffSleepMillis()` method

Additionally, this change adds unit tests for the retries / backoff logic.

This change is based on the changes in #2355 (approved, not yet merged, currently waiting for more reviewers).