### PR TITLE
Pluggable Retry Mechanism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,8 +129,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -24,6 +24,14 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
+/**
+ * Interface to a Jedis cluster.
+ * <p/>
+ * Uses {@link DefaultRetryer}, or you can inject your own using
+ * {@link BinaryJedisCluster#BinaryJedisCluster(Retryer)}.
+ *
+ * @see JedisCluster
+ */
 public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     MultiKeyBinaryJedisClusterCommands, JedisClusterBinaryScriptingCommands, Closeable {
 

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -105,6 +105,10 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
     retryer = new DefaultRetryer(connectionHandler, maxAttempts);
   }
 
+  public BinaryJedisCluster(Retryer retryer) {
+    this.retryer = retryer;
+  }
+
   @Override
   public void close() {
     retryer.close();

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -111,11 +111,11 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   }
 
   public Map<String, JedisPool> getClusterNodes() {
-    return connectionHandler.getNodes();
+    return retryer.getClusterNodes();
   }
 
   public Jedis getConnectionFromSlot(int slot) {
-	  return  this.connectionHandler.getConnectionFromSlot(slot);
+    return retryer.getConnectionFromSlot(slot);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -33,10 +33,6 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   protected final Retryer retryer;
 
-  protected int maxAttempts;
-
-  protected JedisClusterConnectionHandler connectionHandler;
-
   public BinaryJedisCluster(Set<HostAndPort> nodes) {
     this(nodes, DEFAULT_TIMEOUT);
   }
@@ -64,16 +60,16 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxAttempts, String user, String password, String clientName, GenericObjectPoolConfig poolConfig) {
-    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+    JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, user, password, clientName);
-    this.maxAttempts = maxAttempts;
+    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
       int infiniteSoTimeout, int maxAttempts, String user, String password, String clientName, GenericObjectPoolConfig poolConfig) {
-    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+    JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, infiniteSoTimeout, user, password, clientName);
-    this.maxAttempts = maxAttempts;
+    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxAttempts, String password, String clientName, GenericObjectPoolConfig poolConfig,
@@ -96,24 +92,22 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       int maxAttempts, String user, String password, String clientName, GenericObjectPoolConfig poolConfig,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap hostAndPortMap) {
-    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+    JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, user, password, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMap);
-    this.maxAttempts = maxAttempts;
+    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
       int infiniteSoTimeout, int maxAttempts, String user, String password, String clientName, GenericObjectPoolConfig poolConfig,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters, HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap hostAndPortMap) {
-    this.connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
+    JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, infiniteSoTimeout, user, password, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMap);
-    this.maxAttempts = maxAttempts;
+    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
   }
 
   @Override
   public void close() {
-    if (connectionHandler != null) {
-      connectionHandler.close();
-    }
+    retryer.close();
   }
 
   public Map<String, JedisPool> getClusterNodes() {

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -125,1486 +125,751 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public String set(final byte[] key, final byte[] value, final SetParams params) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.set(key, value, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.set(key, value, params), key);
   }
 
   @Override
   public byte[] get(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.get(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.get(key), key);
   }
 
   @Override
   public Long exists(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.exists(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.exists(keys), keys.length, keys);
   }
 
   @Override
   public Boolean exists(final byte[] key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.exists(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.exists(key), key);
   }
 
   @Override
   public Long persist(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.persist(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.persist(key), key);
   }
 
   @Override
   public String type(final byte[] key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.type(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.type(key), key);
   }
 
   @Override
   public byte[] dump(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.dump(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.dump(key), key);
   }
 
   @Override
   public String restore(final byte[] key, final int ttl, final byte[] serializedValue) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.restore(key, ttl, serializedValue);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.restore(key, ttl, serializedValue), key);
   }
 
   @Override
   public Long expire(final byte[] key, final int seconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.expire(key, seconds);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.expire(key, seconds), key);
   }
 
   @Override
   public Long pexpire(final byte[] key, final long milliseconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pexpire(key, milliseconds);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.pexpire(key, milliseconds), key);
   }
 
   @Override
   public Long expireAt(final byte[] key, final long unixTime) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.expireAt(key, unixTime);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.expireAt(key, unixTime), key);
   }
 
   @Override
   public Long pexpireAt(final byte[] key, final long millisecondsTimestamp) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pexpireAt(key, millisecondsTimestamp);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.pexpireAt(key, millisecondsTimestamp), key);
   }
 
   @Override
   public Long ttl(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.ttl(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.ttl(key), key);
   }
 
   @Override
   public Long pttl(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pttl(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.pttl(key), key);
   }
 
   @Override
   public Long touch(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.touch(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.touch(key), key);
   }
 
   @Override
   public Long touch(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.touch(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.touch(keys), keys.length, keys);
   }
 
   @Override
   public Boolean setbit(final byte[] key, final long offset, final boolean value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.setbit(key, offset, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean setbit(final byte[] key, final long offset, final byte[] value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.setbit(key, offset, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean getbit(final byte[] key, final long offset) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.getbit(key, offset);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.getbit(key, offset), key);
   }
 
   @Override
   public Long setrange(final byte[] key, final long offset, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.setrange(key, offset, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.setrange(key, offset, value), key);
   }
 
   @Override
   public byte[] getrange(final byte[] key, final long startOffset, final long endOffset) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.getrange(key, startOffset, endOffset);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.getrange(key, startOffset, endOffset), key);
   }
 
   @Override
   public byte[] getSet(final byte[] key, final byte[] value) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.getSet(key, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.getSet(key, value), key);
   }
 
   @Override
   public Long setnx(final byte[] key, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.setnx(key, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.setnx(key, value), key);
   }
 
   @Override
   public String psetex(final byte[] key, final long milliseconds, final byte[] value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.psetex(key, milliseconds, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.psetex(key, milliseconds, value), key);
   }
 
   @Override
   public String setex(final byte[] key, final int seconds, final byte[] value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.setex(key, seconds, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.setex(key, seconds, value), key);
   }
 
   @Override
   public Long decrBy(final byte[] key, final long decrement) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.decrBy(key, decrement);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.decrBy(key, decrement), key);
   }
 
   @Override
   public Long decr(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.decr(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.decr(key), key);
   }
 
   @Override
   public Long incrBy(final byte[] key, final long increment) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.incrBy(key, increment);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.incrBy(key, increment), key);
   }
 
   @Override
   public Double incrByFloat(final byte[] key, final double increment) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.incrByFloat(key, increment);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.incrByFloat(key, increment), key);
   }
 
   @Override
   public Long incr(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.incr(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.incr(key), key);
   }
 
   @Override
   public Long append(final byte[] key, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.append(key, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.append(key, value), key);
   }
 
   @Override
   public byte[] substr(final byte[] key, final int start, final int end) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.substr(key, start, end);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.substr(key, start, end), key);
   }
 
   @Override
   public Long hset(final byte[] key, final byte[] field, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hset(key, field, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hset(key, field, value), key);
   }
 
   @Override
   public Long hset(final byte[] key, final Map<byte[], byte[]> hash) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hset(key, hash);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hset(key, hash), key);
   }
 
   @Override
   public byte[] hget(final byte[] key, final byte[] field) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.hget(key, field);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hget(key, field), key);
   }
 
   @Override
   public Long hsetnx(final byte[] key, final byte[] field, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hsetnx(key, field, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hsetnx(key, field, value), key);
   }
 
   @Override
   public String hmset(final byte[] key, final Map<byte[], byte[]> hash) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.hmset(key, hash);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hmset(key, hash), key);
   }
 
   @Override
   public List<byte[]> hmget(final byte[] key, final byte[]... fields) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.hmget(key, fields);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hmget(key, fields), key);
   }
 
   @Override
   public Long hincrBy(final byte[] key, final byte[] field, final long value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hincrBy(key, field, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hincrBy(key, field, value), key);
   }
 
   @Override
   public Double hincrByFloat(final byte[] key, final byte[] field, final double value) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.hincrByFloat(key, field, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hincrByFloat(key, field, value), key);
   }
 
   @Override
   public Boolean hexists(final byte[] key, final byte[] field) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.hexists(key, field);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hexists(key, field), key);
   }
 
   @Override
   public Long hdel(final byte[] key, final byte[]... field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hdel(key, field);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hdel(key, field), key);
   }
 
   @Override
   public Long hlen(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hlen(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hlen(key), key);
   }
 
   @Override
   public Set<byte[]> hkeys(final byte[] key) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.hkeys(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hkeys(key), key);
   }
 
   @Override
   public List<byte[]> hvals(final byte[] key) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.hvals(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hvals(key), key);
   }
 
   @Override
   public Map<byte[], byte[]> hgetAll(final byte[] key) {
-    return new JedisClusterCommand<Map<byte[], byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Map<byte[], byte[]> execute(Jedis connection) {
-        return connection.hgetAll(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hgetAll(key), key);
   }
 
   @Override
   public Long rpush(final byte[] key, final byte[]... args) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.rpush(key, args);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.rpush(key, args), key);
   }
 
   @Override
   public Long lpush(final byte[] key, final byte[]... args) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpush(key, args);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lpush(key, args), key);
   }
 
   @Override
   public Long llen(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.llen(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.llen(key), key);
   }
 
   @Override
   public List<byte[]> lrange(final byte[] key, final long start, final long stop) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.lrange(key, start, stop);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lrange(key, start, stop), key);
   }
 
   @Override
   public String ltrim(final byte[] key, final long start, final long stop) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.ltrim(key, start, stop);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.ltrim(key, start, stop), key);
   }
 
   @Override
   public byte[] lindex(final byte[] key, final long index) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.lindex(key, index);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lindex(key, index), key);
   }
 
   @Override
   public String lset(final byte[] key, final long index, final byte[] value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.lset(key, index, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lset(key, index, value), key);
   }
 
   @Override
   public Long lrem(final byte[] key, final long count, final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lrem(key, count, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lrem(key, count, value), key);
   }
 
   @Override
   public byte[] lpop(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.lpop(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lpop(key), key);
   }
 
   @Override
   public List<byte[]> lpop(final byte[] key, final int count) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.lpop(key, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lpop(key, count), key);
   }
 
   @Override
   public Long lpos(final byte[] key, final byte[] element) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpos(key, element);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lpos(key, element), key);
   }
 
   @Override
   public Long lpos(final byte[] key, final byte[] element, final LPosParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpos(key, element, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lpos(key, element, params), key);
   }
 
   @Override
   public List<Long> lpos(final byte[] key, final byte[] element, final LPosParams params, final long count) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
-      @Override
-        public List<Long> execute(Jedis connection) {
-          return connection.lpos(key, element, params, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lpos(key, element, params, count), key);
   }
 
   @Override
   public byte[] rpop(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.rpop(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.rpop(key), key);
   }
 
   @Override
   public List<byte[]> rpop(final byte[] key, final int count) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.rpop(key, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.rpop(key, count), key);
   }
 
   @Override
   public Long sadd(final byte[] key, final byte[]... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sadd(key, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.sadd(key, member), key);
   }
 
   @Override
   public Set<byte[]> smembers(final byte[] key) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.smembers(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.smembers(key), key);
   }
 
   @Override
   public Long srem(final byte[] key, final byte[]... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.srem(key, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.srem(key, member), key);
   }
 
   @Override
   public byte[] spop(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.spop(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.spop(key), key);
   }
 
   @Override
   public Set<byte[]> spop(final byte[] key, final long count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.spop(key, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.spop(key, count), key);
   }
 
   @Override
   public Long scard(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.scard(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.scard(key), key);
   }
 
   @Override
   public Boolean sismember(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.sismember(key, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.sismember(key, member), key);
   }
 
   @Override
   public List<Boolean> smismember(final byte[] key, final byte[]... members) {
-    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Boolean> execute(Jedis connection) {
-        return connection.smismember(key, members);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.smismember(key, members), key);
   }
 
   @Override
   public byte[] srandmember(final byte[] key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.srandmember(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.srandmember(key), key);
   }
 
   @Override
   public Long strlen(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.strlen(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.strlen(key), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final double score, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, score, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zadd(key, score, member), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final double score, final byte[] member,
       final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, score, member, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zadd(key, score, member, params), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, scoreMembers);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zadd(key, scoreMembers), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers, final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, scoreMembers, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zadd(key, scoreMembers, params), key);
   }
 
   @Override
   public Set<byte[]> zrange(final byte[] key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrange(key, start, stop);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrange(key, start, stop), key);
   }
 
   @Override
   public Long zrem(final byte[] key, final byte[]... members) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zrem(key, members);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrem(key, members), key);
   }
 
   @Override
   public Double zincrby(final byte[] key, final double increment, final byte[] member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.zincrby(key, increment, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zincrby(key, increment, member), key);
   }
 
   @Override
   public Double zincrby(final byte[] key, final double increment, final byte[] member,
       final ZIncrByParams params) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.zincrby(key, increment, member, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zincrby(key, increment, member, params), key);
   }
 
   @Override
   public Long zrank(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zrank(key, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrank(key, member), key);
   }
 
   @Override
   public Long zrevrank(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zrevrank(key, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrank(key, member), key);
   }
 
   @Override
   public Set<byte[]> zrevrange(final byte[] key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrevrange(key, start, stop);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrange(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrangeWithScores(final byte[] key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeWithScores(key, start, stop);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final byte[] key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeWithScores(key, start, stop);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Long zcard(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zcard(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zcard(key), key);
   }
 
   @Override
   public Double zscore(final byte[] key, final byte[] member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.zscore(key, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zscore(key, member), key);
   }
 
   @Override
   public List<Double> zmscore(final byte[] key, final byte[]... members) {
-    return new JedisClusterCommand<List<Double>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Double> execute(Jedis connection) {
-        return connection.zmscore(key, members);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zmscore(key, members), key);
   }
 
   @Override
   public Tuple zpopmax(final byte[] key) {
-    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts) {
-      @Override
-      public Tuple execute(Jedis connection) {
-        return connection.zpopmax(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zpopmax(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmax(final byte[] key, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zpopmax(key, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zpopmax(key, count), key);
   }
 
   @Override
   public Tuple zpopmin(final byte[] key) {
-    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts) {
-      @Override
-      public Tuple execute(Jedis connection) {
-        return connection.zpopmin(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zpopmin(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmin(final byte[] key, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zpopmin(key, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zpopmin(key, count), key);
   }
 
   @Override
   public List<byte[]> sort(final byte[] key) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.sort(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.sort(key), key);
   }
 
   @Override
   public List<byte[]> sort(final byte[] key, final SortingParams sortingParameters) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.sort(key, sortingParameters);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.sort(key, sortingParameters), key);
   }
 
   @Override
   public Long zcount(final byte[] key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zcount(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Long zcount(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zcount(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final byte[] max, final byte[] min) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final byte[] max, final byte[] min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final byte[] max, final byte[] min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max,
       final double min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final byte[] max,
       final byte[] min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
   }
 
   @Override
   public Long zremrangeByRank(final byte[] key, final long start, final long stop) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByRank(key, start, stop);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zremrangeByRank(key, start, stop), key);
   }
 
   @Override
   public Long zremrangeByScore(final byte[] key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByScore(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long zremrangeByScore(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByScore(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long linsert(final byte[] key, final ListPosition where, final byte[] pivot,
       final byte[] value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.linsert(key, where, pivot, value);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.linsert(key, where, pivot, value), key);
   }
 
   @Override
   public Long lpushx(final byte[] key, final byte[]... arg) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpushx(key, arg);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.lpushx(key, arg), key);
   }
 
   @Override
   public Long rpushx(final byte[] key, final byte[]... arg) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.rpushx(key, arg);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.rpushx(key, arg), key);
   }
 
   @Override
   public Long del(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.del(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.del(key), key);
   }
 
   @Override
   public Long unlink(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.unlink(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.unlink(key), key);
   }
 
   @Override
   public Long unlink(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.unlink(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.unlink(keys), keys.length, keys);
   }
 
   @Override
   public byte[] echo(final byte[] arg) {
     // note that it'll be run from arbitary node
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.echo(arg);
-      }
-    }.runBinary(arg);
+    return retryer.runBinary((connection) -> connection.echo(arg), arg);
   }
 
   @Override
   public Long bitcount(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.bitcount(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.bitcount(key), key);
   }
 
   @Override
   public Long bitcount(final byte[] key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.bitcount(key, start, end);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.bitcount(key, start, end), key);
   }
 
   @Override
   public Long pfadd(final byte[] key, final byte[]... elements) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pfadd(key, elements);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.pfadd(key, elements), key);
   }
 
   @Override
   public long pfcount(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pfcount(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.pfcount(key), key);
   }
 
   @Override
   public List<byte[]> srandmember(final byte[] key, final int count) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.srandmember(key, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.srandmember(key, count), key);
   }
 
   @Override
   public Long zlexcount(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zlexcount(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zlexcount(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByLex(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrangeByLex(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByLex(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByLex(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrangeByLex(key, min, max, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrangeByLex(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByLex(final byte[] key, final byte[] max, final byte[] min) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrevrangeByLex(key, max, min);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByLex(key, max, min), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByLex(final byte[] key, final byte[] max, final byte[] min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.zrevrangeByLex(key, max, min, offset, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zrevrangeByLex(key, max, min, offset, count), key);
   }
 
   @Override
   public Long zremrangeByLex(final byte[] key, final byte[] min, final byte[] max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByLex(key, min, max);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zremrangeByLex(key, min, max), key);
   }
 
   @Override
   public Object eval(final byte[] script, final byte[] keyCount, final byte[]... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.eval(script, keyCount, params);
-      }
-    }.runBinary(Integer.parseInt(SafeEncoder.encode(keyCount)), params);
+    return retryer.runBinary((connection) -> connection.eval(script, keyCount, params), Integer.parseInt(SafeEncoder.encode(keyCount)), params);
   }
 
   @Override
   public Object eval(final byte[] script, final int keyCount, final byte[]... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.eval(script, keyCount, params);
-      }
-    }.runBinary(keyCount, params);
+    return retryer.runBinary((connection) -> connection.eval(script, keyCount, params), keyCount, params);
   }
 
   @Override
   public Object eval(final byte[] script, final List<byte[]> keys, final List<byte[]> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.eval(script, keys, args);
-      }
-    }.runBinary(keys.size(), keys.toArray(new byte[keys.size()][]));
+    return retryer.runBinary((connection) -> connection.eval(script, keys, args), keys.size(), keys.toArray(new byte[keys.size()][]));
   }
 
   @Override
   public Object eval(final byte[] script, final byte[] sampleKey) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.eval(script);
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary((connection) -> connection.eval(script), sampleKey);
   }
 
   @Override
   public Object evalsha(final byte[] sha1, final byte[] sampleKey) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.evalsha(sha1);
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary((connection) -> connection.evalsha(sha1), sampleKey);
   }
 
   @Override
   public Object evalsha(final byte[] sha1, final List<byte[]> keys, final List<byte[]> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.evalsha(sha1, keys, args);
-      }
-    }.runBinary(keys.size(), keys.toArray(new byte[keys.size()][]));
+    return retryer.runBinary((connection) -> connection.evalsha(sha1, keys, args), keys.size(), keys.toArray(new byte[keys.size()][]));
   }
 
   @Override
   public Object evalsha(final byte[] sha1, final int keyCount, final byte[]... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.evalsha(sha1, keyCount, params);
-      }
-    }.runBinary(keyCount, params);
+    return retryer.runBinary((connection) -> connection.evalsha(sha1, keyCount, params), keyCount, params);
   }
 
   @Override
   public List<Long> scriptExists(final byte[] sampleKey, final byte[]... sha1) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Long> execute(Jedis connection) {
-        return connection.scriptExists(sha1);
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary((connection) -> connection.scriptExists(sha1), sampleKey);
   }
 
   @Override
   public byte[] scriptLoad(final byte[] script, final byte[] sampleKey) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.scriptLoad(script);
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary((connection) -> connection.scriptLoad(script), sampleKey);
   }
 
   @Override
   public String scriptFlush(final byte[] sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.scriptFlush();
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary(BinaryJedis::scriptFlush, sampleKey);
   }
 
   @Override
   public String scriptKill(final byte[] sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.scriptKill();
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary(BinaryJedis::scriptKill, sampleKey);
   }
 
   @Override
   public Long del(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.del(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.del(keys), keys.length, keys);
   }
 
   @Override
   public List<byte[]> blpop(final int timeout, final byte[]... keys) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.blpop(timeout, keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.blpop(timeout, keys), keys.length, keys);
   }
 
   @Override
   public List<byte[]> brpop(final int timeout, final byte[]... keys) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.brpop(timeout, keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.brpop(timeout, keys), keys.length, keys);
   }
 
   @Override
   public List<byte[]> mget(final byte[]... keys) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.mget(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.mget(keys), keys.length, keys);
   }
 
   @Override
@@ -1615,12 +880,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.mset(keysvalues);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.mset(keysvalues), keys.length, keys);
   }
 
   @Override
@@ -1631,196 +891,106 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.msetnx(keysvalues);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.msetnx(keysvalues), keys.length, keys);
   }
 
   @Override
   public String rename(final byte[] oldkey, final byte[] newkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.rename(oldkey, newkey);
-      }
-    }.runBinary(2, oldkey, newkey);
+    return retryer.runBinary((connection) -> connection.rename(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public Long renamenx(final byte[] oldkey, final byte[] newkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.renamenx(oldkey, newkey);
-      }
-    }.runBinary(2, oldkey, newkey);
+    return retryer.runBinary((connection) -> connection.renamenx(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public byte[] rpoplpush(final byte[] srckey, final byte[] dstkey) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.rpoplpush(srckey, dstkey);
-      }
-    }.runBinary(2, srckey, dstkey);
+    return retryer.runBinary((connection) -> connection.rpoplpush(srckey, dstkey), 2, srckey, dstkey);
   }
 
   @Override
   public Set<byte[]> sdiff(final byte[]... keys) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.sdiff(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.sdiff(keys), keys.length, keys);
   }
 
   @Override
   public Long sdiffstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sdiffstore(dstkey, keys);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.sdiffstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Set<byte[]> sinter(final byte[]... keys) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.sinter(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.sinter(keys), keys.length, keys);
   }
 
   @Override
   public Long sinterstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sinterstore(dstkey, keys);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.sinterstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long smove(final byte[] srckey, final byte[] dstkey, final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.smove(srckey, dstkey, member);
-      }
-    }.runBinary(2, srckey, dstkey);
+    return retryer.runBinary((connection) -> connection.smove(srckey, dstkey, member), 2, srckey, dstkey);
   }
 
   @Override
   public Long sort(final byte[] key, final SortingParams sortingParameters, final byte[] dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sort(key, sortingParameters, dstkey);
-      }
-    }.runBinary(2, key, dstkey);
+    return retryer.runBinary((connection) -> connection.sort(key, sortingParameters, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Long sort(final byte[] key, final byte[] dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sort(key, dstkey);
-      }
-    }.runBinary(2, key, dstkey);
+    return retryer.runBinary((connection) -> connection.sort(key, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Set<byte[]> sunion(final byte[]... keys) {
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.sunion(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.sunion(keys), keys.length, keys);
   }
 
   @Override
   public Long sunionstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sunionstore(dstkey, keys);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.sunionstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final byte[] dstkey, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zinterstore(dstkey, sets);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.zinterstore(dstkey, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final byte[] dstkey, final ZParams params, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zinterstore(dstkey, params, sets);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.zinterstore(dstkey, params, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zunionstore(final byte[] dstkey, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zunionstore(dstkey, sets);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.zunionstore(dstkey, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zunionstore(final byte[] dstkey, final ZParams params, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zunionstore(dstkey, params, sets);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.zunionstore(dstkey, params, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public byte[] brpoplpush(final byte[] source, final byte[] destination, final int timeout) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.brpoplpush(source, destination, timeout);
-      }
-    }.runBinary(2, source, destination);
+    return retryer.runBinary((connection) -> connection.brpoplpush(source, destination, timeout), 2, source, destination);
   }
 
   @Override
@@ -1855,196 +1025,106 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public String pfmerge(final byte[] destkey, final byte[]... sourcekeys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(destkey, sourcekeys);
 
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.pfmerge(destkey, sourcekeys);
-      }
-    }.runBinary(wholeKeys.length, wholeKeys);
+    return retryer.runBinary((connection) -> connection.pfmerge(destkey, sourcekeys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long pfcount(final byte[]... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pfcount(keys);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.pfcount(keys), keys.length, keys);
   }
 
   @Override
   public Long geoadd(final byte[] key, final double longitude, final double latitude,
       final byte[] member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.geoadd(key, longitude, latitude, member);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.geoadd(key, longitude, latitude, member), key);
   }
 
   @Override
   public Long geoadd(final byte[] key, final Map<byte[], GeoCoordinate> memberCoordinateMap) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.geoadd(key, memberCoordinateMap);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.geoadd(key, memberCoordinateMap), key);
   }
 
   @Override
   public Double geodist(final byte[] key, final byte[] member1, final byte[] member2) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.geodist(key, member1, member2);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.geodist(key, member1, member2), key);
   }
 
   @Override
   public Double geodist(final byte[] key, final byte[] member1, final byte[] member2,
       final GeoUnit unit) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.geodist(key, member1, member2, unit);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.geodist(key, member1, member2, unit), key);
   }
 
   @Override
   public List<byte[]> geohash(final byte[] key, final byte[]... members) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.geohash(key, members);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.geohash(key, members), key);
   }
 
   @Override
   public List<GeoCoordinate> geopos(final byte[] key, final byte[]... members) {
-    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoCoordinate> execute(Jedis connection) {
-        return connection.geopos(key, members);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.geopos(key, members), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadius(key, longitude, latitude, radius, unit);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadius(key, longitude, latitude, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusReadonly(key, longitude, latitude, radius, unit);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadius(key, longitude, latitude, radius, unit, param);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadius(key, longitude, latitude, radius, unit, param), key);
   }
 
   @Override
   public Long georadiusStore(final byte[] key, final double longitude, final double latitude, final double radius,
       final GeoUnit unit, final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     byte[][] keys = storeParam.getByteKeys(key);
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam), keys.length, keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusReadonly(key, longitude, latitude, radius, unit, param);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit, param), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMember(key, member, radius, unit);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadiusByMember(key, member, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMemberReadonly(key, member, radius, unit);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMember(key, member, radius, unit, param);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadiusByMember(key, member, radius, unit, param), key);
   }
 
   @Override
   public Long georadiusByMemberStore(final byte[] key, final byte[] member, final double radius, final GeoUnit unit,
       final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     byte[][] keys = storeParam.getByteKeys(key);
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam);
-      }
-    }.runBinary(keys.length, keys);
+    return retryer.runBinary((connection) -> connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam), keys.length, keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMemberReadonly(key, member, radius, unit, param);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit, param), key);
   }
 
   @Override
