### PR TITLE
Modify config pattern

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -150,27 +150,27 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout).build());
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final int infiniteSoTimeout) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout)
-        .withInfiniteSoTimeout(infiniteSoTimeout).build());
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
+        .withInfiniteSoTimeoutMillis(infiniteSoTimeout).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final boolean ssl) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout).withSsl(ssl).build());
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout).withSsl(ssl).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final boolean ssl, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout).withSsl(ssl)
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout).withSsl(ssl)
         .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
         .withHostnameVerifier(hostnameVerifier).build());
   }
@@ -180,15 +180,15 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout)
-        .withInfiniteSoTimeout(infiniteSoTimeout).withSsl(ssl)
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
+        .withInfiniteSoTimeoutMillis(infiniteSoTimeout).withSsl(ssl)
         .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
         .withHostnameVerifier(hostnameVerifier).build());
   }
 
   public BinaryJedis(final JedisShardInfo shardInfo) {
     this(shardInfo.getHost(), shardInfo.getPort(), DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(shardInfo.getConnectionTimeout()).withSoTimeout(shardInfo.getSoTimeout())
+        .withConnectionTimeoutMillis(shardInfo.getConnectionTimeout()).withSoTimeoutMillis(shardInfo.getSoTimeout())
         .withUser(shardInfo.getUser()).withPassword(shardInfo.getPassword()).withDatabse(shardInfo.getDb())
         .withSsl(shardInfo.getSsl()).withSslSocketFactory(shardInfo.getSslSocketFactory())
         .withSslParameters(shardInfo.getSslParameters()).withHostnameVerifier(shardInfo.getHostnameVerifier()).build());
@@ -217,14 +217,14 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout) {
     this(uri, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout).build());
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout).build());
   }
 
   public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout,
       final SSLSocketFactory sslSocketFactory,final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
     this(uri, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout)
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
         .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
         .withHostnameVerifier(hostnameVerifier).build());
   }
@@ -233,8 +233,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       final int infiniteSoTimeout, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this(uri, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(connectionTimeout).withSoTimeout(soTimeout)
-        .withInfiniteSoTimeout(infiniteSoTimeout).withSslSocketFactory(sslSocketFactory)
+        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
+        .withInfiniteSoTimeoutMillis(infiniteSoTimeout).withSslSocketFactory(sslSocketFactory)
         .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build());
   }
 