@@ -2057,18 +1137,13 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       throw new IllegalArgumentException(this.getClass().getSimpleName()
           + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
-    return new JedisClusterCommand<Set<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<byte[]> execute(Jedis connection) {
-        return connection.keys(pattern);
-      }
-    }.runBinary(pattern);
+    return retryer.runBinary((connection) -> connection.keys(pattern), pattern);
   }
 
   @Override
   public ScanResult<byte[]> scan(final byte[] cursor, final ScanParams params) {
 
-    byte[] matchPattern = null;
+    byte[] matchPattern;
 
     if (params == null || (matchPattern = params.binaryMatch()) == null || matchPattern.length == 0) {
       throw new IllegalArgumentException(BinaryJedisCluster.class.getSimpleName()
@@ -2080,310 +1155,158 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
           + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
 
-    return new JedisClusterCommand< ScanResult<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<byte[]> execute(Jedis connection) {
-        return connection.scan(cursor, params);
-      }
-    }.runBinary(matchPattern);
+    return retryer.runBinary((connection) -> connection.scan(cursor, params), matchPattern);
   }
-  
+
   @Override
   public ScanResult<Map.Entry<byte[], byte[]>> hscan(final byte[] key, final byte[] cursor) {
-    return new JedisClusterCommand<ScanResult<Map.Entry<byte[], byte[]>>>(connectionHandler,
-                                                                          maxAttempts) {
-      @Override
-      public ScanResult<Map.Entry<byte[], byte[]>> execute(Jedis connection) {
-        return connection.hscan(key, cursor);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<Map.Entry<byte[], byte[]>> hscan(final byte[] key, final byte[] cursor,
       final ScanParams params) {
-    return new JedisClusterCommand<ScanResult<Map.Entry<byte[], byte[]>>>(connectionHandler,
-                                                                          maxAttempts) {
-      @Override
-      public ScanResult<Map.Entry<byte[], byte[]>> execute(Jedis connection) {
-        return connection.hscan(key, cursor, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hscan(key, cursor, params), key);
   }
 
   @Override
   public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor) {
-    return new JedisClusterCommand<ScanResult<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<byte[]> execute(Jedis connection) {
-        return connection.sscan(key, cursor);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.sscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor, final ScanParams params) {
-    return new JedisClusterCommand<ScanResult<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<byte[]> execute(Jedis connection) {
-        return connection.sscan(key, cursor, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.sscan(key, cursor, params), key);
   }
 
   @Override
   public ScanResult<Tuple> zscan(final byte[] key, final byte[] cursor) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<Tuple> execute(Jedis connection) {
-        return connection.zscan(key, cursor);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<Tuple> zscan(final byte[] key, final byte[] cursor, final ScanParams params) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<Tuple> execute(Jedis connection) {
-        return connection.zscan(key, cursor, params);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.zscan(key, cursor, params), key);
   }
 
   @Override
   public List<Long> bitfield(final byte[] key, final byte[]... arguments) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Long> execute(Jedis connection) {
-        return connection.bitfield(key, arguments);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.bitfield(key, arguments), key);
   }
 
   @Override
   public List<Long> bitfieldReadonly(final byte[] key, final byte[]... arguments) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Long> execute(Jedis connection) {
-        return connection.bitfieldReadonly(key, arguments);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.bitfieldReadonly(key, arguments), key);
   }
 
   @Override
   public Long hstrlen(final byte[] key, final byte[] field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hstrlen(key, field);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.hstrlen(key, field), key);
   }
-  
+
   @Override
   public Long memoryUsage(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.memoryUsage(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.memoryUsage(key), key);
   }
-  
+
   @Override
   public Long memoryUsage(final byte[] key, final int samples) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.memoryUsage(key, samples);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.memoryUsage(key, samples), key);
   }
-  
+
   @Override
   public byte[] xadd(final byte[] key, final byte[] id, final Map<byte[], byte[]> hash, final long maxLen, final boolean approximateLength){
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.xadd(key, id, hash, maxLen, approximateLength);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xadd(key, id, hash, maxLen, approximateLength), key);
   }
 
   @Override
   public Long xlen(final byte[] key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xlen(key);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xlen(key), key);
   }
 
   @Override
   public List<byte[]> xrange(final byte[] key, final byte[] start, final byte[] end, final long count) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.xrange(key, start, end, count);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xrange(key, start, end, count), key);
   }
 
   @Override
   public List<byte[]> xrevrange(final byte[] key, final byte[] end, final byte[] start, final int count) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.xrevrange(key, end, start, count);
-      }
-    }.runBinary(key);  
+    return retryer.runBinary((connection) -> connection.xrevrange(key, end, start, count), key);
   }
 
   @Override
   public List<byte[]> xread(final int count, final long block, final Map<byte[], byte[]> streams) {
     byte[][] keys = streams.keySet().toArray(new byte[streams.size()][]);
-    
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.xread(count, block, streams);
-      }
-    }.runBinary(keys.length, keys);  
+
+    return retryer.runBinary((connection) -> connection.xread(count, block, streams), keys.length, keys);
   }
 
   @Override
   public Long xack(final byte[] key, final byte[] group, final byte[]... ids) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xack(key, group, ids);
-      }
-    }.runBinary(key);   
+    return retryer.runBinary((connection) -> connection.xack(key, group, ids), key);
   }
 
   @Override
   public String xgroupCreate(final byte[] key, final byte[] consumer, final byte[] id, final boolean makeStream) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.xgroupCreate(key, consumer, id, makeStream);
-      }
-    }.runBinary(key);  
+    return retryer.runBinary((connection) -> connection.xgroupCreate(key, consumer, id, makeStream), key);
   }
 
   @Override
   public String xgroupSetID(final byte[] key, final byte[] consumer, final byte[] id) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.xgroupSetID(key, consumer, id);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xgroupSetID(key, consumer, id), key);
   }
 
   @Override
   public Long xgroupDestroy(final byte[] key, final byte[] consumer) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xgroupDestroy(key, consumer);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xgroupDestroy(key, consumer), key);
   }
 
   @Override
   public Long xgroupDelConsumer(final byte[] key, final byte[] consumer, final byte[] consumerName) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xgroupDelConsumer(key, consumer, consumerName);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xgroupDelConsumer(key, consumer, consumerName), key);
   }
 
   @Override
-  public   List<byte[]> xreadGroup(final byte[] groupname, final byte[] consumer, final int count, final long block, 
+  public   List<byte[]> xreadGroup(final byte[] groupname, final byte[] consumer, final int count, final long block,
       final boolean noAck, final Map<byte[], byte[]> streams){
-    
+
     byte[][] keys = streams.keySet().toArray(new byte[streams.size()][]);
-    
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.xreadGroup(groupname, consumer, count, block, noAck, streams);
-      }
-    }.runBinary(keys.length, keys);
+
+    return retryer.runBinary((connection) -> connection.xreadGroup(groupname, consumer, count, block, noAck, streams), keys.length, keys);
   }
 
   @Override
   public Long xdel(final byte[] key, final byte[]... ids) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xdel(key, ids);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xdel(key, ids), key);
   }
 
   @Override
   public Long xtrim(final byte[] key, final long maxLen, final boolean approximateLength) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xtrim(key, maxLen, approximateLength);
-      }
-    }.runBinary(key);
-  }
-  
-  @Override
-  public List<byte[]> xpending(final byte[] key, final byte[] groupname, final byte[] start, final byte[] end, 
-      final int count, final byte[] consumername) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.xpending(key, groupname, start, end, count, consumername);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xtrim(key, maxLen, approximateLength), key);
   }
 
   @Override
-  public List<byte[]> xclaim(final byte[] key, final byte[] groupname, final byte[] consumername, 
+  public List<byte[]> xpending(final byte[] key, final byte[] groupname, final byte[] start, final byte[] end,
+      final int count, final byte[] consumername) {
+    return retryer.runBinary((connection) -> connection.xpending(key, groupname, start, end, count, consumername), key);
+  }
+
+  @Override
+  public List<byte[]> xclaim(final byte[] key, final byte[] groupname, final byte[] consumername,
       final long minIdleTime, final long newIdleTime, final int retries, final boolean force, final byte[][] ids) {
-    return new JedisClusterCommand<List<byte[]>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<byte[]> execute(Jedis connection) {
-        return connection.xclaim(key, groupname, consumername, minIdleTime, newIdleTime, retries, force, ids);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.xclaim(key, groupname, consumername, minIdleTime, newIdleTime, retries, force, ids), key);
   }
 
   @Override
   public Long waitReplicas(final byte[] key, final int replicas, final long timeout) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.waitReplicas(replicas, timeout);
-      }
-    }.runBinary(key);
+    return retryer.runBinary((connection) -> connection.waitReplicas(replicas, timeout), key);
   }
 
   public Object sendCommand(final byte[] sampleKey, final ProtocolCommand cmd, final byte[]... args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection){
-        return connection.sendCommand(cmd, args);
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary((connection) -> connection.sendCommand(cmd, args), sampleKey);
   }
 
   public Object sendBlockingCommand(final byte[] sampleKey, final ProtocolCommand cmd, final byte[]... args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection){
-        return connection.sendBlockingCommand(cmd, args);
-      }
-    }.runBinary(sampleKey);
+    return retryer.runBinary((connection) -> connection.sendBlockingCommand(cmd, args), sampleKey);
   }
 }

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -1,15 +1,18 @@
 package redis.clients.jedis;
 
+import java.util.function.Function;
 import redis.clients.jedis.commands.BinaryJedisClusterCommands;
 import redis.clients.jedis.commands.JedisClusterBinaryScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyBinaryJedisClusterCommands;
 import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.GeoRadiusStoreParam;
 import redis.clients.jedis.params.SetParams;
 import redis.clients.jedis.params.ZAddParams;
 import redis.clients.jedis.params.ZIncrByParams;
 import redis.clients.jedis.params.LPosParams;
+import redis.clients.jedis.util.JedisClusterCRC16;
 import redis.clients.jedis.util.JedisClusterHashTagUtil;
 import redis.clients.jedis.util.KeyMergeUtil;
 import redis.clients.jedis.util.SafeEncoder;
@@ -28,7 +31,7 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
  * Interface to a Jedis cluster.
  * <p/>
  * Uses {@link DefaultRetryer}, or you can inject your own using
- * {@link BinaryJedisCluster#BinaryJedisCluster(Retryer)}.
+ * {@link BinaryJedisCluster#BinaryJedisCluster(JedisClusterConnectionHandler, Retryer)}.
  *
  * @see JedisCluster
  */
@@ -40,6 +43,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   protected static final int DEFAULT_MAX_ATTEMPTS = 5;
 
   protected final Retryer retryer;
+  protected final JedisClusterConnectionHandler connectionHandler;
 
   public BinaryJedisCluster(Set<HostAndPort> nodes) {
     this(nodes, DEFAULT_TIMEOUT);
@@ -70,14 +74,16 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxAttempts, String user, String password, String clientName, GenericObjectPoolConfig poolConfig) {
     JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, user, password, clientName);
-    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
+    this.connectionHandler = connectionHandler;
+    this.retryer = new DefaultRetryer(maxAttempts);
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
       int infiniteSoTimeout, int maxAttempts, String user, String password, String clientName, GenericObjectPoolConfig poolConfig) {
     JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, infiniteSoTimeout, user, password, clientName);
-    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
+    this.connectionHandler = connectionHandler;
+    this.retryer = new DefaultRetryer(maxAttempts);
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int maxAttempts, String password, String clientName, GenericObjectPoolConfig poolConfig,
@@ -102,7 +108,8 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap hostAndPortMap) {
     JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, user, password, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMap);
-    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
+    this.connectionHandler = connectionHandler;
+    this.retryer = new DefaultRetryer(maxAttempts);
   }
 
   public BinaryJedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
@@ -110,778 +117,806 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters, HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap hostAndPortMap) {
     JedisClusterConnectionHandler connectionHandler = new JedisSlotBasedConnectionHandler(jedisClusterNode, poolConfig,
         connectionTimeout, soTimeout, infiniteSoTimeout, user, password, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMap);
-    retryer = new DefaultRetryer(connectionHandler, maxAttempts);
+    this.connectionHandler = connectionHandler;
+    this.retryer = new DefaultRetryer(maxAttempts);
   }
 
-  public BinaryJedisCluster(Retryer retryer) {
+  public BinaryJedisCluster(JedisClusterConnectionHandler connectionHandler, Retryer retryer) {
+    this.connectionHandler = connectionHandler;
     this.retryer = retryer;
   }
 
   @Override
   public void close() {
-    retryer.close();
+    if (connectionHandler != null) {
+      connectionHandler.close();
+    }
   }
 
   public Map<String, JedisPool> getClusterNodes() {
-    return retryer.getClusterNodes();
+    return connectionHandler.getNodes();
   }
 
   public Jedis getConnectionFromSlot(int slot) {
-    return retryer.getConnectionFromSlot(slot);
+    return this.connectionHandler.getConnectionFromSlot(slot);
+  }
+
+  private <R> R runBinary(Function<Jedis, R> command, byte[] key) {
+    return retryer.runWithRetries(connectionHandler, JedisClusterCRC16.getSlot(key), command);
+  }
+
+  private <R> R runBinary(Function<Jedis, R> command, int keyCount, byte[]... keys) {
+    if (keys == null || keys.length == 0) {
+      throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
+    }
+
+    // For multiple keys, only execute if they all share the same connection slot.
+    int slot = JedisClusterCRC16.getSlot(keys[0]);
+    if (keys.length > 1) {
+      for (int i = 1; i < keyCount; i++) {
+        int nextSlot = JedisClusterCRC16.getSlot(keys[i]);
+        if (slot != nextSlot) {
+          throw new JedisClusterOperationException("No way to dispatch this command to Redis "
+              + "Cluster because keys have different slots.");
+        }
+      }
+    }
+
+    return retryer.runWithRetries(connectionHandler, slot, command);
   }
 
   @Override
   public String set(final byte[] key, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.set(key, value), key);
+    return runBinary((connection) -> connection.set(key, value), key);
   }
 
   @Override
   public String set(final byte[] key, final byte[] value, final SetParams params) {
-    return retryer.runBinary((connection) -> connection.set(key, value, params), key);
+    return runBinary((connection) -> connection.set(key, value, params), key);
   }
 
   @Override
   public byte[] get(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.get(key), key);
+    return runBinary((connection) -> connection.get(key), key);
   }
 
   @Override
   public Long exists(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.exists(keys), keys.length, keys);
+    return runBinary((connection) -> connection.exists(keys), keys.length, keys);
   }
 
   @Override
   public Boolean exists(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.exists(key), key);
+    return runBinary((connection) -> connection.exists(key), key);
   }
 
   @Override
   public Long persist(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.persist(key), key);
+    return runBinary((connection) -> connection.persist(key), key);
   }
 
   @Override
   public String type(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.type(key), key);
+    return runBinary((connection) -> connection.type(key), key);
   }
 
   @Override
   public byte[] dump(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.dump(key), key);
+    return runBinary((connection) -> connection.dump(key), key);
   }
 
   @Override
   public String restore(final byte[] key, final int ttl, final byte[] serializedValue) {
-    return retryer.runBinary((connection) -> connection.restore(key, ttl, serializedValue), key);
+    return runBinary((connection) -> connection.restore(key, ttl, serializedValue), key);
   }
 
   @Override
   public Long expire(final byte[] key, final int seconds) {
-    return retryer.runBinary((connection) -> connection.expire(key, seconds), key);
+    return runBinary((connection) -> connection.expire(key, seconds), key);
   }
 
   @Override
   public Long pexpire(final byte[] key, final long milliseconds) {
-    return retryer.runBinary((connection) -> connection.pexpire(key, milliseconds), key);
+    return runBinary((connection) -> connection.pexpire(key, milliseconds), key);
   }
 
   @Override
   public Long expireAt(final byte[] key, final long unixTime) {
-    return retryer.runBinary((connection) -> connection.expireAt(key, unixTime), key);
+    return runBinary((connection) -> connection.expireAt(key, unixTime), key);
   }
 
   @Override
   public Long pexpireAt(final byte[] key, final long millisecondsTimestamp) {
-    return retryer.runBinary((connection) -> connection.pexpireAt(key, millisecondsTimestamp), key);
+    return runBinary((connection) -> connection.pexpireAt(key, millisecondsTimestamp), key);
   }
 
   @Override
   public Long ttl(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.ttl(key), key);
+    return runBinary((connection) -> connection.ttl(key), key);
   }
 
   @Override
   public Long pttl(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.pttl(key), key);
+    return runBinary((connection) -> connection.pttl(key), key);
   }
 
   @Override
   public Long touch(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.touch(key), key);
+    return runBinary((connection) -> connection.touch(key), key);
   }
 
   @Override
   public Long touch(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.touch(keys), keys.length, keys);
+    return runBinary((connection) -> connection.touch(keys), keys.length, keys);
   }
 
   @Override
   public Boolean setbit(final byte[] key, final long offset, final boolean value) {
-    return retryer.runBinary((connection) -> connection.setbit(key, offset, value), key);
+    return runBinary((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean setbit(final byte[] key, final long offset, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.setbit(key, offset, value), key);
+    return runBinary((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean getbit(final byte[] key, final long offset) {
-    return retryer.runBinary((connection) -> connection.getbit(key, offset), key);
+    return runBinary((connection) -> connection.getbit(key, offset), key);
   }
 
   @Override
   public Long setrange(final byte[] key, final long offset, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.setrange(key, offset, value), key);
+    return runBinary((connection) -> connection.setrange(key, offset, value), key);
   }
 
   @Override
   public byte[] getrange(final byte[] key, final long startOffset, final long endOffset) {
-    return retryer.runBinary((connection) -> connection.getrange(key, startOffset, endOffset), key);
+    return runBinary((connection) -> connection.getrange(key, startOffset, endOffset), key);
   }
 
   @Override
   public byte[] getSet(final byte[] key, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.getSet(key, value), key);
+    return runBinary((connection) -> connection.getSet(key, value), key);
   }
 
   @Override
   public Long setnx(final byte[] key, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.setnx(key, value), key);
+    return runBinary((connection) -> connection.setnx(key, value), key);
   }
 
   @Override
   public String psetex(final byte[] key, final long milliseconds, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.psetex(key, milliseconds, value), key);
+    return runBinary((connection) -> connection.psetex(key, milliseconds, value), key);
   }
 
   @Override
   public String setex(final byte[] key, final int seconds, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.setex(key, seconds, value), key);
+    return runBinary((connection) -> connection.setex(key, seconds, value), key);
   }
 
   @Override
   public Long decrBy(final byte[] key, final long decrement) {
-    return retryer.runBinary((connection) -> connection.decrBy(key, decrement), key);
+    return runBinary((connection) -> connection.decrBy(key, decrement), key);
   }
 
   @Override
   public Long decr(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.decr(key), key);
+    return runBinary((connection) -> connection.decr(key), key);
   }
 
   @Override
   public Long incrBy(final byte[] key, final long increment) {
-    return retryer.runBinary((connection) -> connection.incrBy(key, increment), key);
+    return runBinary((connection) -> connection.incrBy(key, increment), key);
   }
 
   @Override
   public Double incrByFloat(final byte[] key, final double increment) {
-    return retryer.runBinary((connection) -> connection.incrByFloat(key, increment), key);
+    return runBinary((connection) -> connection.incrByFloat(key, increment), key);
   }
 
   @Override
   public Long incr(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.incr(key), key);
+    return runBinary((connection) -> connection.incr(key), key);
   }
 
   @Override
   public Long append(final byte[] key, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.append(key, value), key);
+    return runBinary((connection) -> connection.append(key, value), key);
   }
 
   @Override
   public byte[] substr(final byte[] key, final int start, final int end) {
-    return retryer.runBinary((connection) -> connection.substr(key, start, end), key);
+    return runBinary((connection) -> connection.substr(key, start, end), key);
   }
 
   @Override
   public Long hset(final byte[] key, final byte[] field, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.hset(key, field, value), key);
+    return runBinary((connection) -> connection.hset(key, field, value), key);
   }
 
   @Override
   public Long hset(final byte[] key, final Map<byte[], byte[]> hash) {
-    return retryer.runBinary((connection) -> connection.hset(key, hash), key);
+    return runBinary((connection) -> connection.hset(key, hash), key);
   }
 
   @Override
   public byte[] hget(final byte[] key, final byte[] field) {
-    return retryer.runBinary((connection) -> connection.hget(key, field), key);
+    return runBinary((connection) -> connection.hget(key, field), key);
   }
 
   @Override
   public Long hsetnx(final byte[] key, final byte[] field, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.hsetnx(key, field, value), key);
+    return runBinary((connection) -> connection.hsetnx(key, field, value), key);
   }
 
   @Override
   public String hmset(final byte[] key, final Map<byte[], byte[]> hash) {
-    return retryer.runBinary((connection) -> connection.hmset(key, hash), key);
+    return runBinary((connection) -> connection.hmset(key, hash), key);
   }
 
   @Override
   public List<byte[]> hmget(final byte[] key, final byte[]... fields) {
-    return retryer.runBinary((connection) -> connection.hmget(key, fields), key);
+    return runBinary((connection) -> connection.hmget(key, fields), key);
   }
 
   @Override
   public Long hincrBy(final byte[] key, final byte[] field, final long value) {
-    return retryer.runBinary((connection) -> connection.hincrBy(key, field, value), key);
+    return runBinary((connection) -> connection.hincrBy(key, field, value), key);
   }
 
   @Override
   public Double hincrByFloat(final byte[] key, final byte[] field, final double value) {
-    return retryer.runBinary((connection) -> connection.hincrByFloat(key, field, value), key);
+    return runBinary((connection) -> connection.hincrByFloat(key, field, value), key);
   }
 
   @Override
   public Boolean hexists(final byte[] key, final byte[] field) {
-    return retryer.runBinary((connection) -> connection.hexists(key, field), key);
+    return runBinary((connection) -> connection.hexists(key, field), key);
   }
 
   @Override
   public Long hdel(final byte[] key, final byte[]... field) {
-    return retryer.runBinary((connection) -> connection.hdel(key, field), key);
+    return runBinary((connection) -> connection.hdel(key, field), key);
   }
 
   @Override
   public Long hlen(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.hlen(key), key);
+    return runBinary((connection) -> connection.hlen(key), key);
   }
 
   @Override
   public Set<byte[]> hkeys(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.hkeys(key), key);
+    return runBinary((connection) -> connection.hkeys(key), key);
   }
 
   @Override
   public List<byte[]> hvals(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.hvals(key), key);
+    return runBinary((connection) -> connection.hvals(key), key);
   }
 
   @Override
   public Map<byte[], byte[]> hgetAll(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.hgetAll(key), key);
+    return runBinary((connection) -> connection.hgetAll(key), key);
   }
 
   @Override
   public Long rpush(final byte[] key, final byte[]... args) {
-    return retryer.runBinary((connection) -> connection.rpush(key, args), key);
+    return runBinary((connection) -> connection.rpush(key, args), key);
   }
 
   @Override
   public Long lpush(final byte[] key, final byte[]... args) {
-    return retryer.runBinary((connection) -> connection.lpush(key, args), key);
+    return runBinary((connection) -> connection.lpush(key, args), key);
   }
 
   @Override
   public Long llen(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.llen(key), key);
+    return runBinary((connection) -> connection.llen(key), key);
   }
 
   @Override
   public List<byte[]> lrange(final byte[] key, final long start, final long stop) {
-    return retryer.runBinary((connection) -> connection.lrange(key, start, stop), key);
+    return runBinary((connection) -> connection.lrange(key, start, stop), key);
   }
 
   @Override
   public String ltrim(final byte[] key, final long start, final long stop) {
-    return retryer.runBinary((connection) -> connection.ltrim(key, start, stop), key);
+    return runBinary((connection) -> connection.ltrim(key, start, stop), key);
   }
 
   @Override
   public byte[] lindex(final byte[] key, final long index) {
-    return retryer.runBinary((connection) -> connection.lindex(key, index), key);
+    return runBinary((connection) -> connection.lindex(key, index), key);
   }
 
   @Override
   public String lset(final byte[] key, final long index, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.lset(key, index, value), key);
+    return runBinary((connection) -> connection.lset(key, index, value), key);
   }
 
   @Override
   public Long lrem(final byte[] key, final long count, final byte[] value) {
-    return retryer.runBinary((connection) -> connection.lrem(key, count, value), key);
+    return runBinary((connection) -> connection.lrem(key, count, value), key);
   }
 
   @Override
   public byte[] lpop(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.lpop(key), key);
+    return runBinary((connection) -> connection.lpop(key), key);
   }
 
   @Override
   public List<byte[]> lpop(final byte[] key, final int count) {
-    return retryer.runBinary((connection) -> connection.lpop(key, count), key);
+    return runBinary((connection) -> connection.lpop(key, count), key);
   }
 
   @Override
   public Long lpos(final byte[] key, final byte[] element) {
-    return retryer.runBinary((connection) -> connection.lpos(key, element), key);
+    return runBinary((connection) -> connection.lpos(key, element), key);
   }
 
   @Override
   public Long lpos(final byte[] key, final byte[] element, final LPosParams params) {
-    return retryer.runBinary((connection) -> connection.lpos(key, element, params), key);
+    return runBinary((connection) -> connection.lpos(key, element, params), key);
   }
 
   @Override
   public List<Long> lpos(final byte[] key, final byte[] element, final LPosParams params, final long count) {
-    return retryer.runBinary((connection) -> connection.lpos(key, element, params, count), key);
+    return runBinary((connection) -> connection.lpos(key, element, params, count), key);
   }
 
   @Override
   public byte[] rpop(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.rpop(key), key);
+    return runBinary((connection) -> connection.rpop(key), key);
   }
 
   @Override
   public List<byte[]> rpop(final byte[] key, final int count) {
-    return retryer.runBinary((connection) -> connection.rpop(key, count), key);
+    return runBinary((connection) -> connection.rpop(key, count), key);
   }
 
   @Override
   public Long sadd(final byte[] key, final byte[]... member) {
-    return retryer.runBinary((connection) -> connection.sadd(key, member), key);
+    return runBinary((connection) -> connection.sadd(key, member), key);
   }
 
   @Override
   public Set<byte[]> smembers(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.smembers(key), key);
+    return runBinary((connection) -> connection.smembers(key), key);
   }
 
   @Override
   public Long srem(final byte[] key, final byte[]... member) {
-    return retryer.runBinary((connection) -> connection.srem(key, member), key);
+    return runBinary((connection) -> connection.srem(key, member), key);
   }
 
   @Override
   public byte[] spop(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.spop(key), key);
+    return runBinary((connection) -> connection.spop(key), key);
   }
 
   @Override
   public Set<byte[]> spop(final byte[] key, final long count) {
-    return retryer.runBinary((connection) -> connection.spop(key, count), key);
+    return runBinary((connection) -> connection.spop(key, count), key);
   }
 
   @Override
   public Long scard(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.scard(key), key);
+    return runBinary((connection) -> connection.scard(key), key);
   }
 
   @Override
   public Boolean sismember(final byte[] key, final byte[] member) {
-    return retryer.runBinary((connection) -> connection.sismember(key, member), key);
+    return runBinary((connection) -> connection.sismember(key, member), key);
   }
 
   @Override
   public List<Boolean> smismember(final byte[] key, final byte[]... members) {
-    return retryer.runBinary((connection) -> connection.smismember(key, members), key);
+    return runBinary((connection) -> connection.smismember(key, members), key);
   }
 
   @Override
   public byte[] srandmember(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.srandmember(key), key);
+    return runBinary((connection) -> connection.srandmember(key), key);
   }
 
   @Override
   public Long strlen(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.strlen(key), key);