@@ -243,8 +243,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       throw new InvalidURIException(String.format("Cannot open Redis connection due invalid URI \"%s\".", uri.toString()));
     }
     client = new Client(new HostAndPort(uri.getHost(), uri.getPort()),
-        DefaultJedisClientConfig.builder().withConnectionTimeout(config.getConnectionTimeout())
-            .withSoTimeout(config.getSoTimeout()).withInfiniteSoTimeout(config.getInfiniteSoTimeout())
+        DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(config.getConnectionTimeoutMillis())
+            .withSoTimeoutMillis(config.getSoTimeoutMillis()).withInfiniteSoTimeoutMillis(config.getInfiniteSoTimeoutMillis())
             .withUser(JedisURIHelper.getUser(uri)).withPassword(JedisURIHelper.getPassword(uri))
             .withDatabse(JedisURIHelper.getDBIndex(uri)).withClientName(config.getClientName())
             .withSsl(JedisURIHelper.isRedisSSLScheme(uri))

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -24,7 +24,7 @@ public class Connection implements Closeable {
   private static final byte[][] EMPTY_ARGS = new byte[0][];
 
   private boolean socketParamModified = false; // for backward compatibility
-  private JedisSocketFactory socketFactory; // TODO: sould be final
+  private JedisSocketFactory socketFactory; // TODO: should be final
   private Socket socket;
   private RedisOutputStream outputStream;
   private RedisInputStream inputStream;
@@ -72,8 +72,8 @@ public class Connection implements Closeable {
 
   public Connection(final HostAndPort hostAndPort, final JedisClientConfig clientConfig) {
     this(new DefaultJedisSocketFactory(hostAndPort, clientConfig));
-    this.soTimeout = clientConfig.getSoTimeout();
-    this.infiniteSoTimeout = clientConfig.getInfiniteSoTimeout();
+    this.soTimeout = clientConfig.getSoTimeoutMillis();
+    this.infiniteSoTimeout = clientConfig.getInfiniteSoTimeoutMillis();
   }
 
   public Connection(final JedisSocketFactory jedisSocketFactory) {

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -22,13 +22,13 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
 
   private final HostAndPortMapper hostAndPortMapper;
 
-  private DefaultJedisClientConfig(int connectionTimeout, int soTimeout, int infiniteSoTimeout,
-      String user, String password, int database, String clientName,
+  private DefaultJedisClientConfig(int connectionTimeoutMillis, int soTimeoutMillis,
+      int infiniteSoTimeoutMillis, String user, String password, int database, String clientName,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, HostAndPortMapper hostAndPortMapper) {
-    this.connectionTimeoutMillis = connectionTimeout;
-    this.soTimeoutMillis = soTimeout;
-    this.infiniteSoTimeoutMillis = infiniteSoTimeout;
+    this.connectionTimeoutMillis = connectionTimeoutMillis;
+    this.soTimeoutMillis = soTimeoutMillis;
+    this.infiniteSoTimeoutMillis = infiniteSoTimeoutMillis;
     this.user = user;
     this.password = password;
     this.database = database;
@@ -106,9 +106,9 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
 
   public static class Builder {
 
-    private int connectionTimeout = Protocol.DEFAULT_TIMEOUT;
-    private int soTimeout = Protocol.DEFAULT_TIMEOUT;
-    private int infiniteSoTimeout = 0;
+    private int connectionTimeoutMillis = Protocol.DEFAULT_TIMEOUT;
+    private int soTimeoutMillis = Protocol.DEFAULT_TIMEOUT;
+    private int infiniteSoTimeoutMillis = 0;
 
     private String user = null;
     private String password = null;
@@ -126,23 +126,23 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     }
 
     public DefaultJedisClientConfig build() {
-      return new DefaultJedisClientConfig(connectionTimeout, soTimeout, infiniteSoTimeout,
-          user, password, databse, clientName,
+      return new DefaultJedisClientConfig(connectionTimeoutMillis, soTimeoutMillis,
+          infiniteSoTimeoutMillis, user, password, databse, clientName,
           ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMapper);
     }
 
-    public Builder withConnectionTimeoutMillis(int connectionTimeout) {
-      this.connectionTimeout = connectionTimeout;
+    public Builder withConnectionTimeoutMillis(int connectionTimeoutMillis) {
+      this.connectionTimeoutMillis = connectionTimeoutMillis;
       return this;
     }
 
-    public Builder withSoTimeoutMillis(int soTimeout) {
-      this.soTimeout = soTimeout;
+    public Builder withSoTimeoutMillis(int soTimeoutMillis) {
+      this.soTimeoutMillis = soTimeoutMillis;
       return this;
     }
 
-    public Builder withInfiniteSoTimeoutMillis(int infiniteSoTimeout) {
-      this.infiniteSoTimeout = infiniteSoTimeout;
+    public Builder withInfiniteSoTimeoutMillis(int infiniteSoTimeoutMillis) {
+      this.infiniteSoTimeoutMillis = infiniteSoTimeoutMillis;
       return this;
     }
 

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -6,9 +6,9 @@ import javax.net.ssl.SSLSocketFactory;
 
 public final class DefaultJedisClientConfig implements JedisClientConfig {
 
-  private final int connectionTimeout;
-  private final int soTimeout;
-  private final int infiniteSoTimeout;
+  private final int connectionTimeoutMillis;
+  private final int soTimeoutMillis;
+  private final int infiniteSoTimeoutMillis;
 
   private final String user;
   private final String password;
@@ -26,9 +26,9 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
       String user, String password, int database, String clientName,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, HostAndPortMapper hostAndPortMapper) {
-    this.connectionTimeout = connectionTimeout;
-    this.soTimeout = soTimeout;
-    this.infiniteSoTimeout = infiniteSoTimeout;
+    this.connectionTimeoutMillis = connectionTimeout;
+    this.soTimeoutMillis = soTimeout;
+    this.infiniteSoTimeoutMillis = infiniteSoTimeout;
     this.user = user;
     this.password = password;
     this.database = database;
@@ -41,18 +41,18 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   }
 
   @Override
-  public int getConnectionTimeout() {
-    return connectionTimeout;
+  public int getConnectionTimeoutMillis() {
+    return connectionTimeoutMillis;
   }
 
   @Override
-  public int getSoTimeout() {
-    return soTimeout;
+  public int getSoTimeoutMillis() {
+    return soTimeoutMillis;
   }
 
   @Override
-  public int getInfiniteSoTimeout() {
-    return infiniteSoTimeout;
+  public int getInfiniteSoTimeoutMillis() {
+    return infiniteSoTimeoutMillis;
   }
 
   @Override
@@ -131,17 +131,17 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
           ssl, sslSocketFactory, sslParameters, hostnameVerifier, hostAndPortMapper);
     }
 
-    public Builder withConnectionTimeout(int connectionTimeout) {
+    public Builder withConnectionTimeoutMillis(int connectionTimeout) {
       this.connectionTimeout = connectionTimeout;
       return this;
     }
 
-    public Builder withSoTimeout(int soTimeout) {
+    public Builder withSoTimeoutMillis(int soTimeout) {
       this.soTimeout = soTimeout;
       return this;
     }
 
-    public Builder withInfiniteSoTimeout(int infiniteSoTimeout) {
+    public Builder withInfiniteSoTimeoutMillis(int infiniteSoTimeout) {
       this.infiniteSoTimeout = infiniteSoTimeout;
       return this;
     }
@@ -193,8 +193,8 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   }
   
   public static DefaultJedisClientConfig copyConfig(JedisClientConfig copy) {
-    return new DefaultJedisClientConfig(copy.getConnectionTimeout(), copy.getSoTimeout(),
-        copy.getInfiniteSoTimeout(), copy.getUser(), copy.getPassword(), copy.getDatabase(),
+    return new DefaultJedisClientConfig(copy.getConnectionTimeoutMillis(), copy.getSoTimeoutMillis(),
+        copy.getInfiniteSoTimeoutMillis(), copy.getUser(), copy.getPassword(), copy.getDatabase(),
         copy.getClientName(), copy.isSsl(), copy.getSslSocketFactory(), copy.getSslParameters(),
         copy.getHostnameVerifier(), copy.getHostAndPortMapper());
   }

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -47,8 +47,8 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
   public DefaultJedisSocketFactory(HostAndPort hostAndPort, JedisClientConfig config) {
     this.hostAndPort = hostAndPort;
     if (config != null) {
-      this.connectionTimeout = config.getConnectionTimeout();
-      this.soTimeout = config.getSoTimeout();
+      this.connectionTimeout = config.getConnectionTimeoutMillis();
+      this.soTimeout = config.getSoTimeoutMillis();
       this.ssl = config.isSsl();
       this.sslSocketFactory = config.getSslSocketFactory();
       this.sslParameters = config.getSslParameters();

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -6,32 +6,68 @@ import javax.net.ssl.SSLSocketFactory;
 
 public interface JedisClientConfig {
 
-  int getConnectionTimeout();
+  /**
+   * @return Connection timeout in milliseconds
+   */
+  default int getConnectionTimeoutMillis() {
+    return Protocol.DEFAULT_TIMEOUT;
+  }
 
-  int getSoTimeout();
+  /**
+   * @return Socket timeout in milliseconds
+   */
+  default int getSoTimeoutMillis() {
+    return Protocol.DEFAULT_TIMEOUT;
+  }
 
   /**
    * @return Socket timeout (in milliseconds) to use during blocking operation. Default is '0',
    * which means to block forever.
    */
-  int getInfiniteSoTimeout();
+  default int getInfiniteSoTimeoutMillis() {
+    return 0;
+  }
 
-  String getUser();
+  /**
+   * @return Redis ACL user
+   */
+  default String getUser() {
+    return null;
+  }
 
-  String getPassword();
+  default String getPassword() {
+    return null;
+  }
 
-  int getDatabase();
+  default int getDatabase() {
+    return Protocol.DEFAULT_DATABASE;
+  }
 
-  String getClientName();
+  default String getClientName() {
+    return null;
+  }
 
-  boolean isSsl();
+  /**
+   * @return <code>true</code> - to create a TLS connection. <code>false</code> - otherwise.
+   */
+  default boolean isSsl() {
+    return false;
+  }
 
-  SSLSocketFactory getSslSocketFactory();
+  default SSLSocketFactory getSslSocketFactory() {
+    return null;
+  }
 
-  SSLParameters getSslParameters();
+  default SSLParameters getSslParameters() {
+    return null;
+  }
 
-  HostnameVerifier getHostnameVerifier();
+  default HostnameVerifier getHostnameVerifier() {
+    return null;
+  }
 
-  HostAndPortMapper getHostAndPortMapper();
+  default HostAndPortMapper getHostAndPortMapper() {
+    return null;
+  }
 
 }

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -65,14 +65,14 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap portMap) {
     this(nodes,
-        DefaultJedisClientConfig.builder().withConnectionTimeout(connectionTimeout)
-            .withSoTimeout(soTimeout).withInfiniteSoTimeout(infiniteSoTimeout)
+        DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
+            .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout)
             .withUser(user).withPassword(password).withClientName(clientName)
             .withSsl(ssl).withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
             .withHostnameVerifier(hostnameVerifier).build(),
         poolConfig,
-        DefaultJedisClientConfig.builder().withConnectionTimeout(connectionTimeout)
-            .withSoTimeout(soTimeout).withInfiniteSoTimeout(infiniteSoTimeout)
+        DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
+            .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout)
             .withUser(user).withPassword(password).withClientName(clientName)
             .withSsl(ssl).withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
             .withHostnameVerifier(hostnameVerifier).withHostAndPortMapper(portMap).build());

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -111,8 +111,8 @@ public class JedisClusterInfoCache {
       SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, HostAndPortMapper hostAndPortMap) {
     this(poolConfig,
-        DefaultJedisClientConfig.builder().withConnectionTimeout(connectionTimeout)
-            .withSoTimeout(soTimeout).withInfiniteSoTimeout(infiniteSoTimeout)
+        DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
+            .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout)
             .withUser(user).withPassword(password).withClientName(clientName)
             .withSsl(ssl).withSslSocketFactory(sslSocketFactory)
             .withSslParameters(sslParameters) .withHostnameVerifier(hostnameVerifier)

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -67,8 +67,8 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
       final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this.hostAndPort.set(new HostAndPort(host, port));
-    this.config = DefaultJedisClientConfig.builder().withConnectionTimeout(connectionTimeout)
-        .withSoTimeout(soTimeout).withInfiniteSoTimeout(infiniteSoTimeout).withUser(user)
+    this.config = DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
+        .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout).withUser(user)
         .withPassword(password).withDatabse(database).withClientName(clientName)
         .withSsl(ssl).withSslSocketFactory(sslSocketFactory)
         .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build();
@@ -93,8 +93,8 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
           "Cannot open Redis connection due invalid URI. %s", uri.toString()));
     }
     this.hostAndPort.set(new HostAndPort(uri.getHost(), uri.getPort()));
-    this.config = DefaultJedisClientConfig.builder().withConnectionTimeout(connectionTimeout)
-        .withSoTimeout(soTimeout).withInfiniteSoTimeout(infiniteSoTimeout)
+    this.config = DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
+        .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout)
         .withUser(JedisURIHelper.getUser(uri)).withPassword(JedisURIHelper.getPassword(uri))
         .withDatabse(JedisURIHelper.getDBIndex(uri)).withClientName(clientName)
         .withSsl(JedisURIHelper.isRedisSSLScheme(uri)).withSslSocketFactory(sslSocketFactory)

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -601,7 +601,7 @@ public class JedisClusterTest {
   public void testJedisClusterTimeoutWithConfig() {
     HostAndPort hp = nodeInfo1;
     try (JedisCluster jc = new JedisCluster(hp, DefaultJedisClientConfig.builder()
-        .withConnectionTimeout(4000).withSoTimeout(4000).withPassword("cluster").build(),
+        .withConnectionTimeoutMillis(4000).withSoTimeoutMillis(4000).withPassword("cluster").build(),
         DEFAULT_REDIRECTIONS, DEFAULT_POOL_CONFIG)) {
 
       jc.getClusterNodes().values().forEach(pool -> {

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.InvalidURIException;
@@ -65,6 +66,26 @@ public class JedisTest extends JedisCommandTestBase {
   public void connectWithConfig() {
     try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().build())) {
       jedis.auth("foobared");
+      assertEquals("PONG", jedis.ping());
+    }
+    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder()
+        .withPassword("foobared").build())) {
+      assertEquals("PONG", jedis.ping());
+    }
+  }
+
+  @Test
+  public void connectWithConfigInterface() {
+    try (Jedis jedis = new Jedis(hnp, new JedisClientConfig() {})) {
+      jedis.auth("foobared");
+      assertEquals("PONG", jedis.ping());
+    }
+    try (Jedis jedis = new Jedis(hnp, new JedisClientConfig() {
+      @Override
+      public String getPassword() {
+        return "foobared";
+      }
+    })) {
       assertEquals("PONG", jedis.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.tests.commands.JedisCommandTestBase;
@@ -52,6 +54,30 @@ public class JedisWithCompleteCredentialsTest extends JedisCommandTestBase {
   public void connectWithConfig() {
     try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().build())) {
       jedis.auth("acljedis", "fizzbuzz");
+      assertEquals("PONG", jedis.ping());
+    }
+    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder()
+        .withUser("acljedis").withPassword("fizzbuzz").build())) {
+      assertEquals("PONG", jedis.ping());
+    }
+  }
+
+  @Test
+  public void connectWithConfigInterface() {
+    try (Jedis jedis = new Jedis(hnp, new JedisClientConfig() {})) {
+      jedis.auth("acljedis", "fizzbuzz");
+      assertEquals("PONG", jedis.ping());
+    }
+    try (Jedis jedis = new Jedis(hnp, new JedisClientConfig() {
+      @Override
+      public String getUser() {
+        return "acljedis";
+      }
+      @Override
+      public String getPassword() {
+        return "fizzbuzz";
+      }
+    })) {
       assertEquals("PONG", jedis.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
@@ -63,7 +64,22 @@ public class SSLJedisTest {
 
   @Test
   public void connectWithConfig() {
-    try (Jedis jedis = new Jedis(new HostAndPort("localhost", 6390), DefaultJedisClientConfig.builder().withSsl(true).build())) {
+    try (Jedis jedis = new Jedis(new HostAndPort("localhost", 6390),
+        DefaultJedisClientConfig.builder().withSsl(true).build())) {
+      jedis.auth("foobared");
+      assertEquals("PONG", jedis.ping());
+    }
+  }
+
+  @Test
+  public void connectWithConfigInterface() {
+    try (Jedis jedis = new Jedis(new HostAndPort("localhost", 6390),
+        new JedisClientConfig() {
+      @Override
+      public boolean isSsl() {
+        return true;
+      }
+    })) {
       jedis.auth("foobared");
       assertEquals("PONG", jedis.ping());
     }


### PR DESCRIPTION
1. Added the word `millis` to the timeout parameters. I have seen people are confused about the unit of timeout parameters in almost everywhere (stackoverflow, github issues, mailing list). Adding the unit in config param name would be self explanatory.
2. After upgrading to JDK 1.8, it is now possible to use `default` which would allow users to code less.

I have put above changes in one PR because merging any of these would cause the other to be git-conflicted.