+    return runBinary((connection) -> connection.strlen(key), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final double score, final byte[] member) {
-    return retryer.runBinary((connection) -> connection.zadd(key, score, member), key);
+    return runBinary((connection) -> connection.zadd(key, score, member), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final double score, final byte[] member,
       final ZAddParams params) {
-    return retryer.runBinary((connection) -> connection.zadd(key, score, member, params), key);
+    return runBinary((connection) -> connection.zadd(key, score, member, params), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers) {
-    return retryer.runBinary((connection) -> connection.zadd(key, scoreMembers), key);
+    return runBinary((connection) -> connection.zadd(key, scoreMembers), key);
   }
 
   @Override
   public Long zadd(final byte[] key, final Map<byte[], Double> scoreMembers, final ZAddParams params) {
-    return retryer.runBinary((connection) -> connection.zadd(key, scoreMembers, params), key);
+    return runBinary((connection) -> connection.zadd(key, scoreMembers, params), key);
   }
 
   @Override
   public Set<byte[]> zrange(final byte[] key, final long start, final long stop) {
-    return retryer.runBinary((connection) -> connection.zrange(key, start, stop), key);
+    return runBinary((connection) -> connection.zrange(key, start, stop), key);
   }
 
   @Override
   public Long zrem(final byte[] key, final byte[]... members) {
-    return retryer.runBinary((connection) -> connection.zrem(key, members), key);
+    return runBinary((connection) -> connection.zrem(key, members), key);
   }
 
   @Override
   public Double zincrby(final byte[] key, final double increment, final byte[] member) {
-    return retryer.runBinary((connection) -> connection.zincrby(key, increment, member), key);
+    return runBinary((connection) -> connection.zincrby(key, increment, member), key);
   }
 
   @Override
   public Double zincrby(final byte[] key, final double increment, final byte[] member,
       final ZIncrByParams params) {
-    return retryer.runBinary((connection) -> connection.zincrby(key, increment, member, params), key);
+    return runBinary((connection) -> connection.zincrby(key, increment, member, params), key);
   }
 
   @Override
   public Long zrank(final byte[] key, final byte[] member) {
-    return retryer.runBinary((connection) -> connection.zrank(key, member), key);
+    return runBinary((connection) -> connection.zrank(key, member), key);
   }
 
   @Override
   public Long zrevrank(final byte[] key, final byte[] member) {
-    return retryer.runBinary((connection) -> connection.zrevrank(key, member), key);
+    return runBinary((connection) -> connection.zrevrank(key, member), key);
   }
 
   @Override
   public Set<byte[]> zrevrange(final byte[] key, final long start, final long stop) {
-    return retryer.runBinary((connection) -> connection.zrevrange(key, start, stop), key);
+    return runBinary((connection) -> connection.zrevrange(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrangeWithScores(final byte[] key, final long start, final long stop) {
-    return retryer.runBinary((connection) -> connection.zrangeWithScores(key, start, stop), key);
+    return runBinary((connection) -> connection.zrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final byte[] key, final long start, final long stop) {
-    return retryer.runBinary((connection) -> connection.zrevrangeWithScores(key, start, stop), key);
+    return runBinary((connection) -> connection.zrevrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Long zcard(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.zcard(key), key);
+    return runBinary((connection) -> connection.zcard(key), key);
   }
 
   @Override
   public Double zscore(final byte[] key, final byte[] member) {
-    return retryer.runBinary((connection) -> connection.zscore(key, member), key);
+    return runBinary((connection) -> connection.zscore(key, member), key);
   }
 
   @Override
   public List<Double> zmscore(final byte[] key, final byte[]... members) {
-    return retryer.runBinary((connection) -> connection.zmscore(key, members), key);
+    return runBinary((connection) -> connection.zmscore(key, members), key);
   }
 
   @Override
   public Tuple zpopmax(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.zpopmax(key), key);
+    return runBinary((connection) -> connection.zpopmax(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmax(final byte[] key, final int count) {
-    return retryer.runBinary((connection) -> connection.zpopmax(key, count), key);
+    return runBinary((connection) -> connection.zpopmax(key, count), key);
   }
 
   @Override
   public Tuple zpopmin(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.zpopmin(key), key);
+    return runBinary((connection) -> connection.zpopmin(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmin(final byte[] key, final int count) {
-    return retryer.runBinary((connection) -> connection.zpopmin(key, count), key);
+    return runBinary((connection) -> connection.zpopmin(key, count), key);
   }
 
   @Override
   public List<byte[]> sort(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.sort(key), key);
+    return runBinary((connection) -> connection.sort(key), key);
   }
 
   @Override
   public List<byte[]> sort(final byte[] key, final SortingParams sortingParameters) {
-    return retryer.runBinary((connection) -> connection.sort(key, sortingParameters), key);
+    return runBinary((connection) -> connection.sort(key, sortingParameters), key);
   }
 
   @Override
   public Long zcount(final byte[] key, final double min, final double max) {
-    return retryer.runBinary((connection) -> connection.zcount(key, min, max), key);
+    return runBinary((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Long zcount(final byte[] key, final byte[] min, final byte[] max) {
-    return retryer.runBinary((connection) -> connection.zcount(key, min, max), key);
+    return runBinary((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max) {
-    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max), key);
+    return runBinary((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final byte[] min, final byte[] max) {
-    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max), key);
+    return runBinary((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min), key);
+    return runBinary((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
+    return runBinary((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final byte[] max, final byte[] min) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min), key);
+    return runBinary((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<byte[]> zrangeByScore(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
+    return runBinary((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final double max, final double min,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
+    return runBinary((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max) {
-    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
+    return runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max, final double min) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
+    return runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final double min, final double max,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
+    return runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByScore(final byte[] key, final byte[] max, final byte[] min,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
+    return runBinary((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max) {
-    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
+    return runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final byte[] max, final byte[] min) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
+    return runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
+    return runBinary((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final double max,
       final double min, final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
+    return runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final byte[] key, final byte[] max,
       final byte[] min, final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
+    return runBinary((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
   }
 
   @Override
   public Long zremrangeByRank(final byte[] key, final long start, final long stop) {
-    return retryer.runBinary((connection) -> connection.zremrangeByRank(key, start, stop), key);
+    return runBinary((connection) -> connection.zremrangeByRank(key, start, stop), key);
   }
 
   @Override
   public Long zremrangeByScore(final byte[] key, final double min, final double max) {
-    return retryer.runBinary((connection) -> connection.zremrangeByScore(key, min, max), key);
+    return runBinary((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long zremrangeByScore(final byte[] key, final byte[] min, final byte[] max) {
-    return retryer.runBinary((connection) -> connection.zremrangeByScore(key, min, max), key);
+    return runBinary((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long linsert(final byte[] key, final ListPosition where, final byte[] pivot,
       final byte[] value) {
-    return retryer.runBinary((connection) -> connection.linsert(key, where, pivot, value), key);
+    return runBinary((connection) -> connection.linsert(key, where, pivot, value), key);
   }
 
   @Override
   public Long lpushx(final byte[] key, final byte[]... arg) {
-    return retryer.runBinary((connection) -> connection.lpushx(key, arg), key);
+    return runBinary((connection) -> connection.lpushx(key, arg), key);
   }
 
   @Override
   public Long rpushx(final byte[] key, final byte[]... arg) {
-    return retryer.runBinary((connection) -> connection.rpushx(key, arg), key);
+    return runBinary((connection) -> connection.rpushx(key, arg), key);
   }
 
   @Override
   public Long del(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.del(key), key);
+    return runBinary((connection) -> connection.del(key), key);
   }
 
   @Override
   public Long unlink(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.unlink(key), key);
+    return runBinary((connection) -> connection.unlink(key), key);
   }
 
   @Override
   public Long unlink(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.unlink(keys), keys.length, keys);
+    return runBinary((connection) -> connection.unlink(keys), keys.length, keys);
   }
 
   @Override
   public byte[] echo(final byte[] arg) {
     // note that it'll be run from arbitary node
-    return retryer.runBinary((connection) -> connection.echo(arg), arg);
+    return runBinary((connection) -> connection.echo(arg), arg);
   }
 
   @Override
   public Long bitcount(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.bitcount(key), key);
+    return runBinary((connection) -> connection.bitcount(key), key);
   }
 
   @Override
   public Long bitcount(final byte[] key, final long start, final long end) {
-    return retryer.runBinary((connection) -> connection.bitcount(key, start, end), key);
+    return runBinary((connection) -> connection.bitcount(key, start, end), key);
   }
 
   @Override
   public Long pfadd(final byte[] key, final byte[]... elements) {
-    return retryer.runBinary((connection) -> connection.pfadd(key, elements), key);
+    return runBinary((connection) -> connection.pfadd(key, elements), key);
   }
 
   @Override
   public long pfcount(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.pfcount(key), key);
+    return runBinary((connection) -> connection.pfcount(key), key);
   }
 
   @Override
   public List<byte[]> srandmember(final byte[] key, final int count) {
-    return retryer.runBinary((connection) -> connection.srandmember(key, count), key);
+    return runBinary((connection) -> connection.srandmember(key, count), key);
   }
 
   @Override
   public Long zlexcount(final byte[] key, final byte[] min, final byte[] max) {
-    return retryer.runBinary((connection) -> connection.zlexcount(key, min, max), key);
+    return runBinary((connection) -> connection.zlexcount(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByLex(final byte[] key, final byte[] min, final byte[] max) {
-    return retryer.runBinary((connection) -> connection.zrangeByLex(key, min, max), key);
+    return runBinary((connection) -> connection.zrangeByLex(key, min, max), key);
   }
 
   @Override
   public Set<byte[]> zrangeByLex(final byte[] key, final byte[] min, final byte[] max,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrangeByLex(key, min, max, offset, count), key);
+    return runBinary((connection) -> connection.zrangeByLex(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByLex(final byte[] key, final byte[] max, final byte[] min) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByLex(key, max, min), key);
+    return runBinary((connection) -> connection.zrevrangeByLex(key, max, min), key);
   }
 
   @Override
   public Set<byte[]> zrevrangeByLex(final byte[] key, final byte[] max, final byte[] min,
       final int offset, final int count) {
-    return retryer.runBinary((connection) -> connection.zrevrangeByLex(key, max, min, offset, count), key);
+    return runBinary((connection) -> connection.zrevrangeByLex(key, max, min, offset, count), key);
   }
 
   @Override
   public Long zremrangeByLex(final byte[] key, final byte[] min, final byte[] max) {
-    return retryer.runBinary((connection) -> connection.zremrangeByLex(key, min, max), key);
+    return runBinary((connection) -> connection.zremrangeByLex(key, min, max), key);
   }
 
   @Override
   public Object eval(final byte[] script, final byte[] keyCount, final byte[]... params) {
-    return retryer.runBinary((connection) -> connection.eval(script, keyCount, params), Integer.parseInt(SafeEncoder.encode(keyCount)), params);
+    return runBinary((connection) -> connection.eval(script, keyCount, params), Integer.parseInt(SafeEncoder.encode(keyCount)), params);
   }
 
   @Override
   public Object eval(final byte[] script, final int keyCount, final byte[]... params) {
-    return retryer.runBinary((connection) -> connection.eval(script, keyCount, params), keyCount, params);
+    return runBinary((connection) -> connection.eval(script, keyCount, params), keyCount, params);
   }
 
   @Override
   public Object eval(final byte[] script, final List<byte[]> keys, final List<byte[]> args) {
-    return retryer.runBinary((connection) -> connection.eval(script, keys, args), keys.size(), keys.toArray(new byte[keys.size()][]));
+    return runBinary((connection) -> connection.eval(script, keys, args), keys.size(), keys.toArray(new byte[keys.size()][]));
   }
 
   @Override
   public Object eval(final byte[] script, final byte[] sampleKey) {
-    return retryer.runBinary((connection) -> connection.eval(script), sampleKey);
+    return runBinary((connection) -> connection.eval(script), sampleKey);
   }
 
   @Override
   public Object evalsha(final byte[] sha1, final byte[] sampleKey) {
-    return retryer.runBinary((connection) -> connection.evalsha(sha1), sampleKey);
+    return runBinary((connection) -> connection.evalsha(sha1), sampleKey);
   }
 
   @Override
   public Object evalsha(final byte[] sha1, final List<byte[]> keys, final List<byte[]> args) {
-    return retryer.runBinary((connection) -> connection.evalsha(sha1, keys, args), keys.size(), keys.toArray(new byte[keys.size()][]));
+    return runBinary((connection) -> connection.evalsha(sha1, keys, args), keys.size(), keys.toArray(new byte[keys.size()][]));
   }
 
   @Override
   public Object evalsha(final byte[] sha1, final int keyCount, final byte[]... params) {
-    return retryer.runBinary((connection) -> connection.evalsha(sha1, keyCount, params), keyCount, params);
+    return runBinary((connection) -> connection.evalsha(sha1, keyCount, params), keyCount, params);
   }
 
   @Override
   public List<Long> scriptExists(final byte[] sampleKey, final byte[]... sha1) {
-    return retryer.runBinary((connection) -> connection.scriptExists(sha1), sampleKey);
+    return runBinary((connection) -> connection.scriptExists(sha1), sampleKey);
   }
 
   @Override
   public byte[] scriptLoad(final byte[] script, final byte[] sampleKey) {
-    return retryer.runBinary((connection) -> connection.scriptLoad(script), sampleKey);
+    return runBinary((connection) -> connection.scriptLoad(script), sampleKey);
   }
 
   @Override
   public String scriptFlush(final byte[] sampleKey) {
-    return retryer.runBinary(BinaryJedis::scriptFlush, sampleKey);
+    return runBinary(BinaryJedis::scriptFlush, sampleKey);
   }
 
   @Override
   public String scriptKill(final byte[] sampleKey) {
-    return retryer.runBinary(BinaryJedis::scriptKill, sampleKey);
+    return runBinary(BinaryJedis::scriptKill, sampleKey);
   }
 
   @Override
   public Long del(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.del(keys), keys.length, keys);
+    return runBinary((connection) -> connection.del(keys), keys.length, keys);
   }
 
   @Override
   public List<byte[]> blpop(final int timeout, final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.blpop(timeout, keys), keys.length, keys);
+    return runBinary((connection) -> connection.blpop(timeout, keys), keys.length, keys);
   }
 
   @Override
   public List<byte[]> brpop(final int timeout, final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.brpop(timeout, keys), keys.length, keys);
+    return runBinary((connection) -> connection.brpop(timeout, keys), keys.length, keys);
   }
 
   @Override
   public List<byte[]> mget(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.mget(keys), keys.length, keys);
+    return runBinary((connection) -> connection.mget(keys), keys.length, keys);
   }
 
   @Override
@@ -892,7 +927,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return retryer.runBinary((connection) -> connection.mset(keysvalues), keys.length, keys);
+    return runBinary((connection) -> connection.mset(keysvalues), keys.length, keys);
   }
 
   @Override
@@ -903,116 +938,116 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return retryer.runBinary((connection) -> connection.msetnx(keysvalues), keys.length, keys);
+    return runBinary((connection) -> connection.msetnx(keysvalues), keys.length, keys);
   }
 
   @Override
   public String rename(final byte[] oldkey, final byte[] newkey) {
-    return retryer.runBinary((connection) -> connection.rename(oldkey, newkey), 2, oldkey, newkey);
+    return runBinary((connection) -> connection.rename(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public Long renamenx(final byte[] oldkey, final byte[] newkey) {
-    return retryer.runBinary((connection) -> connection.renamenx(oldkey, newkey), 2, oldkey, newkey);
+    return runBinary((connection) -> connection.renamenx(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public byte[] rpoplpush(final byte[] srckey, final byte[] dstkey) {
-    return retryer.runBinary((connection) -> connection.rpoplpush(srckey, dstkey), 2, srckey, dstkey);
+    return runBinary((connection) -> connection.rpoplpush(srckey, dstkey), 2, srckey, dstkey);
   }
 
   @Override
   public Set<byte[]> sdiff(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.sdiff(keys), keys.length, keys);
+    return runBinary((connection) -> connection.sdiff(keys), keys.length, keys);
   }
 
   @Override
   public Long sdiffstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return retryer.runBinary((connection) -> connection.sdiffstore(dstkey, keys), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.sdiffstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Set<byte[]> sinter(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.sinter(keys), keys.length, keys);
+    return runBinary((connection) -> connection.sinter(keys), keys.length, keys);
   }
 
   @Override
   public Long sinterstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return retryer.runBinary((connection) -> connection.sinterstore(dstkey, keys), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.sinterstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long smove(final byte[] srckey, final byte[] dstkey, final byte[] member) {
-    return retryer.runBinary((connection) -> connection.smove(srckey, dstkey, member), 2, srckey, dstkey);
+    return runBinary((connection) -> connection.smove(srckey, dstkey, member), 2, srckey, dstkey);
   }
 
   @Override
   public Long sort(final byte[] key, final SortingParams sortingParameters, final byte[] dstkey) {
-    return retryer.runBinary((connection) -> connection.sort(key, sortingParameters, dstkey), 2, key, dstkey);
+    return runBinary((connection) -> connection.sort(key, sortingParameters, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Long sort(final byte[] key, final byte[] dstkey) {
-    return retryer.runBinary((connection) -> connection.sort(key, dstkey), 2, key, dstkey);
+    return runBinary((connection) -> connection.sort(key, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Set<byte[]> sunion(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.sunion(keys), keys.length, keys);
+    return runBinary((connection) -> connection.sunion(keys), keys.length, keys);
   }
 
   @Override
   public Long sunionstore(final byte[] dstkey, final byte[]... keys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return retryer.runBinary((connection) -> connection.sunionstore(dstkey, keys), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.sunionstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final byte[] dstkey, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.runBinary((connection) -> connection.zinterstore(dstkey, sets), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.zinterstore(dstkey, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final byte[] dstkey, final ZParams params, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.runBinary((connection) -> connection.zinterstore(dstkey, params, sets), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.zinterstore(dstkey, params, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zunionstore(final byte[] dstkey, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.runBinary((connection) -> connection.zunionstore(dstkey, sets), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.zunionstore(dstkey, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zunionstore(final byte[] dstkey, final ZParams params, final byte[]... sets) {
     byte[][] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.runBinary((connection) -> connection.zunionstore(dstkey, params, sets), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.zunionstore(dstkey, params, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public byte[] brpoplpush(final byte[] source, final byte[] destination, final int timeout) {
-    return retryer.runBinary((connection) -> connection.brpoplpush(source, destination, timeout), 2, source, destination);
+    return runBinary((connection) -> connection.brpoplpush(source, destination, timeout), 2, source, destination);
   }
 
   @Override
   public Long publish(final byte[] channel, final byte[] message) {
-    return retryer.runWithRetries((connection) -> connection.publish(channel, message));
+    return retryer.runWithRetries(connectionHandler, (connection) -> connection.publish(channel, message));
   }
 
   @Override
   public void subscribe(final BinaryJedisPubSub jedisPubSub, final byte[]... channels) {
-    retryer.runWithRetries((connection) -> {
+    retryer.runWithRetries(connectionHandler, (connection) -> {
       connection.subscribe(jedisPubSub, channels);
       return null;
     });
@@ -1020,7 +1055,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
   @Override
   public void psubscribe(final BinaryJedisPubSub jedisPubSub, final byte[]... patterns) {
-    retryer.runWithRetries((connection) -> {
+    retryer.runWithRetries(connectionHandler, (connection) -> {
       connection.psubscribe(jedisPubSub, patterns);
       return null;
     });
@@ -1030,113 +1065,113 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   public Long bitop(final BitOP op, final byte[] destKey, final byte[]... srcKeys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(destKey, srcKeys);
 
-    return retryer.runBinary((connection) -> connection.bitop(op, destKey, srcKeys), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.bitop(op, destKey, srcKeys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public String pfmerge(final byte[] destkey, final byte[]... sourcekeys) {
     byte[][] wholeKeys = KeyMergeUtil.merge(destkey, sourcekeys);
 
-    return retryer.runBinary((connection) -> connection.pfmerge(destkey, sourcekeys), wholeKeys.length, wholeKeys);
+    return runBinary((connection) -> connection.pfmerge(destkey, sourcekeys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long pfcount(final byte[]... keys) {
-    return retryer.runBinary((connection) -> connection.pfcount(keys), keys.length, keys);
+    return runBinary((connection) -> connection.pfcount(keys), keys.length, keys);
   }
 
   @Override
   public Long geoadd(final byte[] key, final double longitude, final double latitude,
       final byte[] member) {
-    return retryer.runBinary((connection) -> connection.geoadd(key, longitude, latitude, member), key);
+    return runBinary((connection) -> connection.geoadd(key, longitude, latitude, member), key);
   }
 
   @Override
   public Long geoadd(final byte[] key, final Map<byte[], GeoCoordinate> memberCoordinateMap) {
-    return retryer.runBinary((connection) -> connection.geoadd(key, memberCoordinateMap), key);
+    return runBinary((connection) -> connection.geoadd(key, memberCoordinateMap), key);
   }
 
   @Override
   public Double geodist(final byte[] key, final byte[] member1, final byte[] member2) {
-    return retryer.runBinary((connection) -> connection.geodist(key, member1, member2), key);
+    return runBinary((connection) -> connection.geodist(key, member1, member2), key);
   }
 
   @Override
   public Double geodist(final byte[] key, final byte[] member1, final byte[] member2,
       final GeoUnit unit) {
-    return retryer.runBinary((connection) -> connection.geodist(key, member1, member2, unit), key);
+    return runBinary((connection) -> connection.geodist(key, member1, member2, unit), key);
   }
 
   @Override
   public List<byte[]> geohash(final byte[] key, final byte[]... members) {
-    return retryer.runBinary((connection) -> connection.geohash(key, members), key);
+    return runBinary((connection) -> connection.geohash(key, members), key);
   }
 
   @Override
   public List<GeoCoordinate> geopos(final byte[] key, final byte[]... members) {
-    return retryer.runBinary((connection) -> connection.geopos(key, members), key);
+    return runBinary((connection) -> connection.geopos(key, members), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return retryer.runBinary((connection) -> connection.georadius(key, longitude, latitude, radius, unit), key);
+    return runBinary((connection) -> connection.georadius(key, longitude, latitude, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return retryer.runBinary((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit), key);
+    return runBinary((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.runBinary((connection) -> connection.georadius(key, longitude, latitude, radius, unit, param), key);
+    return runBinary((connection) -> connection.georadius(key, longitude, latitude, radius, unit, param), key);
   }
 
   @Override
   public Long georadiusStore(final byte[] key, final double longitude, final double latitude, final double radius,
       final GeoUnit unit, final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     byte[][] keys = storeParam.getByteKeys(key);
-    return retryer.runBinary((connection) -> connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam), keys.length, keys);
+    return runBinary((connection) -> connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam), keys.length, keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final byte[] key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.runBinary((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit, param), key);
+    return runBinary((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit, param), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit) {
-    return retryer.runBinary((connection) -> connection.georadiusByMember(key, member, radius, unit), key);
+    return runBinary((connection) -> connection.georadiusByMember(key, member, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit) {
-    return retryer.runBinary((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit), key);
+    return runBinary((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.runBinary((connection) -> connection.georadiusByMember(key, member, radius, unit, param), key);
+    return runBinary((connection) -> connection.georadiusByMember(key, member, radius, unit, param), key);
   }
 
   @Override
   public Long georadiusByMemberStore(final byte[] key, final byte[] member, final double radius, final GeoUnit unit,
       final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     byte[][] keys = storeParam.getByteKeys(key);
-    return retryer.runBinary((connection) -> connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam), keys.length, keys);
+    return runBinary((connection) -> connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam), keys.length, keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final byte[] key, final byte[] member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.runBinary((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit, param), key);
+    return runBinary((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit, param), key);
   }
 
   @Override
@@ -1149,7 +1184,7 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
       throw new IllegalArgumentException(this.getClass().getSimpleName()
           + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
-    return retryer.runBinary((connection) -> connection.keys(pattern), pattern);
+    return runBinary((connection) -> connection.keys(pattern), pattern);
   }
 
   @Override
@@ -1167,115 +1202,115 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
           + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
 
-    return retryer.runBinary((connection) -> connection.scan(cursor, params), matchPattern);
+    return runBinary((connection) -> connection.scan(cursor, params), matchPattern);
   }
 
   @Override
   public ScanResult<Map.Entry<byte[], byte[]>> hscan(final byte[] key, final byte[] cursor) {
-    return retryer.runBinary((connection) -> connection.hscan(key, cursor), key);
+    return runBinary((connection) -> connection.hscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<Map.Entry<byte[], byte[]>> hscan(final byte[] key, final byte[] cursor,
       final ScanParams params) {
-    return retryer.runBinary((connection) -> connection.hscan(key, cursor, params), key);
+    return runBinary((connection) -> connection.hscan(key, cursor, params), key);
   }
 
   @Override
   public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor) {
-    return retryer.runBinary((connection) -> connection.sscan(key, cursor), key);
+    return runBinary((connection) -> connection.sscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<byte[]> sscan(final byte[] key, final byte[] cursor, final ScanParams params) {
-    return retryer.runBinary((connection) -> connection.sscan(key, cursor, params), key);
+    return runBinary((connection) -> connection.sscan(key, cursor, params), key);
   }
 
   @Override
   public ScanResult<Tuple> zscan(final byte[] key, final byte[] cursor) {
-    return retryer.runBinary((connection) -> connection.zscan(key, cursor), key);
+    return runBinary((connection) -> connection.zscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<Tuple> zscan(final byte[] key, final byte[] cursor, final ScanParams params) {
-    return retryer.runBinary((connection) -> connection.zscan(key, cursor, params), key);
+    return runBinary((connection) -> connection.zscan(key, cursor, params), key);
   }
 
   @Override
   public List<Long> bitfield(final byte[] key, final byte[]... arguments) {
-    return retryer.runBinary((connection) -> connection.bitfield(key, arguments), key);
+    return runBinary((connection) -> connection.bitfield(key, arguments), key);
   }
 
   @Override
   public List<Long> bitfieldReadonly(final byte[] key, final byte[]... arguments) {
-    return retryer.runBinary((connection) -> connection.bitfieldReadonly(key, arguments), key);
+    return runBinary((connection) -> connection.bitfieldReadonly(key, arguments), key);
   }
 
   @Override
   public Long hstrlen(final byte[] key, final byte[] field) {
-    return retryer.runBinary((connection) -> connection.hstrlen(key, field), key);
+    return runBinary((connection) -> connection.hstrlen(key, field), key);
   }
 
   @Override
   public Long memoryUsage(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.memoryUsage(key), key);
+    return runBinary((connection) -> connection.memoryUsage(key), key);
   }
 
   @Override
   public Long memoryUsage(final byte[] key, final int samples) {
-    return retryer.runBinary((connection) -> connection.memoryUsage(key, samples), key);
+    return runBinary((connection) -> connection.memoryUsage(key, samples), key);
   }
 
   @Override
   public byte[] xadd(final byte[] key, final byte[] id, final Map<byte[], byte[]> hash, final long maxLen, final boolean approximateLength){
-    return retryer.runBinary((connection) -> connection.xadd(key, id, hash, maxLen, approximateLength), key);
+    return runBinary((connection) -> connection.xadd(key, id, hash, maxLen, approximateLength), key);
   }
 
   @Override
   public Long xlen(final byte[] key) {
-    return retryer.runBinary((connection) -> connection.xlen(key), key);
+    return runBinary((connection) -> connection.xlen(key), key);
   }
 
   @Override
   public List<byte[]> xrange(final byte[] key, final byte[] start, final byte[] end, final long count) {
-    return retryer.runBinary((connection) -> connection.xrange(key, start, end, count), key);
+    return runBinary((connection) -> connection.xrange(key, start, end, count), key);
   }
 
   @Override
   public List<byte[]> xrevrange(final byte[] key, final byte[] end, final byte[] start, final int count) {
-    return retryer.runBinary((connection) -> connection.xrevrange(key, end, start, count), key);
+    return runBinary((connection) -> connection.xrevrange(key, end, start, count), key);
   }
 
   @Override
   public List<byte[]> xread(final int count, final long block, final Map<byte[], byte[]> streams) {
     byte[][] keys = streams.keySet().toArray(new byte[streams.size()][]);
 
-    return retryer.runBinary((connection) -> connection.xread(count, block, streams), keys.length, keys);
+    return runBinary((connection) -> connection.xread(count, block, streams), keys.length, keys);
   }
 
   @Override
   public Long xack(final byte[] key, final byte[] group, final byte[]... ids) {
-    return retryer.runBinary((connection) -> connection.xack(key, group, ids), key);
+    return runBinary((connection) -> connection.xack(key, group, ids), key);
   }
 
   @Override
   public String xgroupCreate(final byte[] key, final byte[] consumer, final byte[] id, final boolean makeStream) {
-    return retryer.runBinary((connection) -> connection.xgroupCreate(key, consumer, id, makeStream), key);
+    return runBinary((connection) -> connection.xgroupCreate(key, consumer, id, makeStream), key);
   }
 
   @Override
   public String xgroupSetID(final byte[] key, final byte[] consumer, final byte[] id) {
-    return retryer.runBinary((connection) -> connection.xgroupSetID(key, consumer, id), key);
+    return runBinary((connection) -> connection.xgroupSetID(key, consumer, id), key);
   }
 
   @Override
   public Long xgroupDestroy(final byte[] key, final byte[] consumer) {
-    return retryer.runBinary((connection) -> connection.xgroupDestroy(key, consumer), key);
+    return runBinary((connection) -> connection.xgroupDestroy(key, consumer), key);
   }
 
   @Override
   public Long xgroupDelConsumer(final byte[] key, final byte[] consumer, final byte[] consumerName) {
-    return retryer.runBinary((connection) -> connection.xgroupDelConsumer(key, consumer, consumerName), key);
+    return runBinary((connection) -> connection.xgroupDelConsumer(key, consumer, consumerName), key);
   }
 
   @Override
@@ -1284,41 +1319,41 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
 
     byte[][] keys = streams.keySet().toArray(new byte[streams.size()][]);
 
-    return retryer.runBinary((connection) -> connection.xreadGroup(groupname, consumer, count, block, noAck, streams), keys.length, keys);
+    return runBinary((connection) -> connection.xreadGroup(groupname, consumer, count, block, noAck, streams), keys.length, keys);
   }
 
   @Override
   public Long xdel(final byte[] key, final byte[]... ids) {
-    return retryer.runBinary((connection) -> connection.xdel(key, ids), key);
+    return runBinary((connection) -> connection.xdel(key, ids), key);
   }
 
   @Override
   public Long xtrim(final byte[] key, final long maxLen, final boolean approximateLength) {
-    return retryer.runBinary((connection) -> connection.xtrim(key, maxLen, approximateLength), key);
+    return runBinary((connection) -> connection.xtrim(key, maxLen, approximateLength), key);
   }
 
   @Override
   public List<byte[]> xpending(final byte[] key, final byte[] groupname, final byte[] start, final byte[] end,
       final int count, final byte[] consumername) {
-    return retryer.runBinary((connection) -> connection.xpending(key, groupname, start, end, count, consumername), key);
+    return runBinary((connection) -> connection.xpending(key, groupname, start, end, count, consumername), key);
   }
 
   @Override
   public List<byte[]> xclaim(final byte[] key, final byte[] groupname, final byte[] consumername,
       final long minIdleTime, final long newIdleTime, final int retries, final boolean force, final byte[][] ids) {
-    return retryer.runBinary((connection) -> connection.xclaim(key, groupname, consumername, minIdleTime, newIdleTime, retries, force, ids), key);
+    return runBinary((connection) -> connection.xclaim(key, groupname, consumername, minIdleTime, newIdleTime, retries, force, ids), key);
   }
 
   @Override
   public Long waitReplicas(final byte[] key, final int replicas, final long timeout) {
-    return retryer.runBinary((connection) -> connection.waitReplicas(replicas, timeout), key);
+    return runBinary((connection) -> connection.waitReplicas(replicas, timeout), key);
   }
 
   public Object sendCommand(final byte[] sampleKey, final ProtocolCommand cmd, final byte[]... args) {
-    return retryer.runBinary((connection) -> connection.sendCommand(cmd, args), sampleKey);
+    return runBinary((connection) -> connection.sendCommand(cmd, args), sampleKey);
   }
 
   public Object sendBlockingCommand(final byte[] sampleKey, final ProtocolCommand cmd, final byte[]... args) {
-    return retryer.runBinary((connection) -> connection.sendBlockingCommand(cmd, args), sampleKey);
+    return runBinary((connection) -> connection.sendBlockingCommand(cmd, args), sampleKey);
   }
 }

--- a/src/main/java/redis/clients/jedis/DefaultRetryer.java
+++ b/src/main/java/redis/clients/jedis/DefaultRetryer.java
@@ -22,12 +22,6 @@ public class DefaultRetryer implements Retryer {
   }
 
   @Override
-  public <R> R runWithRetries(JedisClusterConnectionHandler connectionHandler, int slot,
-      Function<Jedis, R> command) {
-    return runWithRetries(connectionHandler, command, slot, maxAttempts, false, null);
-  }
-
-  @Override
   public <R> R runWithRetries(JedisClusterConnectionHandler connectionHandler,
       Function<Jedis, R> command) {
     Jedis connection = null;
@@ -39,9 +33,14 @@ public class DefaultRetryer implements Retryer {
     }
   }
 
-  private <R> R runWithRetries(JedisClusterConnectionHandler connectionHandler,
-      Function<Jedis, R> command, final int slot, int attempts, boolean tryRandomNode,
-      JedisRedirectionException redirect) {
+  @Override
+  public <R> R runWithRetries(JedisClusterConnectionHandler connectionHandler, int slot,
+      Function<Jedis, R> command) {
+    return runWithRetries(connectionHandler, command, slot, maxAttempts, false, null);
+  }
+
+  private <R> R runWithRetries(JedisClusterConnectionHandler connectionHandler, Function<Jedis, R> command,
+      final int slot, int attempts, boolean tryRandomNode, JedisRedirectionException redirect) {
     if (attempts <= 0) {
       throw new JedisClusterMaxAttemptsException("No more cluster attempts left.");
     }
@@ -81,8 +80,7 @@ public class DefaultRetryer implements Retryer {
         connectionHandler.renewSlotCache();
       }
 
-      return runWithRetries(connectionHandler, command, slot, attempts - 1, tryRandomNode,
-          redirect);
+      return runWithRetries(connectionHandler, command, slot, attempts - 1, tryRandomNode, redirect);
     } catch (JedisRedirectionException jre) {
       // if MOVED redirection occurred,
       if (jre instanceof JedisMovedDataException) {

--- a/src/main/java/redis/clients/jedis/DefaultRetryer.java
+++ b/src/main/java/redis/clients/jedis/DefaultRetryer.java
@@ -10,11 +10,10 @@ import redis.clients.jedis.exceptions.JedisRedirectionException;
 
 public class DefaultRetryer extends Retryer {
 
-  private final JedisClusterConnectionHandler connectionHandler;
   private final int maxAttempts;
 
   public DefaultRetryer(JedisClusterConnectionHandler connectionHandler, int maxAttempts) {
-    this.connectionHandler = connectionHandler;
+    super(connectionHandler);
     this.maxAttempts = maxAttempts;
   }
 

--- a/src/main/java/redis/clients/jedis/DefaultRetryer.java
+++ b/src/main/java/redis/clients/jedis/DefaultRetryer.java
@@ -33,13 +33,6 @@ public class DefaultRetryer extends Retryer {
     }
   }
 
-  @Override
-  public void close() {
-    if (connectionHandler != null) {
-      connectionHandler.close();
-    }
-  }
-
   private <R> R runWithRetries(Function<Jedis, R> command, final int slot, int attempts, boolean tryRandomNode, JedisRedirectionException redirect) {
     if (attempts <= 0) {
       throw new JedisClusterMaxAttemptsException("No more cluster attempts left.");

--- a/src/main/java/redis/clients/jedis/DefaultRetryer.java
+++ b/src/main/java/redis/clients/jedis/DefaultRetryer.java
@@ -34,6 +34,13 @@ public class DefaultRetryer extends Retryer {
     }
   }
 
+  @Override
+  public void close() {
+    if (connectionHandler != null) {
+      connectionHandler.close();
+    }
+  }
+
   private <R> R runWithRetries(Function<Jedis, R> command, final int slot, int attempts, boolean tryRandomNode, JedisRedirectionException redirect) {
     if (attempts <= 0) {
       throw new JedisClusterMaxAttemptsException("No more cluster attempts left.");

--- a/src/main/java/redis/clients/jedis/DefaultRetryer.java
+++ b/src/main/java/redis/clients/jedis/DefaultRetryer.java
@@ -8,6 +8,11 @@ import redis.clients.jedis.exceptions.JedisMovedDataException;
 import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
 import redis.clients.jedis.exceptions.JedisRedirectionException;
 
+/**
+ * Retries failed and redirected Jedis connections, without any backoff.
+ *
+ * @see Retryer
+ */
 public class DefaultRetryer extends Retryer {
 
   private final int maxAttempts;

--- a/src/main/java/redis/clients/jedis/DefaultRetryer.java
+++ b/src/main/java/redis/clients/jedis/DefaultRetryer.java
@@ -23,6 +23,17 @@ public class DefaultRetryer extends Retryer {
     return runWithRetries(command, slot, maxAttempts, false, null);
   }
 
+  @Override
+  public <R> R runWithRetries(Function<Jedis, R> command) {
+    Jedis connection = null;
+    try {
+      connection = connectionHandler.getConnection();
+      return command.apply(connection);
+    } finally {
+      releaseConnection(connection);
+    }
+  }
+
   private <R> R runWithRetries(Function<Jedis, R> command, final int slot, int attempts, boolean tryRandomNode, JedisRedirectionException redirect) {
     if (attempts <= 0) {
       throw new JedisClusterMaxAttemptsException("No more cluster attempts left.");

--- a/src/main/java/redis/clients/jedis/DefaultRetryer.java
+++ b/src/main/java/redis/clients/jedis/DefaultRetryer.java
@@ -1,85 +1,29 @@
 package redis.clients.jedis;
 
+import java.util.function.Function;
 import redis.clients.jedis.exceptions.JedisAskDataException;
 import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
-import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisMovedDataException;
 import redis.clients.jedis.exceptions.JedisNoReachableClusterNodeException;
 import redis.clients.jedis.exceptions.JedisRedirectionException;
-import redis.clients.jedis.util.JedisClusterCRC16;
 
-public abstract class JedisClusterCommand<T> {
+public class DefaultRetryer extends Retryer {
 
   private final JedisClusterConnectionHandler connectionHandler;
   private final int maxAttempts;
 
-  public JedisClusterCommand(JedisClusterConnectionHandler connectionHandler, int maxAttempts) {
+  public DefaultRetryer(JedisClusterConnectionHandler connectionHandler, int maxAttempts) {
     this.connectionHandler = connectionHandler;
     this.maxAttempts = maxAttempts;
   }
 
-  public abstract T execute(Jedis connection);
-
-  public T run(String key) {
-    return runWithRetries(JedisClusterCRC16.getSlot(key), this.maxAttempts, false, null);
+  @Override
+  protected <R> R runWithRetries(int slot, Function<Jedis, R> command) {
+    return runWithRetries(command, slot, maxAttempts, false, null);
   }
 
-  public T run(int keyCount, String... keys) {
-    if (keys == null || keys.length == 0) {
-      throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
-    }
-
-    // For multiple keys, only execute if they all share the same connection slot.
-    int slot = JedisClusterCRC16.getSlot(keys[0]);
-    if (keys.length > 1) {
-      for (int i = 1; i < keyCount; i++) {
-        int nextSlot = JedisClusterCRC16.getSlot(keys[i]);
-        if (slot != nextSlot) {
-          throw new JedisClusterOperationException("No way to dispatch this command to Redis "
-              + "Cluster because keys have different slots.");
-        }
-      }
-    }
-
-    return runWithRetries(slot, this.maxAttempts, false, null);
-  }
-
-  public T runBinary(byte[] key) {
-    return runWithRetries(JedisClusterCRC16.getSlot(key), this.maxAttempts, false, null);
-  }
-
-  public T runBinary(int keyCount, byte[]... keys) {
-    if (keys == null || keys.length == 0) {
-      throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
-    }
-
-    // For multiple keys, only execute if they all share the same connection slot.
-    int slot = JedisClusterCRC16.getSlot(keys[0]);
-    if (keys.length > 1) {
-      for (int i = 1; i < keyCount; i++) {
-        int nextSlot = JedisClusterCRC16.getSlot(keys[i]);
-        if (slot != nextSlot) {
-          throw new JedisClusterOperationException("No way to dispatch this command to Redis "
-              + "Cluster because keys have different slots.");
-        }
-      }
-    }
-
-    return runWithRetries(slot, this.maxAttempts, false, null);
-  }
-
-  public T runWithAnyNode() {
-    Jedis connection = null;
-    try {
-      connection = connectionHandler.getConnection();
-      return execute(connection);
-    } finally {
-      releaseConnection(connection);
-    }
-  }
-
-  private T runWithRetries(final int slot, int attempts, boolean tryRandomNode, JedisRedirectionException redirect) {
+  private <R> R runWithRetries(Function<Jedis, R> command, final int slot, int attempts, boolean tryRandomNode, JedisRedirectionException redirect) {
     if (attempts <= 0) {
       throw new JedisClusterMaxAttemptsException("No more cluster attempts left.");
     }
@@ -101,7 +45,7 @@ public abstract class JedisClusterCommand<T> {
         }
       }
 
-      return execute(connection);
+      return command.apply(connection);
 
     } catch (JedisNoReachableClusterNodeException jnrcne) {
       throw jnrcne;
@@ -119,7 +63,7 @@ public abstract class JedisClusterCommand<T> {
         this.connectionHandler.renewSlotCache();
       }
 
-      return runWithRetries(slot, attempts - 1, tryRandomNode, redirect);
+      return runWithRetries(command, slot, attempts - 1, tryRandomNode, redirect);
     } catch (JedisRedirectionException jre) {
       // if MOVED redirection occurred,
       if (jre instanceof JedisMovedDataException) {
@@ -131,7 +75,7 @@ public abstract class JedisClusterCommand<T> {
       releaseConnection(connection);
       connection = null;
 
-      return runWithRetries(slot, attempts - 1, false, jre);
+      return runWithRetries(command, slot, attempts - 1, false, jre);
     } finally {
       releaseConnection(connection);
     }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -24,6 +24,14 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
+/**
+ * Interface to a Jedis cluster.
+ * <p/>
+ * Uses {@link DefaultRetryer}, or you can inject your own using
+ * {@link JedisCluster#JedisCluster(Retryer)}.
+ *
+ * @see BinaryJedisCluster
+ */
 public class JedisCluster extends BinaryJedisCluster implements JedisClusterCommands,
     MultiKeyJedisClusterCommands, JedisClusterScriptingCommands {
 

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -193,6 +193,10 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
         clientName, poolConfig, ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMap);
   }
 
+  public JedisCluster(Retryer retryer) {
+    super(retryer);
+  }
+
   @Override
   public String set(final String key, final String value) {
     return retryer.run((connection) -> connection.set(key, value), key);

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -195,62 +195,32 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String set(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.set(key, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.set(key, value), key);
   }
 
   @Override
   public String set(final String key, final String value, final SetParams params) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.set(key, value, params);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.set(key, value, params), key);
   }
 
   @Override
   public String get(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.get(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.get(key), key);
   }
 
   @Override
   public Boolean exists(final String key) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.exists(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.exists(key), key);
   }
 
   @Override
   public Long exists(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.exists(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.exists(keys), keys.length, keys);
   }
 
   @Override
   public Long persist(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.persist(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.persist(key), key);
   }
 
   @Override
@@ -260,1256 +230,636 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public byte[] dump(final String key) {
-    return new JedisClusterCommand<byte[]>(connectionHandler, maxAttempts) {
-      @Override
-      public byte[] execute(Jedis connection) {
-        return connection.dump(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.dump(key), key);
   }
 
   @Override
   public String restore(final String key, final int ttl, final byte[] serializedValue) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.restore(key, ttl, serializedValue);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.restore(key, ttl, serializedValue), key);
   }
 
   @Override
   public Long expire(final String key, final int seconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.expire(key, seconds);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.expire(key, seconds), key);
   }
 
   @Override
   public Long pexpire(final String key, final long milliseconds) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pexpire(key, milliseconds);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.pexpire(key, milliseconds), key);
   }
 
   @Override
   public Long expireAt(final String key, final long unixTime) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.expireAt(key, unixTime);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.expireAt(key, unixTime), key);
   }
 
   @Override
   public Long pexpireAt(final String key, final long millisecondsTimestamp) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pexpireAt(key, millisecondsTimestamp);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.pexpireAt(key, millisecondsTimestamp), key);
   }
 
   @Override
   public Long ttl(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.ttl(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.ttl(key), key);
   }
 
   @Override
   public Long pttl(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pttl(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.pttl(key), key);
   }
 
   @Override
   public Long touch(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.touch(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.touch(key), key);
   }
 
   @Override
   public Long touch(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.touch(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.touch(keys), keys.length, keys);
   }
 
   @Override
   public Boolean setbit(final String key, final long offset, final boolean value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.setbit(key, offset, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean setbit(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.setbit(key, offset, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean getbit(final String key, final long offset) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.getbit(key, offset);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.getbit(key, offset), key);
   }
 
   @Override
   public Long setrange(final String key, final long offset, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.setrange(key, offset, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.setrange(key, offset, value), key);
   }
 
   @Override
   public String getrange(final String key, final long startOffset, final long endOffset) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.getrange(key, startOffset, endOffset);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.getrange(key, startOffset, endOffset), key);
   }
 
   @Override
   public String getSet(final String key, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.getSet(key, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.getSet(key, value), key);
   }
 
   @Override
   public Long setnx(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.setnx(key, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.setnx(key, value), key);
   }
 
   @Override
   public String setex(final String key, final int seconds, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.setex(key, seconds, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.setex(key, seconds, value), key);
   }
 
   @Override
   public String psetex(final String key, final long milliseconds, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.psetex(key, milliseconds, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.psetex(key, milliseconds, value), key);
   }
 
   @Override
   public Long decrBy(final String key, final long decrement) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.decrBy(key, decrement);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.decrBy(key, decrement), key);
   }
 
   @Override
   public Long decr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.decr(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.decr(key), key);
   }
 
   @Override
   public Long incrBy(final String key, final long increment) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.incrBy(key, increment);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.incrBy(key, increment), key);
   }
 
   @Override
   public Double incrByFloat(final String key, final double increment) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.incrByFloat(key, increment);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.incrByFloat(key, increment), key);
   }
 
   @Override
   public Long incr(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.incr(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.incr(key), key);
   }
 
   @Override
   public Long append(final String key, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.append(key, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.append(key, value), key);
   }
 
   @Override
   public String substr(final String key, final int start, final int end) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.substr(key, start, end);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.substr(key, start, end), key);
   }
 
   @Override
   public Long hset(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hset(key, field, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hset(key, field, value), key);
   }
 
   @Override
   public Long hset(final String key, final Map<String, String> hash) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hset(key, hash);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hset(key, hash), key);
   }
 
   @Override
   public String hget(final String key, final String field) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.hget(key, field);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hget(key, field), key);
   }
 
   @Override
   public Long hsetnx(final String key, final String field, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hsetnx(key, field, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hsetnx(key, field, value), key);
   }
 
   @Override
   public String hmset(final String key, final Map<String, String> hash) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.hmset(key, hash);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hmset(key, hash), key);
   }
 
   @Override
   public List<String> hmget(final String key, final String... fields) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.hmget(key, fields);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hmget(key, fields), key);
   }
 
   @Override
   public Long hincrBy(final String key, final String field, final long value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hincrBy(key, field, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hincrBy(key, field, value), key);
   }
 
   @Override
   public Double hincrByFloat(final String key, final String field, final double value) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.hincrByFloat(key, field, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hincrByFloat(key, field, value), key);
   }
 
   @Override
   public Boolean hexists(final String key, final String field) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.hexists(key, field);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hexists(key, field), key);
   }
 
   @Override
   public Long hdel(final String key, final String... field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hdel(key, field);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hdel(key, field), key);
   }
 
   @Override
   public Long hlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hlen(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hlen(key), key);
   }
 
   @Override
   public Set<String> hkeys(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.hkeys(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hkeys(key), key);
   }
 
   @Override
   public List<String> hvals(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.hvals(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hvals(key), key);
   }
 
   @Override
   public Map<String, String> hgetAll(final String key) {
-    return new JedisClusterCommand<Map<String, String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Map<String, String> execute(Jedis connection) {
-        return connection.hgetAll(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hgetAll(key), key);
   }
 
   @Override
   public Long rpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.rpush(key, string);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.rpush(key, string), key);
   }
 
   @Override
   public Long lpush(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpush(key, string);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lpush(key, string), key);
   }
 
   @Override
   public Long llen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.llen(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.llen(key), key);
   }
 
   @Override
   public List<String> lrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.lrange(key, start, stop);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lrange(key, start, stop), key);
   }
 
   @Override
   public String ltrim(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.ltrim(key, start, stop);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.ltrim(key, start, stop), key);
   }
 
   @Override
   public String lindex(final String key, final long index) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.lindex(key, index);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lindex(key, index), key);
   }
 
   @Override
   public String lset(final String key, final long index, final String value) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.lset(key, index, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lset(key, index, value), key);
   }
 
   @Override
   public Long lrem(final String key, final long count, final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lrem(key, count, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lrem(key, count, value), key);
   }
 
   @Override
   public String lpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.lpop(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lpop(key), key);
   }
 
   @Override
   public List<String> lpop(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.lpop(key, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lpop(key, count), key);
   }
 
   @Override
   public Long lpos(final String key, final String element) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpos(key, element);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lpos(key, element), key);
   }
 
   @Override
   public Long lpos(final String key, final String element, final LPosParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpos(key, element, params);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lpos(key, element, params), key);
   }
 
   @Override
   public List<Long> lpos(final String key, final String element, final LPosParams params, final long count) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Long> execute(Jedis connection) {
-        return connection.lpos(key, element, params, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lpos(key, element, params, count), key);
   }
 
   @Override
   public String rpop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.rpop(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.rpop(key), key);
   }
 
   @Override
   public List<String> rpop(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.rpop(key, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.rpop(key, count), key);
   }
 
   @Override
   public Long sadd(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sadd(key, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.sadd(key, member), key);
   }
 
   @Override
   public Set<String> smembers(final String key) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.smembers(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.smembers(key), key);
   }
 
   @Override
   public Long srem(final String key, final String... member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.srem(key, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.srem(key, member), key);
   }
 
   @Override
   public String spop(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.spop(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.spop(key), key);
   }
 
   @Override
   public Set<String> spop(final String key, final long count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.spop(key, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.spop(key, count), key);
   }
 
   @Override
   public Long scard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.scard(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.scard(key), key);
   }
 
   @Override
   public Boolean sismember(final String key, final String member) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.sismember(key, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.sismember(key, member), key);
   }
 
   @Override
   public List<Boolean> smismember(final String key, final String... members) {
-    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Boolean> execute(Jedis connection) {
-        return connection.smismember(key, members);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.smismember(key, members), key);
   }
 
   @Override
   public String srandmember(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.srandmember(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.srandmember(key), key);
   }
 
   @Override
   public List<String> srandmember(final String key, final int count) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.srandmember(key, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.srandmember(key, count), key);
   }
 
   @Override
   public Long strlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.strlen(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.strlen(key), key);
   }
 
   @Override
   public Long zadd(final String key, final double score, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, score, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zadd(key, score, member), key);
   }
 
   @Override
   public Long zadd(final String key, final double score, final String member,
       final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, score, member, params);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zadd(key, score, member, params), key);
   }
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, scoreMembers);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zadd(key, scoreMembers), key);
   }
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers, final ZAddParams params) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zadd(key, scoreMembers, params);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zadd(key, scoreMembers, params), key);
   }
 
   @Override
   public Set<String> zrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrange(key, start, stop);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrange(key, start, stop), key);
   }
 
   @Override
   public Long zrem(final String key, final String... members) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zrem(key, members);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrem(key, members), key);
   }
 
   @Override
   public Double zincrby(final String key, final double increment, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.zincrby(key, increment, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zincrby(key, increment, member), key);
   }
 
   @Override
   public Double zincrby(final String key, final double increment, final String member,
       final ZIncrByParams params) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.zincrby(key, increment, member, params);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zincrby(key, increment, member, params), key);
   }
 
   @Override
   public Long zrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zrank(key, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrank(key, member), key);
   }
 
   @Override
   public Long zrevrank(final String key, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zrevrank(key, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrank(key, member), key);
   }
 
   @Override
   public Set<String> zrevrange(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrevrange(key, start, stop);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrange(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrangeWithScores(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeWithScores(key, start, stop);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeWithScores(key, start, stop);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Long zcard(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zcard(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zcard(key), key);
   }
 
   @Override
   public Double zscore(final String key, final String member) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.zscore(key, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zscore(key, member), key);
   }
 
   @Override
   public List<Double> zmscore(final String key, final String... members) {
-    return new JedisClusterCommand<List<Double>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Double> execute(Jedis connection) {
-        return connection.zmscore(key, members);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zmscore(key, members), key);
   }
 
   @Override
   public Tuple zpopmax(final String key) {
-    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts) {
-      @Override
-      public Tuple execute(Jedis connection) {
-        return connection.zpopmax(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zpopmax(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmax(final String key, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zpopmax(key, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zpopmax(key, count), key);
   }
 
   @Override
   public Tuple zpopmin(final String key) {
-    return new JedisClusterCommand<Tuple>(connectionHandler, maxAttempts) {
-      @Override
-      public Tuple execute(Jedis connection) {
-        return connection.zpopmin(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zpopmin(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmin(final String key, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zpopmin(key, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zpopmin(key, count), key);
   }
 
   @Override
   public List<String> sort(final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.sort(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.sort(key), key);
   }
 
   @Override
   public List<String> sort(final String key, final SortingParams sortingParameters) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.sort(key, sortingParameters);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.sort(key, sortingParameters), key);
   }
 
   @Override
   public Long zcount(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zcount(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Long zcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zcount(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrangeByScore(key, min, max, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByScore(key, max, min, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrangeByScoreWithScores(key, min, max, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max,
       final double min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max,
       final String min, final int offset, final int count) {
-    return new JedisClusterCommand<Set<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<Tuple> execute(Jedis connection) {
-        return connection.zrevrangeByScoreWithScores(key, max, min, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
   }
 
   @Override
   public Long zremrangeByRank(final String key, final long start, final long stop) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByRank(key, start, stop);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zremrangeByRank(key, start, stop), key);
   }
 
   @Override
   public Long zremrangeByScore(final String key, final double min, final double max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByScore(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long zremrangeByScore(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByScore(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long zlexcount(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zlexcount(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zlexcount(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrangeByLex(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByLex(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrangeByLex(key, min, max, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrangeByLex(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByLex(key, max, min);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByLex(key, max, min), key);
   }
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min,
       final int offset, final int count) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.zrevrangeByLex(key, max, min, offset, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zrevrangeByLex(key, max, min, offset, count), key);
   }
 
   @Override
   public Long zremrangeByLex(final String key, final String min, final String max) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zremrangeByLex(key, min, max);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zremrangeByLex(key, min, max), key);
   }
 
   @Override
   public Long linsert(final String key, final ListPosition where, final String pivot,
       final String value) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.linsert(key, where, pivot, value);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.linsert(key, where, pivot, value), key);
   }
 
   @Override
   public Long lpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.lpushx(key, string);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.lpushx(key, string), key);
   }
 
   @Override
   public Long rpushx(final String key, final String... string) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.rpushx(key, string);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.rpushx(key, string), key);
   }
 
   @Override
   public Long del(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.del(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.del(key), key);
   }
 
   @Override
   public Long unlink(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.unlink(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.unlink(key), key);
   }
 
   @Override
   public Long unlink(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.unlink(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.unlink(keys), keys.length, keys);
   }
 
   @Override
   public String echo(final String string) {
     // note that it'll be run from arbitrary node
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.echo(string);
-      }
-    }.run(string);
+    return retryer.run((connection) -> connection.echo(string), string);
   }
 
   @Override
   public Long bitcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.bitcount(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.bitcount(key), key);
   }
 
   @Override
   public Long bitcount(final String key, final long start, final long end) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.bitcount(key, start, end);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.bitcount(key, start, end), key);
   }
 
   @Override
@@ -1522,18 +872,13 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       throw new IllegalArgumentException(this.getClass().getSimpleName()
           + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.keys(pattern);
-      }
-    }.run(pattern);
+    return retryer.run((connection) -> connection.keys(pattern), pattern);
   }
 
   @Override
   public ScanResult<String> scan(final String cursor, final ScanParams params) {
 
-    String matchPattern = null;
+    String matchPattern;
 
     if (params == null || (matchPattern = params.match()) == null || matchPattern.isEmpty()) {
       throw new IllegalArgumentException(JedisCluster.class.getSimpleName()
@@ -1545,124 +890,63 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
           + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
 
-    return new JedisClusterCommand< ScanResult<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<String> execute(Jedis connection) {
-        return connection.scan(cursor, params);
-      }
-    }.run(matchPattern);
+    return retryer.run((connection) -> connection.scan(cursor, params), matchPattern);
   }
-  
+
   @Override
   public ScanResult<Entry<String, String>> hscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<Entry<String, String>>>(connectionHandler,
-                                                                      maxAttempts) {
-      @Override
-      public ScanResult<Entry<String, String>> execute(Jedis connection) {
-        return connection.hscan(key, cursor);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<String> sscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<String> execute(Jedis connection) {
-        return connection.sscan(key, cursor);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.sscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<Tuple> zscan(final String key, final String cursor) {
-    return new JedisClusterCommand<ScanResult<Tuple>>(connectionHandler, maxAttempts) {
-      @Override
-      public ScanResult<Tuple> execute(Jedis connection) {
-        return connection.zscan(key, cursor);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.zscan(key, cursor), key);
   }
 
   @Override
   public Long pfadd(final String key, final String... elements) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pfadd(key, elements);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.pfadd(key, elements), key);
   }
 
   @Override
   public long pfcount(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pfcount(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.pfcount(key), key);
   }
 
   @Override
   public List<String> blpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.blpop(timeout, key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.blpop(timeout, key), key);
   }
 
   @Override
   public List<String> brpop(final int timeout, final String key) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.brpop(timeout, key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.brpop(timeout, key), key);
   }
 
   @Override
   public Long del(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.del(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.del(keys), keys.length, keys);
   }
 
   @Override
   public List<String> blpop(final int timeout, final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.blpop(timeout, keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.blpop(timeout, keys), keys.length, keys);
 
   }
 
   @Override
   public List<String> brpop(final int timeout, final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.brpop(timeout, keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.brpop(timeout, keys), keys.length, keys);
   }
 
   @Override
   public List<String> mget(final String... keys) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.mget(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.mget(keys), keys.length, keys);
   }
 
   @Override
@@ -1673,12 +957,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.mset(keysvalues);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.mset(keysvalues), keys.length, keys);
   }
 
   @Override
@@ -1689,647 +968,346 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.msetnx(keysvalues);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.msetnx(keysvalues), keys.length, keys);
   }
 
   @Override
   public String rename(final String oldkey, final String newkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.rename(oldkey, newkey);
-      }
-    }.run(2, oldkey, newkey);
+    return retryer.run((connection) -> connection.rename(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public Long renamenx(final String oldkey, final String newkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.renamenx(oldkey, newkey);
-      }
-    }.run(2, oldkey, newkey);
+    return retryer.run((connection) -> connection.renamenx(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public String rpoplpush(final String srckey, final String dstkey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.rpoplpush(srckey, dstkey);
-      }
-    }.run(2, srckey, dstkey);
+    return retryer.run((connection) -> connection.rpoplpush(srckey, dstkey), 2, srckey, dstkey);
   }
 
   @Override
   public Set<String> sdiff(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.sdiff(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.sdiff(keys), keys.length, keys);
   }
 
   @Override
   public Long sdiffstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sdiffstore(dstkey, keys);
-      }
-    }.run(mergedKeys.length, mergedKeys);
+    return retryer.run((connection) -> connection.sdiffstore(dstkey, keys), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public Set<String> sinter(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.sinter(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.sinter(keys), keys.length, keys);
   }
 
   @Override
   public Long sinterstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sinterstore(dstkey, keys);
-      }
-    }.run(mergedKeys.length, mergedKeys);
+    return retryer.run((connection) -> connection.sinterstore(dstkey, keys), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public Long smove(final String srckey, final String dstkey, final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.smove(srckey, dstkey, member);
-      }
-    }.run(2, srckey, dstkey);
+    return retryer.run((connection) -> connection.smove(srckey, dstkey, member), 2, srckey, dstkey);
   }
 
   @Override
   public Long sort(final String key, final SortingParams sortingParameters, final String dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sort(key, sortingParameters, dstkey);
-      }
-    }.run(2, key, dstkey);
+    return retryer.run((connection) -> connection.sort(key, sortingParameters, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Long sort(final String key, final String dstkey) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sort(key, dstkey);
-      }
-    }.run(2, key, dstkey);
+    return retryer.run((connection) -> connection.sort(key, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Set<String> sunion(final String... keys) {
-    return new JedisClusterCommand<Set<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public Set<String> execute(Jedis connection) {
-        return connection.sunion(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.sunion(keys), keys.length, keys);
   }
 
   @Override
   public Long sunionstore(final String dstkey, final String... keys) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.sunionstore(dstkey, keys);
-      }
-    }.run(wholeKeys.length, wholeKeys);
+    return retryer.run((connection) -> connection.sunionstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final String dstkey, final String... sets) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zinterstore(dstkey, sets);
-      }
-    }.run(wholeKeys.length, wholeKeys);
+    return retryer.run((connection) -> connection.zinterstore(dstkey, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zinterstore(dstkey, params, sets);
-      }
-    }.run(mergedKeys.length, mergedKeys);
+    return retryer.run((connection) -> connection.zinterstore(dstkey, params, sets), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public Long zunionstore(final String dstkey, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zunionstore(dstkey, sets);
-      }
-    }.run(mergedKeys.length, mergedKeys);
+    return retryer.run((connection) -> connection.zunionstore(dstkey, sets), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public Long zunionstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.zunionstore(dstkey, params, sets);
-      }
-    }.run(mergedKeys.length, mergedKeys);
+    return retryer.run((connection) -> connection.zunionstore(dstkey, params, sets), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public String brpoplpush(final String source, final String destination, final int timeout) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.brpoplpush(source, destination, timeout);
-      }
-    }.run(2, source, destination);
+    return retryer.run((connection) -> connection.brpoplpush(source, destination, timeout), 2, source, destination);
   }
 
   @Override
   public Long publish(final String channel, final String message) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.publish(channel, message);
-      }
-    }.runWithAnyNode();
+    return retryer.runWithRetries((connection) -> connection.publish(channel, message));
   }
 
   @Override
   public void subscribe(final JedisPubSub jedisPubSub, final String... channels) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
-      @Override
-      public Integer execute(Jedis connection) {
-        connection.subscribe(jedisPubSub, channels);
-        return 0;
-      }
-    }.runWithAnyNode();
+    retryer.runWithRetries((connection) -> {
+      connection.subscribe(jedisPubSub, channels);
+      return null;
+    });
   }
 
   @Override
   public void psubscribe(final JedisPubSub jedisPubSub, final String... patterns) {
-    new JedisClusterCommand<Integer>(connectionHandler, maxAttempts) {
-      @Override
-      public Integer execute(Jedis connection) {
-        connection.psubscribe(jedisPubSub, patterns);
-        return 0;
-      }
-    }.runWithAnyNode();
+    retryer.runWithRetries((connection) -> {
+      connection.psubscribe(jedisPubSub, patterns);
+      return null;
+    });
   }
 
   @Override
   public Long bitop(final BitOP op, final String destKey, final String... srcKeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destKey, srcKeys);
 
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.bitop(op, destKey, srcKeys);
-      }
-    }.run(mergedKeys.length, mergedKeys);
+    return retryer.run((connection) -> connection.bitop(op, destKey, srcKeys), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public String pfmerge(final String destkey, final String... sourcekeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destkey, sourcekeys);
 
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.pfmerge(destkey, sourcekeys);
-      }
-    }.run(mergedKeys.length, mergedKeys);
+    return retryer.run((connection) -> connection.pfmerge(destkey, sourcekeys), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public long pfcount(final String... keys) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.pfcount(keys);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.pfcount(keys), keys.length, keys);
   }
 
   @Override
   public Object eval(final String script, final int keyCount, final String... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.eval(script, keyCount, params);
-      }
-    }.run(keyCount, params);
+    return retryer.run((connection) -> connection.eval(script, keyCount, params), keyCount, params);
   }
 
   @Override
   public Object eval(final String script, final String sampleKey) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.eval(script);
-      }
-    }.run(sampleKey);
+    return retryer.run((connection) -> connection.eval(script), sampleKey);
   }
 
   @Override
   public Object eval(final String script, final List<String> keys, final List<String> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.eval(script, keys, args);
-      }
-    }.run(keys.size(), keys.toArray(new String[keys.size()]));
+    return retryer.run((connection) -> connection.eval(script, keys, args), keys.size(), keys.toArray(new String[keys.size()]));
   }
 
   @Override
   public Object evalsha(final String sha1, final int keyCount, final String... params) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.evalsha(sha1, keyCount, params);
-      }
-    }.run(keyCount, params);
+    return retryer.run((connection) -> connection.evalsha(sha1, keyCount, params), keyCount, params);
   }
 
   @Override
   public Object evalsha(final String sha1, final List<String> keys, final List<String> args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.evalsha(sha1, keys, args);
-      }
-    }.run(keys.size(), keys.toArray(new String[keys.size()]));
+    return retryer.run((connection) -> connection.evalsha(sha1, keys, args), keys.size(), keys.toArray(new String[keys.size()]));
   }
 
   @Override
   public Object evalsha(final String sha1, final String sampleKey) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection) {
-        return connection.evalsha(sha1);
-      }
-    }.run(sampleKey);
+    return retryer.run((connection) -> connection.evalsha(sha1), sampleKey);
   }
 
   @Override
   public Boolean scriptExists(final String sha1, final String sampleKey) {
-    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts) {
-      @Override
-      public Boolean execute(Jedis connection) {
-        return connection.scriptExists(sha1);
-      }
-    }.run(sampleKey);
+    return retryer.run((connection) -> connection.scriptExists(sha1), sampleKey);
   }
 
   @Override
   public List<Boolean> scriptExists(final String sampleKey, final String... sha1) {
-    return new JedisClusterCommand<List<Boolean>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Boolean> execute(Jedis connection) {
-        return connection.scriptExists(sha1);
-      }
-    }.run(sampleKey);
+    return retryer.run((connection) -> connection.scriptExists(sha1), sampleKey);
   }
 
   @Override
   public String scriptLoad(final String script, final String sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.scriptLoad(script);
-      }
-    }.run(sampleKey);
+    return retryer.run((connection) -> connection.scriptLoad(script), sampleKey);
   }
 
   @Override
   public String scriptFlush(final String sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.scriptFlush();
-      }
-    }.run(sampleKey);
+    return retryer.run(BinaryJedis::scriptFlush, sampleKey);
   }
 
   @Override
   public String scriptKill(final String sampleKey) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.scriptKill();
-      }
-    }.run(sampleKey);
+    return retryer.run(BinaryJedis::scriptKill, sampleKey);
   }
 
   @Override
   public Long geoadd(final String key, final double longitude, final double latitude,
       final String member) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.geoadd(key, longitude, latitude, member);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.geoadd(key, longitude, latitude, member), key);
   }
 
   @Override
   public Long geoadd(final String key, final Map<String, GeoCoordinate> memberCoordinateMap) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.geoadd(key, memberCoordinateMap);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.geoadd(key, memberCoordinateMap), key);
   }
 
   @Override
   public Double geodist(final String key, final String member1, final String member2) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.geodist(key, member1, member2);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.geodist(key, member1, member2), key);
   }
 
   @Override
   public Double geodist(final String key, final String member1, final String member2,
       final GeoUnit unit) {
-    return new JedisClusterCommand<Double>(connectionHandler, maxAttempts) {
-      @Override
-      public Double execute(Jedis connection) {
-        return connection.geodist(key, member1, member2, unit);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.geodist(key, member1, member2, unit), key);
   }
 
   @Override
   public List<String> geohash(final String key, final String... members) {
-    return new JedisClusterCommand<List<String>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<String> execute(Jedis connection) {
-        return connection.geohash(key, members);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.geohash(key, members), key);
   }
 
   @Override
   public List<GeoCoordinate> geopos(final String key, final String... members) {
-    return new JedisClusterCommand<List<GeoCoordinate>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoCoordinate> execute(Jedis connection) {
-        return connection.geopos(key, members);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.geopos(key, members), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadius(key, longitude, latitude, radius, unit);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadius(key, longitude, latitude, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusReadonly(key, longitude, latitude, radius, unit);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadius(key, longitude, latitude, radius, unit, param);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadius(key, longitude, latitude, radius, unit, param), key);
   }
 
   @Override
   public Long georadiusStore(final String key, final double longitude, final double latitude,
       final double radius, final GeoUnit unit, final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     String[] keys = storeParam.getStringKeys(key);
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam), keys.length, keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusReadonly(key, longitude, latitude, radius, unit, param);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit, param), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMember(key, member, radius, unit);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadiusByMember(key, member, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final String key, final String member,
       final double radius, final GeoUnit unit) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMemberReadonly(key, member, radius, unit);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMember(key, member, radius, unit, param);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadiusByMember(key, member, radius, unit, param), key);
   }
 
   @Override
   public Long georadiusByMemberStore(final String key, final String member, final double radius, final GeoUnit unit,
       final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     String[] keys = storeParam.getStringKeys(key);
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam);
-      }
-    }.run(keys.length, keys);
+    return retryer.run((connection) -> connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam), keys.length, keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final String key, final String member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return new JedisClusterCommand<List<GeoRadiusResponse>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<GeoRadiusResponse> execute(Jedis connection) {
-        return connection.georadiusByMemberReadonly(key, member, radius, unit, param);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit, param), key);
   }
 
   @Override
   public List<Long> bitfield(final String key, final String... arguments) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Long> execute(Jedis connection) {
-        return connection.bitfield(key, arguments);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.bitfield(key, arguments), key);
   }
 
   @Override
   public List<Long> bitfieldReadonly(final String key, final String... arguments) {
-    return new JedisClusterCommand<List<Long>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Long> execute(Jedis connection) {
-        return connection.bitfieldReadonly(key, arguments);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.bitfieldReadonly(key, arguments), key);
   }
 
   @Override
   public Long hstrlen(final String key, final String field) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.hstrlen(key, field);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.hstrlen(key, field), key);
   }
 
-  
+
   @Override
   public Long memoryUsage(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.memoryUsage(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.memoryUsage(key), key);
   }
-  
+
   @Override
   public Long memoryUsage(final String key, final int samples) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.memoryUsage(key, samples);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.memoryUsage(key, samples), key);
   }
-  
+
   @Override
   public StreamEntryID xadd(final String key, final StreamEntryID id, final Map<String, String> hash) {
-    return new JedisClusterCommand<StreamEntryID>(connectionHandler, maxAttempts) {
-      @Override
-      public StreamEntryID execute(Jedis connection) {
-        return connection.xadd(key, id, hash);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xadd(key, id, hash), key);
   }
 
   @Override
   public StreamEntryID xadd(final String key, final StreamEntryID id, final Map<String, String> hash, final long maxLen, final boolean approximateLength) {
-    return new JedisClusterCommand<StreamEntryID>(connectionHandler, maxAttempts) {
-      @Override
-      public StreamEntryID execute(Jedis connection) {
-        return connection.xadd(key, id, hash, maxLen, approximateLength);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xadd(key, id, hash, maxLen, approximateLength), key);
   }
 
   @Override
   public Long xlen(final String key) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xlen(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xlen(key), key);
   }
 
   @Override
   public List<StreamEntry> xrange(final String key, final StreamEntryID start, final StreamEntryID end, final int count) {
-    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<StreamEntry> execute(Jedis connection) {
-        return connection.xrange(key, start, end, count);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xrange(key, start, end, count), key);
   }
 
   @Override
   public List<StreamEntry> xrevrange(final String key, final StreamEntryID end, final StreamEntryID start, final int count) {
-    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<StreamEntry> execute(Jedis connection) {
-        return connection.xrevrange(key, end, start, count);
-      }
-    }.run(key);  
+    return retryer.run((connection) -> connection.xrevrange(key, end, start, count), key);
   }
 
   @Override
@@ -2338,149 +1316,79 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
     for(int i=0; i<streams.length; ++i) {
       keys[i] = streams[i].getKey();
     }
-    
-    return new JedisClusterCommand<List<Entry<String, List<StreamEntry>>>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Entry<String, List<StreamEntry>>> execute(Jedis connection) {
-        return connection.xread(count, block, streams);
-      }
-    }.run(keys.length, keys);  
+
+    return retryer.run((connection) -> connection.xread(count, block, streams), keys.length, keys);
   }
 
   @Override
   public Long xack(final String key, final String group, final StreamEntryID... ids) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xack(key, group, ids);
-      }
-    }.run(key);   
+    return retryer.run((connection) -> connection.xack(key, group, ids), key);
   }
 
   @Override
   public String xgroupCreate(final String key, final String groupname, final StreamEntryID id, final boolean makeStream) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.xgroupCreate(key, groupname, id, makeStream);
-      }
-    }.run(key);  
+    return retryer.run((connection) -> connection.xgroupCreate(key, groupname, id, makeStream), key);
   }
 
   @Override
   public String xgroupSetID(final String key, final String groupname, final StreamEntryID id) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.xgroupSetID(key, groupname, id);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xgroupSetID(key, groupname, id), key);
   }
 
   @Override
   public Long xgroupDestroy(final String key, final String groupname) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xgroupDestroy(key, groupname);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xgroupDestroy(key, groupname), key);
   }
 
   @Override
   public Long xgroupDelConsumer(final String key, final String groupname, final String consumername) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xgroupDelConsumer(key, groupname, consumername);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xgroupDelConsumer(key, groupname, consumername), key);
   }
 
   @Override
   public List<Entry<String, List<StreamEntry>>> xreadGroup(final String groupname, final String consumer, final int count, final long block,
       final boolean noAck, final Entry<String, StreamEntryID>... streams) {
-    
+
     String[] keys = new String[streams.length];
     for(int i=0; i<streams.length; ++i) {
       keys[i] = streams[i].getKey();
     }
-    
-    return new JedisClusterCommand<List<Entry<String, List<StreamEntry>>>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<Entry<String, List<StreamEntry>>> execute(Jedis connection) {
-        return connection.xreadGroup(groupname, consumer, count, block, noAck, streams);
-      }
-    }.run(keys.length, keys);
+
+    return retryer.run((connection) -> connection.xreadGroup(groupname, consumer, count, block, noAck, streams), keys.length, keys);
   }
 
   @Override
   public List<StreamPendingEntry> xpending(final String key, final String groupname, final StreamEntryID start, final StreamEntryID end, final int count,
       final String consumername) {
-    return new JedisClusterCommand<List<StreamPendingEntry>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<StreamPendingEntry> execute(Jedis connection) {
-        return connection.xpending(key, groupname, start, end, count, consumername);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xpending(key, groupname, start, end, count, consumername), key);
   }
 
   @Override
   public Long xdel(final String key, final StreamEntryID... ids) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xdel(key, ids);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xdel(key, ids), key);
   }
 
   @Override
   public Long xtrim(final  String key, final long maxLen, final boolean approximateLength) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.xtrim(key, maxLen, approximateLength);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xtrim(key, maxLen, approximateLength), key);
   }
 
   @Override
   public List<StreamEntry> xclaim(final String key, final String group, final String consumername, final long minIdleTime, final long newIdleTime,
       final int retries, final boolean force, final StreamEntryID... ids) {
-    return new JedisClusterCommand<List<StreamEntry>>(connectionHandler, maxAttempts) {
-      @Override
-      public List<StreamEntry> execute(Jedis connection) {
-        return connection.xclaim(key, group, consumername, minIdleTime, newIdleTime, retries, force, ids);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.xclaim(key, group, consumername, minIdleTime, newIdleTime, retries, force, ids), key);
   }
 
   public Long waitReplicas(final String key, final int replicas, final long timeout) {
-    return new JedisClusterCommand<Long>(connectionHandler, maxAttempts) {
-      @Override
-      public Long execute(Jedis connection) {
-        return connection.waitReplicas(replicas, timeout);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.waitReplicas(replicas, timeout), key);
   }
 
   public Object sendCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection){
-        return connection.sendCommand(cmd, args);
-      }
-    }.run(sampleKey);
+    return retryer.run((connection) -> connection.sendCommand(cmd, args), sampleKey);
   }
 
   public Object sendBlockingCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
-    return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
-      @Override
-      public Object execute(Jedis connection){
-        return connection.sendBlockingCommand(cmd, args);
-      }
-    }.run(sampleKey);
+    return retryer.run((connection) -> connection.sendBlockingCommand(cmd, args), sampleKey);
   }
 
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -1,6 +1,8 @@
 package redis.clients.jedis;
 
+import java.util.function.Function;
 import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.GeoRadiusStoreParam;
 import redis.clients.jedis.params.SetParams;
@@ -10,6 +12,7 @@ import redis.clients.jedis.params.LPosParams;
 import redis.clients.jedis.commands.JedisClusterCommands;
 import redis.clients.jedis.commands.JedisClusterScriptingCommands;
 import redis.clients.jedis.commands.MultiKeyJedisClusterCommands;
+import redis.clients.jedis.util.JedisClusterCRC16;
 import redis.clients.jedis.util.JedisClusterHashTagUtil;
 import redis.clients.jedis.util.KeyMergeUtil;
 
@@ -27,8 +30,8 @@ import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 /**
  * Interface to a Jedis cluster.
  * <p/>
- * Uses {@link DefaultRetryer}, or you can inject your own using
- * {@link JedisCluster#JedisCluster(Retryer)}.
+ * Uses {@link DefaultRetryer}, or you can inject your own using {@link
+ * JedisCluster#JedisCluster(JedisClusterConnectionHandler, Retryer)}.
  *
  * @see BinaryJedisCluster
  */
@@ -193,685 +196,718 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
             ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMap);
   }
 
-  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout, int infiniteSoTimeout,
-      int maxAttempts, String user, String password, String clientName, final GenericObjectPoolConfig poolConfig,
+  public JedisCluster(Set<HostAndPort> jedisClusterNode, int connectionTimeout, int soTimeout,
+      int infiniteSoTimeout,
+      int maxAttempts, String user, String password, String clientName,
+      final GenericObjectPoolConfig poolConfig,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap hostAndPortMap) {
-    super(jedisClusterNode, connectionTimeout, soTimeout, infiniteSoTimeout, maxAttempts, user, password,
-        clientName, poolConfig, ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMap);
+    super(jedisClusterNode, connectionTimeout, soTimeout, infiniteSoTimeout, maxAttempts, user,
+        password,
+        clientName, poolConfig, ssl, sslSocketFactory, sslParameters, hostnameVerifier,
+        hostAndPortMap);
   }
 
-  public JedisCluster(Retryer retryer) {
-    super(retryer);
+  public JedisCluster(JedisClusterConnectionHandler connectionHandler, Retryer retryer) {
+    super(connectionHandler, retryer);
   }
+
+  public final <R> R run(Function<Jedis, R> command, String key) {
+    return retryer.runWithRetries(connectionHandler, JedisClusterCRC16.getSlot(key), command);
+  }
+
+  public final <R> R run(Function<Jedis, R> command, int keyCount, String... keys) {
+    if (keys == null || keys.length == 0) {
+      throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
+    }
+
+    // For multiple keys, only execute if they all share the same connection slot.
+    int slot = JedisClusterCRC16.getSlot(keys[0]);
+    if (keys.length > 1) {
+      for (int i = 1; i < keyCount; i++) {
+        int nextSlot = JedisClusterCRC16.getSlot(keys[i]);
+        if (slot != nextSlot) {
+          throw new JedisClusterOperationException("No way to dispatch this command to Redis "
+              + "Cluster because keys have different slots.");
+        }
+      }
+    }
+
+    return retryer.runWithRetries(connectionHandler, slot, command);
+  }
+
 
   @Override
   public String set(final String key, final String value) {
-    return retryer.run((connection) -> connection.set(key, value), key);
+    return run((connection) -> connection.set(key, value), key);
   }
 
   @Override
   public String set(final String key, final String value, final SetParams params) {
-    return retryer.run((connection) -> connection.set(key, value, params), key);
+    return run((connection) -> connection.set(key, value, params), key);
   }
 
   @Override
   public String get(final String key) {
-    return retryer.run((connection) -> connection.get(key), key);
+    return run((connection) -> connection.get(key), key);
   }
 
   @Override
   public Boolean exists(final String key) {
-    return retryer.run((connection) -> connection.exists(key), key);
+    return run((connection) -> connection.exists(key), key);
   }
 
   @Override
   public Long exists(final String... keys) {
-    return retryer.run((connection) -> connection.exists(keys), keys.length, keys);
+    return run((connection) -> connection.exists(keys), keys.length, keys);
   }
 
   @Override
   public Long persist(final String key) {
-    return retryer.run((connection) -> connection.persist(key), key);
+    return run((connection) -> connection.persist(key), key);
   }
 
   @Override
   public String type(final String key) {
-    return retryer.run((connection) -> connection.type(key), key);
+    return run((connection) -> connection.type(key), key);
   }
 
   @Override
   public byte[] dump(final String key) {
-    return retryer.run((connection) -> connection.dump(key), key);
+    return run((connection) -> connection.dump(key), key);
   }
 
   @Override
   public String restore(final String key, final int ttl, final byte[] serializedValue) {
-    return retryer.run((connection) -> connection.restore(key, ttl, serializedValue), key);
+    return run((connection) -> connection.restore(key, ttl, serializedValue), key);
   }
 
   @Override
   public Long expire(final String key, final int seconds) {
-    return retryer.run((connection) -> connection.expire(key, seconds), key);
+    return run((connection) -> connection.expire(key, seconds), key);
   }
 
   @Override
   public Long pexpire(final String key, final long milliseconds) {
-    return retryer.run((connection) -> connection.pexpire(key, milliseconds), key);
+    return run((connection) -> connection.pexpire(key, milliseconds), key);
   }
 
   @Override
   public Long expireAt(final String key, final long unixTime) {
-    return retryer.run((connection) -> connection.expireAt(key, unixTime), key);
+    return run((connection) -> connection.expireAt(key, unixTime), key);
   }
 
   @Override
   public Long pexpireAt(final String key, final long millisecondsTimestamp) {
-    return retryer.run((connection) -> connection.pexpireAt(key, millisecondsTimestamp), key);
+    return run((connection) -> connection.pexpireAt(key, millisecondsTimestamp), key);
   }
 
   @Override
   public Long ttl(final String key) {
-    return retryer.run((connection) -> connection.ttl(key), key);
+    return run((connection) -> connection.ttl(key), key);
   }
 
   @Override
   public Long pttl(final String key) {
-    return retryer.run((connection) -> connection.pttl(key), key);
+    return run((connection) -> connection.pttl(key), key);
   }
 
   @Override
   public Long touch(final String key) {
-    return retryer.run((connection) -> connection.touch(key), key);
+    return run((connection) -> connection.touch(key), key);
   }
 
   @Override
   public Long touch(final String... keys) {
-    return retryer.run((connection) -> connection.touch(keys), keys.length, keys);
+    return run((connection) -> connection.touch(keys), keys.length, keys);
   }
 
   @Override
   public Boolean setbit(final String key, final long offset, final boolean value) {
-    return retryer.run((connection) -> connection.setbit(key, offset, value), key);
+    return run((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean setbit(final String key, final long offset, final String value) {
-    return retryer.run((connection) -> connection.setbit(key, offset, value), key);
+    return run((connection) -> connection.setbit(key, offset, value), key);
   }
 
   @Override
   public Boolean getbit(final String key, final long offset) {
-    return retryer.run((connection) -> connection.getbit(key, offset), key);
+    return run((connection) -> connection.getbit(key, offset), key);
   }
 
   @Override
   public Long setrange(final String key, final long offset, final String value) {
-    return retryer.run((connection) -> connection.setrange(key, offset, value), key);
+    return run((connection) -> connection.setrange(key, offset, value), key);
   }
 
   @Override
   public String getrange(final String key, final long startOffset, final long endOffset) {
-    return retryer.run((connection) -> connection.getrange(key, startOffset, endOffset), key);
+    return run((connection) -> connection.getrange(key, startOffset, endOffset), key);
   }
 
   @Override
   public String getSet(final String key, final String value) {
-    return retryer.run((connection) -> connection.getSet(key, value), key);
+    return run((connection) -> connection.getSet(key, value), key);
   }
 
   @Override
   public Long setnx(final String key, final String value) {
-    return retryer.run((connection) -> connection.setnx(key, value), key);
+    return run((connection) -> connection.setnx(key, value), key);
   }
 
   @Override
   public String setex(final String key, final int seconds, final String value) {
-    return retryer.run((connection) -> connection.setex(key, seconds, value), key);
+    return run((connection) -> connection.setex(key, seconds, value), key);
   }
 
   @Override
   public String psetex(final String key, final long milliseconds, final String value) {
-    return retryer.run((connection) -> connection.psetex(key, milliseconds, value), key);
+    return run((connection) -> connection.psetex(key, milliseconds, value), key);
   }
 
   @Override
   public Long decrBy(final String key, final long decrement) {
-    return retryer.run((connection) -> connection.decrBy(key, decrement), key);
+    return run((connection) -> connection.decrBy(key, decrement), key);
   }
 
   @Override
   public Long decr(final String key) {
-    return retryer.run((connection) -> connection.decr(key), key);
+    return run((connection) -> connection.decr(key), key);
   }
 
   @Override
   public Long incrBy(final String key, final long increment) {
-    return retryer.run((connection) -> connection.incrBy(key, increment), key);
+    return run((connection) -> connection.incrBy(key, increment), key);
   }
 
   @Override
   public Double incrByFloat(final String key, final double increment) {
-    return retryer.run((connection) -> connection.incrByFloat(key, increment), key);
+    return run((connection) -> connection.incrByFloat(key, increment), key);
   }
 
   @Override
   public Long incr(final String key) {
-    return retryer.run((connection) -> connection.incr(key), key);
+    return run((connection) -> connection.incr(key), key);
   }
 
   @Override
   public Long append(final String key, final String value) {
-    return retryer.run((connection) -> connection.append(key, value), key);
+    return run((connection) -> connection.append(key, value), key);
   }
 
   @Override
   public String substr(final String key, final int start, final int end) {
-    return retryer.run((connection) -> connection.substr(key, start, end), key);
+    return run((connection) -> connection.substr(key, start, end), key);
   }
 
   @Override
   public Long hset(final String key, final String field, final String value) {
-    return retryer.run((connection) -> connection.hset(key, field, value), key);
+    return run((connection) -> connection.hset(key, field, value), key);
   }
 
   @Override
   public Long hset(final String key, final Map<String, String> hash) {
-    return retryer.run((connection) -> connection.hset(key, hash), key);
+    return run((connection) -> connection.hset(key, hash), key);
   }
 
   @Override
   public String hget(final String key, final String field) {
-    return retryer.run((connection) -> connection.hget(key, field), key);
+    return run((connection) -> connection.hget(key, field), key);
   }
 
   @Override
   public Long hsetnx(final String key, final String field, final String value) {
-    return retryer.run((connection) -> connection.hsetnx(key, field, value), key);
+    return run((connection) -> connection.hsetnx(key, field, value), key);
   }
 
   @Override
   public String hmset(final String key, final Map<String, String> hash) {
-    return retryer.run((connection) -> connection.hmset(key, hash), key);
+    return run((connection) -> connection.hmset(key, hash), key);
   }
 
   @Override
   public List<String> hmget(final String key, final String... fields) {
-    return retryer.run((connection) -> connection.hmget(key, fields), key);
+    return run((connection) -> connection.hmget(key, fields), key);
   }
 
   @Override
   public Long hincrBy(final String key, final String field, final long value) {
-    return retryer.run((connection) -> connection.hincrBy(key, field, value), key);
+    return run((connection) -> connection.hincrBy(key, field, value), key);
   }
 
   @Override
   public Double hincrByFloat(final String key, final String field, final double value) {
-    return retryer.run((connection) -> connection.hincrByFloat(key, field, value), key);
+    return run((connection) -> connection.hincrByFloat(key, field, value), key);
   }
 
   @Override
   public Boolean hexists(final String key, final String field) {
-    return retryer.run((connection) -> connection.hexists(key, field), key);
+    return run((connection) -> connection.hexists(key, field), key);
   }
 
   @Override
   public Long hdel(final String key, final String... field) {
-    return retryer.run((connection) -> connection.hdel(key, field), key);
+    return run((connection) -> connection.hdel(key, field), key);
   }
 
   @Override
   public Long hlen(final String key) {
-    return retryer.run((connection) -> connection.hlen(key), key);
+    return run((connection) -> connection.hlen(key), key);
   }
 
   @Override
   public Set<String> hkeys(final String key) {
-    return retryer.run((connection) -> connection.hkeys(key), key);
+    return run((connection) -> connection.hkeys(key), key);
   }
 
   @Override
   public List<String> hvals(final String key) {
-    return retryer.run((connection) -> connection.hvals(key), key);
+    return run((connection) -> connection.hvals(key), key);
   }
 
   @Override
   public Map<String, String> hgetAll(final String key) {
-    return retryer.run((connection) -> connection.hgetAll(key), key);
+    return run((connection) -> connection.hgetAll(key), key);
   }
 
   @Override
   public Long rpush(final String key, final String... string) {
-    return retryer.run((connection) -> connection.rpush(key, string), key);
+    return run((connection) -> connection.rpush(key, string), key);
   }
 
   @Override
   public Long lpush(final String key, final String... string) {
-    return retryer.run((connection) -> connection.lpush(key, string), key);
+    return run((connection) -> connection.lpush(key, string), key);
   }
 
   @Override
   public Long llen(final String key) {
-    return retryer.run((connection) -> connection.llen(key), key);
+    return run((connection) -> connection.llen(key), key);
   }
 
   @Override
   public List<String> lrange(final String key, final long start, final long stop) {
-    return retryer.run((connection) -> connection.lrange(key, start, stop), key);
+    return run((connection) -> connection.lrange(key, start, stop), key);
   }
 
   @Override
   public String ltrim(final String key, final long start, final long stop) {
-    return retryer.run((connection) -> connection.ltrim(key, start, stop), key);
+    return run((connection) -> connection.ltrim(key, start, stop), key);
   }
 
   @Override
   public String lindex(final String key, final long index) {
-    return retryer.run((connection) -> connection.lindex(key, index), key);
+    return run((connection) -> connection.lindex(key, index), key);
   }
 
   @Override
   public String lset(final String key, final long index, final String value) {
-    return retryer.run((connection) -> connection.lset(key, index, value), key);
+    return run((connection) -> connection.lset(key, index, value), key);
   }
 
   @Override
   public Long lrem(final String key, final long count, final String value) {
-    return retryer.run((connection) -> connection.lrem(key, count, value), key);
+    return run((connection) -> connection.lrem(key, count, value), key);
   }
 
   @Override
   public String lpop(final String key) {
-    return retryer.run((connection) -> connection.lpop(key), key);
+    return run((connection) -> connection.lpop(key), key);
   }
 
   @Override
   public List<String> lpop(final String key, final int count) {
-    return retryer.run((connection) -> connection.lpop(key, count), key);
+    return run((connection) -> connection.lpop(key, count), key);
   }
 
   @Override
   public Long lpos(final String key, final String element) {
-    return retryer.run((connection) -> connection.lpos(key, element), key);
+    return run((connection) -> connection.lpos(key, element), key);
   }
 
   @Override
   public Long lpos(final String key, final String element, final LPosParams params) {
-    return retryer.run((connection) -> connection.lpos(key, element, params), key);
+    return run((connection) -> connection.lpos(key, element, params), key);
   }
 
   @Override
   public List<Long> lpos(final String key, final String element, final LPosParams params, final long count) {
-    return retryer.run((connection) -> connection.lpos(key, element, params, count), key);
+    return run((connection) -> connection.lpos(key, element, params, count), key);
   }
 
   @Override
   public String rpop(final String key) {
-    return retryer.run((connection) -> connection.rpop(key), key);
+    return run((connection) -> connection.rpop(key), key);
   }
 
   @Override
   public List<String> rpop(final String key, final int count) {
-    return retryer.run((connection) -> connection.rpop(key, count), key);
+    return run((connection) -> connection.rpop(key, count), key);
   }
 
   @Override
   public Long sadd(final String key, final String... member) {
-    return retryer.run((connection) -> connection.sadd(key, member), key);
+    return run((connection) -> connection.sadd(key, member), key);
   }
 
   @Override
   public Set<String> smembers(final String key) {
-    return retryer.run((connection) -> connection.smembers(key), key);
+    return run((connection) -> connection.smembers(key), key);
   }
 
   @Override
   public Long srem(final String key, final String... member) {
-    return retryer.run((connection) -> connection.srem(key, member), key);
+    return run((connection) -> connection.srem(key, member), key);
   }
 
   @Override
   public String spop(final String key) {
-    return retryer.run((connection) -> connection.spop(key), key);
+    return run((connection) -> connection.spop(key), key);
   }
 
   @Override
   public Set<String> spop(final String key, final long count) {
-    return retryer.run((connection) -> connection.spop(key, count), key);
+    return run((connection) -> connection.spop(key, count), key);
   }
 
   @Override
   public Long scard(final String key) {
-    return retryer.run((connection) -> connection.scard(key), key);
+    return run((connection) -> connection.scard(key), key);
   }
 
   @Override
   public Boolean sismember(final String key, final String member) {
-    return retryer.run((connection) -> connection.sismember(key, member), key);
+    return run((connection) -> connection.sismember(key, member), key);
   }
 
   @Override
   public List<Boolean> smismember(final String key, final String... members) {
-    return retryer.run((connection) -> connection.smismember(key, members), key);
+    return run((connection) -> connection.smismember(key, members), key);
   }
 
   @Override
   public String srandmember(final String key) {
-    return retryer.run((connection) -> connection.srandmember(key), key);
+    return run((connection) -> connection.srandmember(key), key);
   }
 
   @Override
   public List<String> srandmember(final String key, final int count) {
-    return retryer.run((connection) -> connection.srandmember(key, count), key);
+    return run((connection) -> connection.srandmember(key, count), key);
   }
 
   @Override
   public Long strlen(final String key) {
-    return retryer.run((connection) -> connection.strlen(key), key);
+    return run((connection) -> connection.strlen(key), key);
   }
 
   @Override
   public Long zadd(final String key, final double score, final String member) {
-    return retryer.run((connection) -> connection.zadd(key, score, member), key);
+    return run((connection) -> connection.zadd(key, score, member), key);
   }
 
   @Override
   public Long zadd(final String key, final double score, final String member,
       final ZAddParams params) {
-    return retryer.run((connection) -> connection.zadd(key, score, member, params), key);
+    return run((connection) -> connection.zadd(key, score, member, params), key);
   }
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers) {
-    return retryer.run((connection) -> connection.zadd(key, scoreMembers), key);
+    return run((connection) -> connection.zadd(key, scoreMembers), key);
   }
 
   @Override
   public Long zadd(final String key, final Map<String, Double> scoreMembers, final ZAddParams params) {
-    return retryer.run((connection) -> connection.zadd(key, scoreMembers, params), key);
+    return run((connection) -> connection.zadd(key, scoreMembers, params), key);
   }
 
   @Override
   public Set<String> zrange(final String key, final long start, final long stop) {
-    return retryer.run((connection) -> connection.zrange(key, start, stop), key);
+    return run((connection) -> connection.zrange(key, start, stop), key);
   }
 
   @Override
   public Long zrem(final String key, final String... members) {
-    return retryer.run((connection) -> connection.zrem(key, members), key);
+    return run((connection) -> connection.zrem(key, members), key);
   }
 
   @Override
   public Double zincrby(final String key, final double increment, final String member) {
-    return retryer.run((connection) -> connection.zincrby(key, increment, member), key);
+    return run((connection) -> connection.zincrby(key, increment, member), key);
   }
 
   @Override
   public Double zincrby(final String key, final double increment, final String member,
       final ZIncrByParams params) {
-    return retryer.run((connection) -> connection.zincrby(key, increment, member, params), key);
+    return run((connection) -> connection.zincrby(key, increment, member, params), key);
   }
 
   @Override
   public Long zrank(final String key, final String member) {
-    return retryer.run((connection) -> connection.zrank(key, member), key);
+    return run((connection) -> connection.zrank(key, member), key);
   }
 
   @Override
   public Long zrevrank(final String key, final String member) {
-    return retryer.run((connection) -> connection.zrevrank(key, member), key);
+    return run((connection) -> connection.zrevrank(key, member), key);
   }
 
   @Override
   public Set<String> zrevrange(final String key, final long start, final long stop) {
-    return retryer.run((connection) -> connection.zrevrange(key, start, stop), key);
+    return run((connection) -> connection.zrevrange(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrangeWithScores(final String key, final long start, final long stop) {
-    return retryer.run((connection) -> connection.zrangeWithScores(key, start, stop), key);
+    return run((connection) -> connection.zrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeWithScores(final String key, final long start, final long stop) {
-    return retryer.run((connection) -> connection.zrevrangeWithScores(key, start, stop), key);
+    return run((connection) -> connection.zrevrangeWithScores(key, start, stop), key);
   }
 
   @Override
   public Long zcard(final String key) {
-    return retryer.run((connection) -> connection.zcard(key), key);
+    return run((connection) -> connection.zcard(key), key);
   }
 
   @Override
   public Double zscore(final String key, final String member) {
-    return retryer.run((connection) -> connection.zscore(key, member), key);
+    return run((connection) -> connection.zscore(key, member), key);
   }
 
   @Override
   public List<Double> zmscore(final String key, final String... members) {
-    return retryer.run((connection) -> connection.zmscore(key, members), key);
+    return run((connection) -> connection.zmscore(key, members), key);
   }
 
   @Override
   public Tuple zpopmax(final String key) {
-    return retryer.run((connection) -> connection.zpopmax(key), key);
+    return run((connection) -> connection.zpopmax(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmax(final String key, final int count) {
-    return retryer.run((connection) -> connection.zpopmax(key, count), key);
+    return run((connection) -> connection.zpopmax(key, count), key);
   }
 
   @Override
   public Tuple zpopmin(final String key) {
-    return retryer.run((connection) -> connection.zpopmin(key), key);
+    return run((connection) -> connection.zpopmin(key), key);
   }
 
   @Override
   public Set<Tuple> zpopmin(final String key, final int count) {
-    return retryer.run((connection) -> connection.zpopmin(key, count), key);
+    return run((connection) -> connection.zpopmin(key, count), key);
   }
 
   @Override
   public List<String> sort(final String key) {
-    return retryer.run((connection) -> connection.sort(key), key);
+    return run((connection) -> connection.sort(key), key);
   }
 
   @Override
   public List<String> sort(final String key, final SortingParams sortingParameters) {
-    return retryer.run((connection) -> connection.sort(key, sortingParameters), key);
+    return run((connection) -> connection.sort(key, sortingParameters), key);
   }
 
   @Override
   public Long zcount(final String key, final double min, final double max) {
-    return retryer.run((connection) -> connection.zcount(key, min, max), key);
+    return run((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Long zcount(final String key, final String min, final String max) {
-    return retryer.run((connection) -> connection.zcount(key, min, max), key);
+    return run((connection) -> connection.zcount(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max) {
-    return retryer.run((connection) -> connection.zrangeByScore(key, min, max), key);
+    return run((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max) {
-    return retryer.run((connection) -> connection.zrangeByScore(key, min, max), key);
+    return run((connection) -> connection.zrangeByScore(key, min, max), key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min) {
-    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min), key);
+    return run((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final double min, final double max,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
+    return run((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min) {
-    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min), key);
+    return run((connection) -> connection.zrevrangeByScore(key, max, min), key);
   }
 
   @Override
   public Set<String> zrangeByScore(final String key, final String min, final String max,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
+    return run((connection) -> connection.zrangeByScore(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final double max, final double min,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
+    return run((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max) {
-    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
+    return run((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max, final double min) {
-    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
+    return run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final double min, final double max,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
+    return run((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count),
+        key);
   }
 
   @Override
   public Set<String> zrevrangeByScore(final String key, final String max, final String min,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
+    return run((connection) -> connection.zrevrangeByScore(key, max, min, offset, count), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max) {
-    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
+    return run((connection) -> connection.zrangeByScoreWithScores(key, min, max), key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max, final String min) {
-    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
+    return run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min), key);
   }
 
   @Override
   public Set<Tuple> zrangeByScoreWithScores(final String key, final String min, final String max,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count), key);
+    return run((connection) -> connection.zrangeByScoreWithScores(key, min, max, offset, count),
+        key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final double max,
       final double min, final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
+    return run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count),
+        key);
   }
 
   @Override
   public Set<Tuple> zrevrangeByScoreWithScores(final String key, final String max,
       final String min, final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count), key);
+    return run((connection) -> connection.zrevrangeByScoreWithScores(key, max, min, offset, count),
+        key);
   }
 
   @Override
   public Long zremrangeByRank(final String key, final long start, final long stop) {
-    return retryer.run((connection) -> connection.zremrangeByRank(key, start, stop), key);
+    return run((connection) -> connection.zremrangeByRank(key, start, stop), key);
   }
 
   @Override
   public Long zremrangeByScore(final String key, final double min, final double max) {
-    return retryer.run((connection) -> connection.zremrangeByScore(key, min, max), key);
+    return run((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long zremrangeByScore(final String key, final String min, final String max) {
-    return retryer.run((connection) -> connection.zremrangeByScore(key, min, max), key);
+    return run((connection) -> connection.zremrangeByScore(key, min, max), key);
   }
 
   @Override
   public Long zlexcount(final String key, final String min, final String max) {
-    return retryer.run((connection) -> connection.zlexcount(key, min, max), key);
+    return run((connection) -> connection.zlexcount(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max) {
-    return retryer.run((connection) -> connection.zrangeByLex(key, min, max), key);
+    return run((connection) -> connection.zrangeByLex(key, min, max), key);
   }
 
   @Override
   public Set<String> zrangeByLex(final String key, final String min, final String max,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrangeByLex(key, min, max, offset, count), key);
+    return run((connection) -> connection.zrangeByLex(key, min, max, offset, count), key);
   }
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min) {
-    return retryer.run((connection) -> connection.zrevrangeByLex(key, max, min), key);
+    return run((connection) -> connection.zrevrangeByLex(key, max, min), key);
   }
 
   @Override
   public Set<String> zrevrangeByLex(final String key, final String max, final String min,
       final int offset, final int count) {
-    return retryer.run((connection) -> connection.zrevrangeByLex(key, max, min, offset, count), key);
+    return run((connection) -> connection.zrevrangeByLex(key, max, min, offset, count), key);
   }
 
   @Override
   public Long zremrangeByLex(final String key, final String min, final String max) {
-    return retryer.run((connection) -> connection.zremrangeByLex(key, min, max), key);
+    return run((connection) -> connection.zremrangeByLex(key, min, max), key);
   }
 
   @Override
   public Long linsert(final String key, final ListPosition where, final String pivot,
       final String value) {
-    return retryer.run((connection) -> connection.linsert(key, where, pivot, value), key);
+    return run((connection) -> connection.linsert(key, where, pivot, value), key);
   }
 
   @Override
   public Long lpushx(final String key, final String... string) {
-    return retryer.run((connection) -> connection.lpushx(key, string), key);
+    return run((connection) -> connection.lpushx(key, string), key);
   }
 
   @Override
   public Long rpushx(final String key, final String... string) {
-    return retryer.run((connection) -> connection.rpushx(key, string), key);
+    return run((connection) -> connection.rpushx(key, string), key);
   }
 
   @Override
   public Long del(final String key) {
-    return retryer.run((connection) -> connection.del(key), key);
+    return run((connection) -> connection.del(key), key);
   }
 
   @Override
   public Long unlink(final String key) {
-    return retryer.run((connection) -> connection.unlink(key), key);
+    return run((connection) -> connection.unlink(key), key);
   }
 
   @Override
   public Long unlink(final String... keys) {
-    return retryer.run((connection) -> connection.unlink(keys), keys.length, keys);
+    return run((connection) -> connection.unlink(keys), keys.length, keys);
   }
 
   @Override
   public String echo(final String string) {
     // note that it'll be run from arbitrary node
-    return retryer.run((connection) -> connection.echo(string), string);
+    return run((connection) -> connection.echo(string), string);
   }
 
   @Override
   public Long bitcount(final String key) {
-    return retryer.run((connection) -> connection.bitcount(key), key);
+    return run((connection) -> connection.bitcount(key), key);
   }
 
   @Override
   public Long bitcount(final String key, final long start, final long end) {
-    return retryer.run((connection) -> connection.bitcount(key, start, end), key);
+    return run((connection) -> connection.bitcount(key, start, end), key);
   }
 
   @Override
@@ -884,7 +920,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       throw new IllegalArgumentException(this.getClass().getSimpleName()
           + " only supports KEYS commands with patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
-    return retryer.run((connection) -> connection.keys(pattern), pattern);
+    return run((connection) -> connection.keys(pattern), pattern);
   }
 
   @Override
@@ -902,63 +938,63 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
           + " only supports SCAN commands with MATCH patterns containing hash-tags ( curly-brackets enclosed strings )");
     }
 
-    return retryer.run((connection) -> connection.scan(cursor, params), matchPattern);
+    return run((connection) -> connection.scan(cursor, params), matchPattern);
   }
 
   @Override
   public ScanResult<Entry<String, String>> hscan(final String key, final String cursor) {
-    return retryer.run((connection) -> connection.hscan(key, cursor), key);
+    return run((connection) -> connection.hscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<String> sscan(final String key, final String cursor) {
-    return retryer.run((connection) -> connection.sscan(key, cursor), key);
+    return run((connection) -> connection.sscan(key, cursor), key);
   }
 
   @Override
   public ScanResult<Tuple> zscan(final String key, final String cursor) {
-    return retryer.run((connection) -> connection.zscan(key, cursor), key);
+    return run((connection) -> connection.zscan(key, cursor), key);
   }
 
   @Override
   public Long pfadd(final String key, final String... elements) {
-    return retryer.run((connection) -> connection.pfadd(key, elements), key);
+    return run((connection) -> connection.pfadd(key, elements), key);
   }
 
   @Override
   public long pfcount(final String key) {
-    return retryer.run((connection) -> connection.pfcount(key), key);
+    return run((connection) -> connection.pfcount(key), key);
   }
 
   @Override
   public List<String> blpop(final int timeout, final String key) {
-    return retryer.run((connection) -> connection.blpop(timeout, key), key);
+    return run((connection) -> connection.blpop(timeout, key), key);
   }
 
   @Override
   public List<String> brpop(final int timeout, final String key) {
-    return retryer.run((connection) -> connection.brpop(timeout, key), key);
+    return run((connection) -> connection.brpop(timeout, key), key);
   }
 
   @Override
   public Long del(final String... keys) {
-    return retryer.run((connection) -> connection.del(keys), keys.length, keys);
+    return run((connection) -> connection.del(keys), keys.length, keys);
   }
 
   @Override
   public List<String> blpop(final int timeout, final String... keys) {
-    return retryer.run((connection) -> connection.blpop(timeout, keys), keys.length, keys);
+    return run((connection) -> connection.blpop(timeout, keys), keys.length, keys);
 
   }
 
   @Override
   public List<String> brpop(final int timeout, final String... keys) {
-    return retryer.run((connection) -> connection.brpop(timeout, keys), keys.length, keys);
+    return run((connection) -> connection.brpop(timeout, keys), keys.length, keys);
   }
 
   @Override
   public List<String> mget(final String... keys) {
-    return retryer.run((connection) -> connection.mget(keys), keys.length, keys);
+    return run((connection) -> connection.mget(keys), keys.length, keys);
   }
 
   @Override
@@ -969,7 +1005,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return retryer.run((connection) -> connection.mset(keysvalues), keys.length, keys);
+    return run((connection) -> connection.mset(keysvalues), keys.length, keys);
   }
 
   @Override
@@ -980,116 +1016,119 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[keyIdx] = keysvalues[keyIdx * 2];
     }
 
-    return retryer.run((connection) -> connection.msetnx(keysvalues), keys.length, keys);
+    return run((connection) -> connection.msetnx(keysvalues), keys.length, keys);
   }
 
   @Override
   public String rename(final String oldkey, final String newkey) {
-    return retryer.run((connection) -> connection.rename(oldkey, newkey), 2, oldkey, newkey);
+    return run((connection) -> connection.rename(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public Long renamenx(final String oldkey, final String newkey) {
-    return retryer.run((connection) -> connection.renamenx(oldkey, newkey), 2, oldkey, newkey);
+    return run((connection) -> connection.renamenx(oldkey, newkey), 2, oldkey, newkey);
   }
 
   @Override
   public String rpoplpush(final String srckey, final String dstkey) {
-    return retryer.run((connection) -> connection.rpoplpush(srckey, dstkey), 2, srckey, dstkey);
+    return run((connection) -> connection.rpoplpush(srckey, dstkey), 2, srckey, dstkey);
   }
 
   @Override
   public Set<String> sdiff(final String... keys) {
-    return retryer.run((connection) -> connection.sdiff(keys), keys.length, keys);
+    return run((connection) -> connection.sdiff(keys), keys.length, keys);
   }
 
   @Override
   public Long sdiffstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return retryer.run((connection) -> connection.sdiffstore(dstkey, keys), mergedKeys.length, mergedKeys);
+    return run((connection) -> connection.sdiffstore(dstkey, keys), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public Set<String> sinter(final String... keys) {
-    return retryer.run((connection) -> connection.sinter(keys), keys.length, keys);
+    return run((connection) -> connection.sinter(keys), keys.length, keys);
   }
 
   @Override
   public Long sinterstore(final String dstkey, final String... keys) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return retryer.run((connection) -> connection.sinterstore(dstkey, keys), mergedKeys.length, mergedKeys);
+    return run((connection) -> connection.sinterstore(dstkey, keys), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public Long smove(final String srckey, final String dstkey, final String member) {
-    return retryer.run((connection) -> connection.smove(srckey, dstkey, member), 2, srckey, dstkey);
+    return run((connection) -> connection.smove(srckey, dstkey, member), 2, srckey, dstkey);
   }
 
   @Override
   public Long sort(final String key, final SortingParams sortingParameters, final String dstkey) {
-    return retryer.run((connection) -> connection.sort(key, sortingParameters, dstkey), 2, key, dstkey);
+    return run((connection) -> connection.sort(key, sortingParameters, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Long sort(final String key, final String dstkey) {
-    return retryer.run((connection) -> connection.sort(key, dstkey), 2, key, dstkey);
+    return run((connection) -> connection.sort(key, dstkey), 2, key, dstkey);
   }
 
   @Override
   public Set<String> sunion(final String... keys) {
-    return retryer.run((connection) -> connection.sunion(keys), keys.length, keys);
+    return run((connection) -> connection.sunion(keys), keys.length, keys);
   }
 
   @Override
   public Long sunionstore(final String dstkey, final String... keys) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, keys);
 
-    return retryer.run((connection) -> connection.sunionstore(dstkey, keys), wholeKeys.length, wholeKeys);
+    return run((connection) -> connection.sunionstore(dstkey, keys), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final String dstkey, final String... sets) {
     String[] wholeKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.run((connection) -> connection.zinterstore(dstkey, sets), wholeKeys.length, wholeKeys);
+    return run((connection) -> connection.zinterstore(dstkey, sets), wholeKeys.length, wholeKeys);
   }
 
   @Override
   public Long zinterstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.run((connection) -> connection.zinterstore(dstkey, params, sets), mergedKeys.length, mergedKeys);
+    return run((connection) -> connection.zinterstore(dstkey, params, sets), mergedKeys.length,
+        mergedKeys);
   }
 
   @Override
   public Long zunionstore(final String dstkey, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.run((connection) -> connection.zunionstore(dstkey, sets), mergedKeys.length, mergedKeys);
+    return run((connection) -> connection.zunionstore(dstkey, sets), mergedKeys.length, mergedKeys);
   }
 
   @Override
   public Long zunionstore(final String dstkey, final ZParams params, final String... sets) {
     String[] mergedKeys = KeyMergeUtil.merge(dstkey, sets);
 
-    return retryer.run((connection) -> connection.zunionstore(dstkey, params, sets), mergedKeys.length, mergedKeys);
+    return run((connection) -> connection.zunionstore(dstkey, params, sets), mergedKeys.length,
+        mergedKeys);
   }
 
   @Override
   public String brpoplpush(final String source, final String destination, final int timeout) {
-    return retryer.run((connection) -> connection.brpoplpush(source, destination, timeout), 2, source, destination);
+    return run((connection) -> connection.brpoplpush(source, destination, timeout), 2, source,
+        destination);
   }
 
   @Override
   public Long publish(final String channel, final String message) {
-    return retryer.runWithRetries((connection) -> connection.publish(channel, message));
+    return retryer.runWithRetries(connectionHandler, (connection) -> connection.publish(channel, message));
   }
 
   @Override
   public void subscribe(final JedisPubSub jedisPubSub, final String... channels) {
-    retryer.runWithRetries((connection) -> {
+    retryer.runWithRetries(connectionHandler, (connection) -> {
       connection.subscribe(jedisPubSub, channels);
       return null;
     });
@@ -1097,7 +1136,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public void psubscribe(final JedisPubSub jedisPubSub, final String... patterns) {
-    retryer.runWithRetries((connection) -> {
+    retryer.runWithRetries(connectionHandler, (connection) -> {
       connection.psubscribe(jedisPubSub, patterns);
       return null;
     });
@@ -1107,219 +1146,233 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   public Long bitop(final BitOP op, final String destKey, final String... srcKeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destKey, srcKeys);
 
-    return retryer.run((connection) -> connection.bitop(op, destKey, srcKeys), mergedKeys.length, mergedKeys);
+    return run((connection) -> connection.bitop(op, destKey, srcKeys), mergedKeys.length,
+        mergedKeys);
   }
 
   @Override
   public String pfmerge(final String destkey, final String... sourcekeys) {
     String[] mergedKeys = KeyMergeUtil.merge(destkey, sourcekeys);
 
-    return retryer.run((connection) -> connection.pfmerge(destkey, sourcekeys), mergedKeys.length, mergedKeys);
+    return run((connection) -> connection.pfmerge(destkey, sourcekeys), mergedKeys.length,
+        mergedKeys);
   }
 
   @Override
   public long pfcount(final String... keys) {
-    return retryer.run((connection) -> connection.pfcount(keys), keys.length, keys);
+    return run((connection) -> connection.pfcount(keys), keys.length, keys);
   }
 
   @Override
   public Object eval(final String script, final int keyCount, final String... params) {
-    return retryer.run((connection) -> connection.eval(script, keyCount, params), keyCount, params);
+    return run((connection) -> connection.eval(script, keyCount, params), keyCount, params);
   }
 
   @Override
   public Object eval(final String script, final String sampleKey) {
-    return retryer.run((connection) -> connection.eval(script), sampleKey);
+    return run((connection) -> connection.eval(script), sampleKey);
   }
 
   @Override
   public Object eval(final String script, final List<String> keys, final List<String> args) {
-    return retryer.run((connection) -> connection.eval(script, keys, args), keys.size(), keys.toArray(new String[keys.size()]));
+    return run((connection) -> connection.eval(script, keys, args), keys.size(),
+        keys.toArray(new String[keys.size()]));
   }
 
   @Override
   public Object evalsha(final String sha1, final int keyCount, final String... params) {
-    return retryer.run((connection) -> connection.evalsha(sha1, keyCount, params), keyCount, params);
+    return run((connection) -> connection.evalsha(sha1, keyCount, params), keyCount, params);
   }
 
   @Override
   public Object evalsha(final String sha1, final List<String> keys, final List<String> args) {
-    return retryer.run((connection) -> connection.evalsha(sha1, keys, args), keys.size(), keys.toArray(new String[keys.size()]));
+    return run((connection) -> connection.evalsha(sha1, keys, args), keys.size(),
+        keys.toArray(new String[keys.size()]));
   }
 
   @Override
   public Object evalsha(final String sha1, final String sampleKey) {
-    return retryer.run((connection) -> connection.evalsha(sha1), sampleKey);
+    return run((connection) -> connection.evalsha(sha1), sampleKey);
   }
 
   @Override
   public Boolean scriptExists(final String sha1, final String sampleKey) {
-    return retryer.run((connection) -> connection.scriptExists(sha1), sampleKey);
+    return run((connection) -> connection.scriptExists(sha1), sampleKey);
   }
 
   @Override
   public List<Boolean> scriptExists(final String sampleKey, final String... sha1) {
-    return retryer.run((connection) -> connection.scriptExists(sha1), sampleKey);
+    return run((connection) -> connection.scriptExists(sha1), sampleKey);
   }
 
   @Override
   public String scriptLoad(final String script, final String sampleKey) {
-    return retryer.run((connection) -> connection.scriptLoad(script), sampleKey);
+    return run((connection) -> connection.scriptLoad(script), sampleKey);
   }
 
   @Override
   public String scriptFlush(final String sampleKey) {
-    return retryer.run(BinaryJedis::scriptFlush, sampleKey);
+    return run(BinaryJedis::scriptFlush, sampleKey);
   }
 
   @Override
   public String scriptKill(final String sampleKey) {
-    return retryer.run(BinaryJedis::scriptKill, sampleKey);
+    return run(BinaryJedis::scriptKill, sampleKey);
   }
 
   @Override
   public Long geoadd(final String key, final double longitude, final double latitude,
       final String member) {
-    return retryer.run((connection) -> connection.geoadd(key, longitude, latitude, member), key);
+    return run((connection) -> connection.geoadd(key, longitude, latitude, member), key);
   }
 
   @Override
   public Long geoadd(final String key, final Map<String, GeoCoordinate> memberCoordinateMap) {
-    return retryer.run((connection) -> connection.geoadd(key, memberCoordinateMap), key);
+    return run((connection) -> connection.geoadd(key, memberCoordinateMap), key);
   }
 
   @Override
   public Double geodist(final String key, final String member1, final String member2) {
-    return retryer.run((connection) -> connection.geodist(key, member1, member2), key);
+    return run((connection) -> connection.geodist(key, member1, member2), key);
   }
 
   @Override
   public Double geodist(final String key, final String member1, final String member2,
       final GeoUnit unit) {
-    return retryer.run((connection) -> connection.geodist(key, member1, member2, unit), key);
+    return run((connection) -> connection.geodist(key, member1, member2, unit), key);
   }
 
   @Override
   public List<String> geohash(final String key, final String... members) {
-    return retryer.run((connection) -> connection.geohash(key, members), key);
+    return run((connection) -> connection.geohash(key, members), key);
   }
 
   @Override
   public List<GeoCoordinate> geopos(final String key, final String... members) {
-    return retryer.run((connection) -> connection.geopos(key, members), key);
+    return run((connection) -> connection.geopos(key, members), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return retryer.run((connection) -> connection.georadius(key, longitude, latitude, radius, unit), key);
+    return run((connection) -> connection.georadius(key, longitude, latitude, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit) {
-    return retryer.run((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit), key);
+    return run((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit),
+        key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadius(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.run((connection) -> connection.georadius(key, longitude, latitude, radius, unit, param), key);
+    return run((connection) -> connection.georadius(key, longitude, latitude, radius, unit, param),
+        key);
   }
 
   @Override
   public Long georadiusStore(final String key, final double longitude, final double latitude,
       final double radius, final GeoUnit unit, final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     String[] keys = storeParam.getStringKeys(key);
-    return retryer.run((connection) -> connection.georadiusStore(key, longitude, latitude, radius, unit, param, storeParam), keys.length, keys);
+    return run((connection) -> connection
+            .georadiusStore(key, longitude, latitude, radius, unit, param, storeParam), keys.length,
+        keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusReadonly(final String key, final double longitude,
       final double latitude, final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.run((connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit, param), key);
+    return run(
+        (connection) -> connection.georadiusReadonly(key, longitude, latitude, radius, unit, param),
+        key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit) {
-    return retryer.run((connection) -> connection.georadiusByMember(key, member, radius, unit), key);
+    return run((connection) -> connection.georadiusByMember(key, member, radius, unit), key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final String key, final String member,
       final double radius, final GeoUnit unit) {
-    return retryer.run((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit), key);
+    return run((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit),
+        key);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMember(final String key, final String member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.run((connection) -> connection.georadiusByMember(key, member, radius, unit, param), key);
+    return run((connection) -> connection.georadiusByMember(key, member, radius, unit, param), key);
   }
 
   @Override
   public Long georadiusByMemberStore(final String key, final String member, final double radius, final GeoUnit unit,
       final GeoRadiusParam param, final GeoRadiusStoreParam storeParam) {
     String[] keys = storeParam.getStringKeys(key);
-    return retryer.run((connection) -> connection.georadiusByMemberStore(key, member, radius, unit, param, storeParam), keys.length, keys);
+    return run((connection) -> connection
+        .georadiusByMemberStore(key, member, radius, unit, param, storeParam), keys.length, keys);
   }
 
   @Override
   public List<GeoRadiusResponse> georadiusByMemberReadonly(final String key, final String member,
       final double radius, final GeoUnit unit, final GeoRadiusParam param) {
-    return retryer.run((connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit, param), key);
+    return run(
+        (connection) -> connection.georadiusByMemberReadonly(key, member, radius, unit, param),
+        key);
   }
 
   @Override
   public List<Long> bitfield(final String key, final String... arguments) {
-    return retryer.run((connection) -> connection.bitfield(key, arguments), key);
+    return run((connection) -> connection.bitfield(key, arguments), key);
   }
 
   @Override
   public List<Long> bitfieldReadonly(final String key, final String... arguments) {
-    return retryer.run((connection) -> connection.bitfieldReadonly(key, arguments), key);
+    return run((connection) -> connection.bitfieldReadonly(key, arguments), key);
   }
 
   @Override
   public Long hstrlen(final String key, final String field) {
-    return retryer.run((connection) -> connection.hstrlen(key, field), key);
+    return run((connection) -> connection.hstrlen(key, field), key);
   }
 
 
   @Override
   public Long memoryUsage(final String key) {
-    return retryer.run((connection) -> connection.memoryUsage(key), key);
+    return run((connection) -> connection.memoryUsage(key), key);
   }
 
   @Override
   public Long memoryUsage(final String key, final int samples) {
-    return retryer.run((connection) -> connection.memoryUsage(key, samples), key);
+    return run((connection) -> connection.memoryUsage(key, samples), key);
   }
 
   @Override
   public StreamEntryID xadd(final String key, final StreamEntryID id, final Map<String, String> hash) {
-    return retryer.run((connection) -> connection.xadd(key, id, hash), key);
+    return run((connection) -> connection.xadd(key, id, hash), key);
   }
 
   @Override
   public StreamEntryID xadd(final String key, final StreamEntryID id, final Map<String, String> hash, final long maxLen, final boolean approximateLength) {
-    return retryer.run((connection) -> connection.xadd(key, id, hash, maxLen, approximateLength), key);
+    return run((connection) -> connection.xadd(key, id, hash, maxLen, approximateLength), key);
   }
 
   @Override
   public Long xlen(final String key) {
-    return retryer.run((connection) -> connection.xlen(key), key);
+    return run((connection) -> connection.xlen(key), key);
   }
 
   @Override
   public List<StreamEntry> xrange(final String key, final StreamEntryID start, final StreamEntryID end, final int count) {
-    return retryer.run((connection) -> connection.xrange(key, start, end, count), key);
+    return run((connection) -> connection.xrange(key, start, end, count), key);
   }
 
   @Override
   public List<StreamEntry> xrevrange(final String key, final StreamEntryID end, final StreamEntryID start, final int count) {
-    return retryer.run((connection) -> connection.xrevrange(key, end, start, count), key);
+    return run((connection) -> connection.xrevrange(key, end, start, count), key);
   }
 
   @Override
@@ -1329,32 +1382,32 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[i] = streams[i].getKey();
     }
 
-    return retryer.run((connection) -> connection.xread(count, block, streams), keys.length, keys);
+    return run((connection) -> connection.xread(count, block, streams), keys.length, keys);
   }
 
   @Override
   public Long xack(final String key, final String group, final StreamEntryID... ids) {
-    return retryer.run((connection) -> connection.xack(key, group, ids), key);
+    return run((connection) -> connection.xack(key, group, ids), key);
   }
 
   @Override
   public String xgroupCreate(final String key, final String groupname, final StreamEntryID id, final boolean makeStream) {
-    return retryer.run((connection) -> connection.xgroupCreate(key, groupname, id, makeStream), key);
+    return run((connection) -> connection.xgroupCreate(key, groupname, id, makeStream), key);
   }
 
   @Override
   public String xgroupSetID(final String key, final String groupname, final StreamEntryID id) {
-    return retryer.run((connection) -> connection.xgroupSetID(key, groupname, id), key);
+    return run((connection) -> connection.xgroupSetID(key, groupname, id), key);
   }
 
   @Override
   public Long xgroupDestroy(final String key, final String groupname) {
-    return retryer.run((connection) -> connection.xgroupDestroy(key, groupname), key);
+    return run((connection) -> connection.xgroupDestroy(key, groupname), key);
   }
 
   @Override
   public Long xgroupDelConsumer(final String key, final String groupname, final String consumername) {
-    return retryer.run((connection) -> connection.xgroupDelConsumer(key, groupname, consumername), key);
+    return run((connection) -> connection.xgroupDelConsumer(key, groupname, consumername), key);
   }
 
   @Override
@@ -1366,41 +1419,45 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
       keys[i] = streams[i].getKey();
     }
 
-    return retryer.run((connection) -> connection.xreadGroup(groupname, consumer, count, block, noAck, streams), keys.length, keys);
+    return run(
+        (connection) -> connection.xreadGroup(groupname, consumer, count, block, noAck, streams),
+        keys.length, keys);
   }
 
   @Override
   public List<StreamPendingEntry> xpending(final String key, final String groupname, final StreamEntryID start, final StreamEntryID end, final int count,
       final String consumername) {
-    return retryer.run((connection) -> connection.xpending(key, groupname, start, end, count, consumername), key);
+    return run((connection) -> connection.xpending(key, groupname, start, end, count, consumername),
+        key);
   }
 
   @Override
   public Long xdel(final String key, final StreamEntryID... ids) {
-    return retryer.run((connection) -> connection.xdel(key, ids), key);
+    return run((connection) -> connection.xdel(key, ids), key);
   }
 
   @Override
   public Long xtrim(final  String key, final long maxLen, final boolean approximateLength) {
-    return retryer.run((connection) -> connection.xtrim(key, maxLen, approximateLength), key);
+    return run((connection) -> connection.xtrim(key, maxLen, approximateLength), key);
   }
 
   @Override
   public List<StreamEntry> xclaim(final String key, final String group, final String consumername, final long minIdleTime, final long newIdleTime,
       final int retries, final boolean force, final StreamEntryID... ids) {
-    return retryer.run((connection) -> connection.xclaim(key, group, consumername, minIdleTime, newIdleTime, retries, force, ids), key);
+    return run((connection) -> connection
+        .xclaim(key, group, consumername, minIdleTime, newIdleTime, retries, force, ids), key);
   }
 
   public Long waitReplicas(final String key, final int replicas, final long timeout) {
-    return retryer.run((connection) -> connection.waitReplicas(replicas, timeout), key);
+    return run((connection) -> connection.waitReplicas(replicas, timeout), key);
   }
 
   public Object sendCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
-    return retryer.run((connection) -> connection.sendCommand(cmd, args), sampleKey);
+    return run((connection) -> connection.sendCommand(cmd, args), sampleKey);
   }
 
   public Object sendBlockingCommand(final String sampleKey, final ProtocolCommand cmd, final String... args) {
-    return retryer.run((connection) -> connection.sendBlockingCommand(cmd, args), sampleKey);
+    return run((connection) -> connection.sendBlockingCommand(cmd, args), sampleKey);
   }
 
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -255,12 +255,7 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
 
   @Override
   public String type(final String key) {
-    return new JedisClusterCommand<String>(connectionHandler, maxAttempts) {
-      @Override
-      public String execute(Jedis connection) {
-        return connection.type(key);
-      }
-    }.run(key);
+    return retryer.run((connection) -> connection.type(key), key);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -13,6 +13,11 @@ public abstract class Retryer {
    */
   protected abstract <R> R runWithRetries(int slot, Function<Jedis, R> command);
 
+  /**
+   * Execute a Redis command on any random node.
+   */
+  public abstract <R> R runWithRetries(Function<Jedis, R> command);
+
   public <R> R run(Function<Jedis, R> command, String key) {
     return runWithRetries(JedisClusterCRC16.getSlot(key), command);
   }

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -1,13 +1,63 @@
 package redis.clients.jedis;
 
 import java.util.function.Function;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
-public interface Retryer {
+public abstract class Retryer {
   /**
    * Execute a Redis command with retries.
    *
    * @param slot From one of the {@code JedisClusterCRC16#get*())} methods
    * @return The result of running the given command with retries
    */
-  <R> R runWithRetries(int slot, Function<Jedis, R> command);
+  protected abstract <R> R runWithRetries(int slot, Function<Jedis, R> command);
+
+  public <R> R run(Function<Jedis, R> command, String key) {
+    return runWithRetries(JedisClusterCRC16.getSlot(key), command);
+  }
+
+  public <R> R run(Function<Jedis, R> command, int keyCount, String... keys) {
+    if (keys == null || keys.length == 0) {
+      throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
+    }
+
+    // For multiple keys, only execute if they all share the same connection slot.
+    int slot = JedisClusterCRC16.getSlot(keys[0]);
+    if (keys.length > 1) {
+      for (int i = 1; i < keyCount; i++) {
+        int nextSlot = JedisClusterCRC16.getSlot(keys[i]);
+        if (slot != nextSlot) {
+          throw new JedisClusterOperationException("No way to dispatch this command to Redis "
+              + "Cluster because keys have different slots.");
+        }
+      }
+    }
+
+    return runWithRetries(slot, command);
+  }
+
+  public <R> R runBinary(Function<Jedis, R> command, byte[] key) {
+    return runWithRetries(JedisClusterCRC16.getSlot(key), command);
+  }
+
+  public <R> R runBinary(Function<Jedis, R> command, int keyCount, byte[]... keys) {
+    if (keys == null || keys.length == 0) {
+      throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
+    }
+
+    // For multiple keys, only execute if they all share the same connection slot.
+    int slot = JedisClusterCRC16.getSlot(keys[0]);
+    if (keys.length > 1) {
+      for (int i = 1; i < keyCount; i++) {
+        int nextSlot = JedisClusterCRC16.getSlot(keys[i]);
+        if (slot != nextSlot) {
+          throw new JedisClusterOperationException("No way to dispatch this command to Redis "
+              + "Cluster because keys have different slots.");
+        }
+      }
+    }
+
+    return runWithRetries(slot, command);
+  }
 }

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -18,6 +18,13 @@ public abstract class Retryer {
    */
   public abstract <R> R runWithRetries(Function<Jedis, R> command);
 
+  /**
+   * Override this method to free up any resources.
+   */
+  public void close() {
+    // This method intentionally left blank
+  }
+
   public <R> R run(Function<Jedis, R> command, String key) {
     return runWithRetries(JedisClusterCRC16.getSlot(key), command);
   }

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -27,9 +27,13 @@ public abstract class Retryer {
 
   /**
    * Override this method to free up any resources.
+   * <p/>
+   * And if you do, you <em>must</em> call {@code super.close()} from your overriding method!
    */
   public void close() {
-    // This method intentionally left blank
+    if (connectionHandler != null) {
+      connectionHandler.close();
+    }
   }
 
   public Map<String, JedisPool> getClusterNodes() {

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -5,6 +5,16 @@ import java.util.function.Function;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.util.JedisClusterCRC16;
 
+/**
+ * Functionality for retrying Redis connections.
+ * <p/>
+ * This class contains scaffolding around the retry mechanism. The actual retrying will be done in
+ * subclasses of this class, with {@link DefaultRetryer} being the default implementation.
+ *
+ * @see BinaryJedisCluster#BinaryJedisCluster(Retryer)
+ * @see JedisCluster#JedisCluster(Retryer)
+ * @see DefaultRetryer
+ */
 public abstract class Retryer {
   protected final JedisClusterConnectionHandler connectionHandler;
 

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -1,10 +1,17 @@
 package redis.clients.jedis;
 
+import java.util.Map;
 import java.util.function.Function;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.util.JedisClusterCRC16;
 
 public abstract class Retryer {
+  protected final JedisClusterConnectionHandler connectionHandler;
+
+  public Retryer(JedisClusterConnectionHandler connectionHandler) {
+    this.connectionHandler = connectionHandler;
+  }
+
   /**
    * Execute a Redis command with retries.
    *
@@ -23,6 +30,14 @@ public abstract class Retryer {
    */
   public void close() {
     // This method intentionally left blank
+  }
+
+  public Map<String, JedisPool> getClusterNodes() {
+    return connectionHandler.getNodes();
+  }
+
+  public Jedis getConnectionFromSlot(int slot) {
+    return connectionHandler.getConnectionFromSlot(slot);
   }
 
   public <R> R run(Function<Jedis, R> command, String key) {

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -1,0 +1,13 @@
+package redis.clients.jedis;
+
+import java.util.function.Function;
+
+public interface Retryer {
+  /**
+   * Execute a Redis command with retries.
+   *
+   * @param slot From one of the {@code JedisClusterCRC16#get*())} methods
+   * @return The result of running the given command with retries
+   */
+  <R> R runWithRetries(int slot, Function<Jedis, R> command);
+}

--- a/src/main/java/redis/clients/jedis/Retryer.java
+++ b/src/main/java/redis/clients/jedis/Retryer.java
@@ -36,19 +36,19 @@ public abstract class Retryer {
     }
   }
 
-  public Map<String, JedisPool> getClusterNodes() {
+  public final Map<String, JedisPool> getClusterNodes() {
     return connectionHandler.getNodes();
   }
 
-  public Jedis getConnectionFromSlot(int slot) {
+  public final Jedis getConnectionFromSlot(int slot) {
     return connectionHandler.getConnectionFromSlot(slot);
   }
 
-  public <R> R run(Function<Jedis, R> command, String key) {
+  public final <R> R run(Function<Jedis, R> command, String key) {
     return runWithRetries(JedisClusterCRC16.getSlot(key), command);
   }
 
-  public <R> R run(Function<Jedis, R> command, int keyCount, String... keys) {
+  public final <R> R run(Function<Jedis, R> command, int keyCount, String... keys) {
     if (keys == null || keys.length == 0) {
       throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
     }
@@ -68,11 +68,11 @@ public abstract class Retryer {
     return runWithRetries(slot, command);
   }
 
-  public <R> R runBinary(Function<Jedis, R> command, byte[] key) {
+  public final <R> R runBinary(Function<Jedis, R> command, byte[] key) {
     return runWithRetries(JedisClusterCRC16.getSlot(key), command);
   }
 
-  public <R> R runBinary(Function<Jedis, R> command, int keyCount, byte[]... keys) {
+  public final <R> R runBinary(Function<Jedis, R> command, int keyCount, byte[]... keys) {
     if (keys == null || keys.length == 0) {
       throw new JedisClusterOperationException("No way to dispatch this command to Redis Cluster.");
     }


### PR DESCRIPTION
Inspired by @mina-asham in <https://github.com/redis/jedis/pull/2358#pullrequestreview-592136327>:
> We can even define a simple backoff strategy interface so that users can define whatever they want, and I suggest we keep the default behavior as is (i.e. uniform with 0 wait)

This PR does exactly that.

It adds [a new `Retryer` interface](https://github.com/walles/jedis/blob/j/pluggable-retries/src/main/java/redis/clients/jedis/Retryer.java) that people can implement. `Retryer` instances can be passed to two new `BinaryJedisCluster` and `JedisCluster` constructors.

[The existing retry code has been copied into `DefaultRetryer`](https://github.com/walles/jedis/blob/j/pluggable-retries/src/main/java/redis/clients/jedis/DefaultRetryer.java). This retryer is what's used by `BinaryJedisCluster` and `JedisCluster` for any old code.

The previous `JedisClusterCommand` class has been split into:
* `runWithRetries()` went (unchanged) into `DefaultRetryer`
* Some scaffolding `run...()` methods went into [`BinaryJedisCluster` (search for `runBinary`)](https://github.com/walles/jedis/blob/j/pluggable-retries/src/main/java/redis/clients/jedis/BinaryJedisCluster.java), which is the only place from which they were called
* Some other scaffolding `run...()` methods went into [`JedisCluster` (search for `run`)](https://github.com/walles/jedis/blob/j/pluggable-retries/src/main/java/redis/clients/jedis/JedisCluster.java), which is the only place from which they were called

One point with this PR is that it does *not* change any behavior. This will simplify review, since backoffs are hard.

With this change merged, Jedis users can roll their own backoff strategies.

And if they work well, those strategies can be easily turned into PRs.