### PR TITLE
Rename socket timeout params and builder methods

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -152,20 +152,20 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout).build());
+        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final int infiniteSoTimeout) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
-        .withInfiniteSoTimeoutMillis(infiniteSoTimeout).build());
+        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
+        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final boolean ssl) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout).withSsl(ssl)
+        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout).withSsl(ssl)
         .build());
   }
 
@@ -173,7 +173,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       final int soTimeout, final boolean ssl, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout).withSsl(ssl)
+        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout).withSsl(ssl)
         .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
         .withHostnameVerifier(hostnameVerifier).build());
   }
@@ -183,8 +183,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
-        .withInfiniteSoTimeoutMillis(infiniteSoTimeout).withSsl(ssl)
+        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
+        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).withSsl(ssl)
         .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
         .withHostnameVerifier(hostnameVerifier).build());
   }
@@ -192,7 +192,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   public BinaryJedis(final JedisShardInfo shardInfo) {
     this(shardInfo.getHost(), shardInfo.getPort(), DefaultJedisClientConfig.builder()
         .withConnectionTimeoutMillis(shardInfo.getConnectionTimeout())
-        .withSoTimeoutMillis(shardInfo.getSoTimeout()).withUser(shardInfo.getUser())
+        .withSocketTimeoutMillis(shardInfo.getSoTimeout()).withUser(shardInfo.getUser())
         .withPassword(shardInfo.getPassword()).withDatabse(shardInfo.getDb())
         .withSsl(shardInfo.getSsl()).withSslSocketFactory(shardInfo.getSslSocketFactory())
         .withSslParameters(shardInfo.getSslParameters())
@@ -221,14 +221,14 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout) {
     this(uri, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSoTimeoutMillis(soTimeout).build());
+        .withSocketTimeoutMillis(soTimeout).build());
   }
 
   public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout,
       final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
     this(uri, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSoTimeoutMillis(soTimeout).withSslSocketFactory(sslSocketFactory)
+        .withSocketTimeoutMillis(soTimeout).withSslSocketFactory(sslSocketFactory)
         .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build());
   }
 
@@ -236,7 +236,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       final int infiniteSoTimeout, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this(uri, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout)
+        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout)
         .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
         .withHostnameVerifier(hostnameVerifier).build());
   }
@@ -248,8 +248,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     }
     client = new Client(new HostAndPort(uri.getHost(), uri.getPort()), DefaultJedisClientConfig
         .builder().withConnectionTimeoutMillis(config.getConnectionTimeoutMillis())
-        .withSoTimeoutMillis(config.getSoTimeoutMillis())
-        .withInfiniteSoTimeoutMillis(config.getInfiniteSoTimeoutMillis())
+        .withSocketTimeoutMillis(config.getSocketTimeoutMillis())
+        .withBlockingSocketTimeoutMillis(config.getBlockingSocketTimeoutMillis())
         .withUser(JedisURIHelper.getUser(uri)).withPassword(JedisURIHelper.getPassword(uri))
         .withDatabse(JedisURIHelper.getDBIndex(uri)).withClientName(config.getClientName())
         .withSsl(JedisURIHelper.isRedisSSLScheme(uri))

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -124,15 +124,15 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   public BinaryJedis(final String host, final int port, final boolean ssl) {
-    this(host, port, DefaultJedisClientConfig.builder().withSsl(ssl).build());
+    this(host, port, DefaultJedisClientConfig.builder().ssl(ssl).build());
   }
 
   public BinaryJedis(final String host, final int port, final boolean ssl,
       final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
-    this(host, port, DefaultJedisClientConfig.builder().withSsl(ssl)
-        .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
-        .withHostnameVerifier(hostnameVerifier).build());
+    this(host, port, DefaultJedisClientConfig.builder().ssl(ssl)
+        .sslSocketFactory(sslSocketFactory).sslParameters(sslParameters)
+        .hostnameVerifier(hostnameVerifier).build());
   }
 
   public BinaryJedis(final String host, final int port, final int timeout) {
@@ -152,20 +152,20 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout).build());
+        .connectionTimeoutMillis(connectionTimeout).socketTimeoutMillis(soTimeout).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final int infiniteSoTimeout) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
-        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).build());
+        .connectionTimeoutMillis(connectionTimeout).socketTimeoutMillis(soTimeout)
+        .blockingSocketTimeoutMillis(infiniteSoTimeout).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
       final int soTimeout, final boolean ssl) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout).withSsl(ssl)
+        .connectionTimeoutMillis(connectionTimeout).socketTimeoutMillis(soTimeout).ssl(ssl)
         .build());
   }
 
@@ -173,9 +173,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       final int soTimeout, final boolean ssl, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout).withSsl(ssl)
-        .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
-        .withHostnameVerifier(hostnameVerifier).build());
+        .connectionTimeoutMillis(connectionTimeout).socketTimeoutMillis(soTimeout).ssl(ssl)
+        .sslSocketFactory(sslSocketFactory).sslParameters(sslParameters)
+        .hostnameVerifier(hostnameVerifier).build());
   }
 
   public BinaryJedis(final String host, final int port, final int connectionTimeout,
@@ -183,20 +183,20 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
       final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
     this(host, port, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
-        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).withSsl(ssl)
-        .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
-        .withHostnameVerifier(hostnameVerifier).build());
+        .connectionTimeoutMillis(connectionTimeout).socketTimeoutMillis(soTimeout)
+        .blockingSocketTimeoutMillis(infiniteSoTimeout).ssl(ssl)
+        .sslSocketFactory(sslSocketFactory).sslParameters(sslParameters)
+        .hostnameVerifier(hostnameVerifier).build());
   }
 
   public BinaryJedis(final JedisShardInfo shardInfo) {
     this(shardInfo.getHost(), shardInfo.getPort(), DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(shardInfo.getConnectionTimeout())
-        .withSocketTimeoutMillis(shardInfo.getSoTimeout()).withUser(shardInfo.getUser())
-        .withPassword(shardInfo.getPassword()).withDatabse(shardInfo.getDb())
-        .withSsl(shardInfo.getSsl()).withSslSocketFactory(shardInfo.getSslSocketFactory())
-        .withSslParameters(shardInfo.getSslParameters())
-        .withHostnameVerifier(shardInfo.getHostnameVerifier()).build());
+        .connectionTimeoutMillis(shardInfo.getConnectionTimeout())
+        .socketTimeoutMillis(shardInfo.getSoTimeout()).user(shardInfo.getUser())
+        .password(shardInfo.getPassword()).databse(shardInfo.getDb())
+        .ssl(shardInfo.getSsl()).sslSocketFactory(shardInfo.getSslSocketFactory())
+        .sslParameters(shardInfo.getSslParameters())
+        .hostnameVerifier(shardInfo.getHostnameVerifier()).build());
   }
 
   public BinaryJedis(URI uri) {
@@ -206,8 +206,8 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
 
   public BinaryJedis(URI uri, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
-    this(uri, DefaultJedisClientConfig.builder().withSslSocketFactory(sslSocketFactory)
-        .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build());
+    this(uri, DefaultJedisClientConfig.builder().sslSocketFactory(sslSocketFactory)
+        .sslParameters(sslParameters).hostnameVerifier(hostnameVerifier).build());
   }
 
   public BinaryJedis(final URI uri, final int timeout) {
@@ -220,25 +220,25 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout) {
-    this(uri, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSocketTimeoutMillis(soTimeout).build());
+    this(uri, DefaultJedisClientConfig.builder().connectionTimeoutMillis(connectionTimeout)
+        .socketTimeoutMillis(soTimeout).build());
   }
 
   public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout,
       final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
       final HostnameVerifier hostnameVerifier) {
-    this(uri, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSocketTimeoutMillis(soTimeout).withSslSocketFactory(sslSocketFactory)
-        .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build());
+    this(uri, DefaultJedisClientConfig.builder().connectionTimeoutMillis(connectionTimeout)
+        .socketTimeoutMillis(soTimeout).sslSocketFactory(sslSocketFactory)
+        .sslParameters(sslParameters).hostnameVerifier(hostnameVerifier).build());
   }
 
   public BinaryJedis(final URI uri, final int connectionTimeout, final int soTimeout,
       final int infiniteSoTimeout, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
-    this(uri, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout)
-        .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
-        .withHostnameVerifier(hostnameVerifier).build());
+    this(uri, DefaultJedisClientConfig.builder().connectionTimeoutMillis(connectionTimeout)
+        .socketTimeoutMillis(soTimeout).blockingSocketTimeoutMillis(infiniteSoTimeout)
+        .sslSocketFactory(sslSocketFactory).sslParameters(sslParameters)
+        .hostnameVerifier(hostnameVerifier).build());
   }
 
   public BinaryJedis(final URI uri, JedisClientConfig config) {
@@ -247,15 +247,15 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
         "Cannot open Redis connection due invalid URI \"%s\".", uri.toString()));
     }
     client = new Client(new HostAndPort(uri.getHost(), uri.getPort()), DefaultJedisClientConfig
-        .builder().withConnectionTimeoutMillis(config.getConnectionTimeoutMillis())
-        .withSocketTimeoutMillis(config.getSocketTimeoutMillis())
-        .withBlockingSocketTimeoutMillis(config.getBlockingSocketTimeoutMillis())
-        .withUser(JedisURIHelper.getUser(uri)).withPassword(JedisURIHelper.getPassword(uri))
-        .withDatabse(JedisURIHelper.getDBIndex(uri)).withClientName(config.getClientName())
-        .withSsl(JedisURIHelper.isRedisSSLScheme(uri))
-        .withSslSocketFactory(config.getSslSocketFactory())
-        .withSslParameters(config.getSslParameters())
-        .withHostnameVerifier(config.getHostnameVerifier()).build());
+        .builder().connectionTimeoutMillis(config.getConnectionTimeoutMillis())
+        .socketTimeoutMillis(config.getSocketTimeoutMillis())
+        .blockingSocketTimeoutMillis(config.getBlockingSocketTimeoutMillis())
+        .user(JedisURIHelper.getUser(uri)).password(JedisURIHelper.getPassword(uri))
+        .databse(JedisURIHelper.getDBIndex(uri)).clientName(config.getClientName())
+        .ssl(JedisURIHelper.isRedisSSLScheme(uri))
+        .sslSocketFactory(config.getSslSocketFactory())
+        .sslParameters(config.getSslParameters())
+        .hostnameVerifier(config.getHostnameVerifier()).build());
     initializeFromURI(uri);
   }
 
@@ -265,7 +265,7 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
         "Cannot open Redis connection due invalid URI \"%s\".", uri.toString()));
     }
     return new Client(new HostAndPort(uri.getHost(), uri.getPort()), DefaultJedisClientConfig
-        .builder().withSsl(JedisURIHelper.isRedisSSLScheme(uri)).build());
+        .builder().ssl(JedisURIHelper.isRedisSSLScheme(uri)).build());
   }
 
   private void initializeFromURI(URI uri) {

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -55,7 +55,7 @@ public class Connection implements Closeable {
    */
   @Deprecated
   public Connection(final String host, final int port, final boolean ssl) {
-    this(new HostAndPort(host, port), DefaultJedisClientConfig.builder().withSsl(ssl).build());
+    this(new HostAndPort(host, port), DefaultJedisClientConfig.builder().ssl(ssl).build());
   }
 
   /**
@@ -65,9 +65,9 @@ public class Connection implements Closeable {
   public Connection(final String host, final int port, final boolean ssl,
       SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier) {
-    this(new HostAndPort(host, port), DefaultJedisClientConfig.builder().withSsl(ssl)
-        .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
-        .withHostnameVerifier(hostnameVerifier).build());
+    this(new HostAndPort(host, port), DefaultJedisClientConfig.builder().ssl(ssl)
+        .sslSocketFactory(sslSocketFactory).sslParameters(sslParameters)
+        .hostnameVerifier(hostnameVerifier).build());
   }
 
   public Connection(final HostAndPort hostAndPort, final JedisClientConfig clientConfig) {

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -72,8 +72,8 @@ public class Connection implements Closeable {
 
   public Connection(final HostAndPort hostAndPort, final JedisClientConfig clientConfig) {
     this(new DefaultJedisSocketFactory(hostAndPort, clientConfig));
-    this.soTimeout = clientConfig.getSoTimeoutMillis();
-    this.infiniteSoTimeout = clientConfig.getInfiniteSoTimeoutMillis();
+    this.soTimeout = clientConfig.getSocketTimeoutMillis();
+    this.infiniteSoTimeout = clientConfig.getBlockingSocketTimeoutMillis();
   }
 
   public Connection(final JedisSocketFactory jedisSocketFactory) {

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -131,62 +131,62 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
           sslParameters, hostnameVerifier, hostAndPortMapper);
     }
 
-    public Builder withConnectionTimeoutMillis(int connectionTimeoutMillis) {
+    public Builder connectionTimeoutMillis(int connectionTimeoutMillis) {
       this.connectionTimeoutMillis = connectionTimeoutMillis;
       return this;
     }
 
-    public Builder withSocketTimeoutMillis(int socketTimeoutMillis) {
+    public Builder socketTimeoutMillis(int socketTimeoutMillis) {
       this.socketTimeoutMillis = socketTimeoutMillis;
       return this;
     }
 
-    public Builder withBlockingSocketTimeoutMillis(int blockingSocketTimeoutMillis) {
+    public Builder blockingSocketTimeoutMillis(int blockingSocketTimeoutMillis) {
       this.blockingSocketTimeoutMillis = blockingSocketTimeoutMillis;
       return this;
     }
 
-    public Builder withUser(String user) {
+    public Builder user(String user) {
       this.user = user;
       return this;
     }
 
-    public Builder withPassword(String password) {
+    public Builder password(String password) {
       this.password = password;
       return this;
     }
 
-    public Builder withDatabse(int databse) {
+    public Builder databse(int databse) {
       this.databse = databse;
       return this;
     }
 
-    public Builder withClientName(String clientName) {
+    public Builder clientName(String clientName) {
       this.clientName = clientName;
       return this;
     }
 
-    public Builder withSsl(boolean ssl) {
+    public Builder ssl(boolean ssl) {
       this.ssl = ssl;
       return this;
     }
 
-    public Builder withSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+    public Builder sslSocketFactory(SSLSocketFactory sslSocketFactory) {
       this.sslSocketFactory = sslSocketFactory;
       return this;
     }
 
-    public Builder withSslParameters(SSLParameters sslParameters) {
+    public Builder sslParameters(SSLParameters sslParameters) {
       this.sslParameters = sslParameters;
       return this;
     }
 
-    public Builder withHostnameVerifier(HostnameVerifier hostnameVerifier) {
+    public Builder hostnameVerifier(HostnameVerifier hostnameVerifier) {
       this.hostnameVerifier = hostnameVerifier;
       return this;
     }
 
-    public Builder withHostAndPortMapper(HostAndPortMapper hostAndPortMapper) {
+    public Builder hostAndPortMapper(HostAndPortMapper hostAndPortMapper) {
       this.hostAndPortMapper = hostAndPortMapper;
       return this;
     }

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -7,8 +7,8 @@ import javax.net.ssl.SSLSocketFactory;
 public final class DefaultJedisClientConfig implements JedisClientConfig {
 
   private final int connectionTimeoutMillis;
-  private final int soTimeoutMillis;
-  private final int infiniteSoTimeoutMillis;
+  private final int socketTimeoutMillis;
+  private final int blockingSocketTimeoutMillis;
 
   private final String user;
   private final String password;
@@ -23,12 +23,12 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   private final HostAndPortMapper hostAndPortMapper;
 
   private DefaultJedisClientConfig(int connectionTimeoutMillis, int soTimeoutMillis,
-      int infiniteSoTimeoutMillis, String user, String password, int database, String clientName,
+      int blockingSocketTimeoutMillis, String user, String password, int database, String clientName,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, HostAndPortMapper hostAndPortMapper) {
     this.connectionTimeoutMillis = connectionTimeoutMillis;
-    this.soTimeoutMillis = soTimeoutMillis;
-    this.infiniteSoTimeoutMillis = infiniteSoTimeoutMillis;
+    this.socketTimeoutMillis = soTimeoutMillis;
+    this.blockingSocketTimeoutMillis = blockingSocketTimeoutMillis;
     this.user = user;
     this.password = password;
     this.database = database;
@@ -46,13 +46,13 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   }
 
   @Override
-  public int getSoTimeoutMillis() {
-    return soTimeoutMillis;
+  public int getSocketTimeoutMillis() {
+    return socketTimeoutMillis;
   }
 
   @Override
-  public int getInfiniteSoTimeoutMillis() {
-    return infiniteSoTimeoutMillis;
+  public int getBlockingSocketTimeoutMillis() {
+    return blockingSocketTimeoutMillis;
   }
 
   @Override
@@ -107,8 +107,8 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   public static class Builder {
 
     private int connectionTimeoutMillis = Protocol.DEFAULT_TIMEOUT;
-    private int soTimeoutMillis = Protocol.DEFAULT_TIMEOUT;
-    private int infiniteSoTimeoutMillis = 0;
+    private int socketTimeoutMillis = Protocol.DEFAULT_TIMEOUT;
+    private int blockingSocketTimeoutMillis = 0;
 
     private String user = null;
     private String password = null;
@@ -126,8 +126,8 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     }
 
     public DefaultJedisClientConfig build() {
-      return new DefaultJedisClientConfig(connectionTimeoutMillis, soTimeoutMillis,
-          infiniteSoTimeoutMillis, user, password, databse, clientName, ssl, sslSocketFactory,
+      return new DefaultJedisClientConfig(connectionTimeoutMillis, socketTimeoutMillis,
+          blockingSocketTimeoutMillis, user, password, databse, clientName, ssl, sslSocketFactory,
           sslParameters, hostnameVerifier, hostAndPortMapper);
     }
 
@@ -136,13 +136,13 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
       return this;
     }
 
-    public Builder withSoTimeoutMillis(int soTimeoutMillis) {
-      this.soTimeoutMillis = soTimeoutMillis;
+    public Builder withSocketTimeoutMillis(int socketTimeoutMillis) {
+      this.socketTimeoutMillis = socketTimeoutMillis;
       return this;
     }
 
-    public Builder withInfiniteSoTimeoutMillis(int infiniteSoTimeoutMillis) {
-      this.infiniteSoTimeoutMillis = infiniteSoTimeoutMillis;
+    public Builder withBlockingSocketTimeoutMillis(int blockingSocketTimeoutMillis) {
+      this.blockingSocketTimeoutMillis = blockingSocketTimeoutMillis;
       return this;
     }
 
@@ -194,7 +194,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
 
   public static DefaultJedisClientConfig copyConfig(JedisClientConfig copy) {
     return new DefaultJedisClientConfig(copy.getConnectionTimeoutMillis(),
-        copy.getSoTimeoutMillis(), copy.getInfiniteSoTimeoutMillis(), copy.getUser(),
+        copy.getSocketTimeoutMillis(), copy.getBlockingSocketTimeoutMillis(), copy.getUser(),
         copy.getPassword(), copy.getDatabase(), copy.getClientName(), copy.isSsl(),
         copy.getSslSocketFactory(), copy.getSslParameters(), copy.getHostnameVerifier(),
         copy.getHostAndPortMapper());

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -18,7 +18,7 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
 
   private HostAndPort hostAndPort = DEFAULT_HOST_AND_PORT;
   private int connectionTimeout = Protocol.DEFAULT_TIMEOUT;
-  private int soTimeout = Protocol.DEFAULT_TIMEOUT;
+  private int socketTimeout = Protocol.DEFAULT_TIMEOUT;
   private boolean ssl = false;
   private SSLSocketFactory sslSocketFactory = null;
   private SSLParameters sslParameters = null;
@@ -33,12 +33,12 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
   }
 
   @Deprecated
-  public DefaultJedisSocketFactory(String host, int port, int connectionTimeout, int soTimeout,
+  public DefaultJedisSocketFactory(String host, int port, int connectionTimeout, int socketTimeout,
       boolean ssl, SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier) {
     this.hostAndPort = new HostAndPort(host, port);
     this.connectionTimeout = connectionTimeout;
-    this.soTimeout = soTimeout;
+    this.socketTimeout = socketTimeout;
     this.ssl = ssl;
     this.sslSocketFactory = sslSocketFactory;
     this.sslParameters = sslParameters;
@@ -49,7 +49,7 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
     this.hostAndPort = hostAndPort;
     if (config != null) {
       this.connectionTimeout = config.getConnectionTimeoutMillis();
-      this.soTimeout = config.getSoTimeoutMillis();
+      this.socketTimeout = config.getSocketTimeoutMillis();
       this.ssl = config.isSsl();
       this.sslSocketFactory = config.getSslSocketFactory();
       this.sslParameters = config.getSslParameters();
@@ -162,12 +162,12 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
 
   @Override
   public int getSoTimeout() {
-    return this.soTimeout;
+    return this.socketTimeout;
   }
 
   @Override
   public void setSoTimeout(int soTimeout) {
-    this.soTimeout = soTimeout;
+    this.socketTimeout = soTimeout;
   }
 
   public boolean isSsl() {

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -16,7 +16,7 @@ public interface JedisClientConfig {
   /**
    * @return Socket timeout in milliseconds
    */
-  default int getSoTimeoutMillis() {
+  default int getSocketTimeoutMillis() {
     return Protocol.DEFAULT_TIMEOUT;
   }
 
@@ -24,7 +24,7 @@ public interface JedisClientConfig {
    * @return Socket timeout (in milliseconds) to use during blocking operation. Default is '0',
    * which means to block forever.
    */
-  default int getInfiniteSoTimeoutMillis() {
+  default int getBlockingSocketTimeoutMillis() {
     return 0;
   }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -75,12 +75,12 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
       SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap portMap) {
     this(nodes, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout)
+        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout)
         .withUser(user).withPassword(password).withClientName(clientName).withSsl(ssl)
         .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
         .withHostnameVerifier(hostnameVerifier).build(), poolConfig, DefaultJedisClientConfig
-        .builder().withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
-        .withInfiniteSoTimeoutMillis(infiniteSoTimeout).withUser(user).withPassword(password)
+        .builder().withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
+        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).withUser(user).withPassword(password)
         .withClientName(clientName).withSsl(ssl).withSslSocketFactory(sslSocketFactory)
         .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier)
         .withHostAndPortMapper(portMap).build());

--- a/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterConnectionHandler.java
@@ -74,16 +74,16 @@ public abstract class JedisClusterConnectionHandler implements Closeable {
       int infiniteSoTimeout, String user, String password, String clientName, boolean ssl,
       SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, JedisClusterHostAndPortMap portMap) {
-    this(nodes, DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout)
-        .withUser(user).withPassword(password).withClientName(clientName).withSsl(ssl)
-        .withSslSocketFactory(sslSocketFactory).withSslParameters(sslParameters)
-        .withHostnameVerifier(hostnameVerifier).build(), poolConfig, DefaultJedisClientConfig
-        .builder().withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
-        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).withUser(user).withPassword(password)
-        .withClientName(clientName).withSsl(ssl).withSslSocketFactory(sslSocketFactory)
-        .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier)
-        .withHostAndPortMapper(portMap).build());
+    this(nodes, DefaultJedisClientConfig.builder().connectionTimeoutMillis(connectionTimeout)
+        .socketTimeoutMillis(soTimeout).blockingSocketTimeoutMillis(infiniteSoTimeout)
+        .user(user).password(password).clientName(clientName).ssl(ssl)
+        .sslSocketFactory(sslSocketFactory).sslParameters(sslParameters)
+        .hostnameVerifier(hostnameVerifier).build(), poolConfig, DefaultJedisClientConfig
+        .builder().connectionTimeoutMillis(connectionTimeout).socketTimeoutMillis(soTimeout)
+        .blockingSocketTimeoutMillis(infiniteSoTimeout).user(user).password(password)
+        .clientName(clientName).ssl(ssl).sslSocketFactory(sslSocketFactory)
+        .sslParameters(sslParameters).hostnameVerifier(hostnameVerifier)
+        .hostAndPortMapper(portMap).build());
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -124,11 +124,11 @@ public class JedisClusterInfoCache {
       SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, HostAndPortMapper hostAndPortMap) {
     this(poolConfig, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
-        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).withUser(user).withPassword(password)
-        .withClientName(clientName).withSsl(ssl).withSslSocketFactory(sslSocketFactory)
-        .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier)
-        .withHostAndPortMapper(hostAndPortMap).build());
+        .connectionTimeoutMillis(connectionTimeout).socketTimeoutMillis(soTimeout)
+        .blockingSocketTimeoutMillis(infiniteSoTimeout).user(user).password(password)
+        .clientName(clientName).ssl(ssl).sslSocketFactory(sslSocketFactory)
+        .sslParameters(sslParameters).hostnameVerifier(hostnameVerifier)
+        .hostAndPortMapper(hostAndPortMap).build());
   }
 
   public JedisClusterInfoCache(final GenericObjectPoolConfig<Jedis> poolConfig,

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -124,8 +124,8 @@ public class JedisClusterInfoCache {
       SSLSocketFactory sslSocketFactory, SSLParameters sslParameters,
       HostnameVerifier hostnameVerifier, HostAndPortMapper hostAndPortMap) {
     this(poolConfig, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(connectionTimeout).withSoTimeoutMillis(soTimeout)
-        .withInfiniteSoTimeoutMillis(infiniteSoTimeout).withUser(user).withPassword(password)
+        .withConnectionTimeoutMillis(connectionTimeout).withSocketTimeoutMillis(soTimeout)
+        .withBlockingSocketTimeoutMillis(infiniteSoTimeout).withUser(user).withPassword(password)
         .withClientName(clientName).withSsl(ssl).withSslSocketFactory(sslSocketFactory)
         .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier)
         .withHostAndPortMapper(hostAndPortMap).build());

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -68,7 +68,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this.hostAndPort.set(new HostAndPort(host, port));
     this.config = DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout).withUser(user)
+        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout).withUser(user)
         .withPassword(password).withDatabse(database).withClientName(clientName)
         .withSsl(ssl).withSslSocketFactory(sslSocketFactory)
         .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build();
@@ -94,7 +94,7 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
     }
     this.hostAndPort.set(new HostAndPort(uri.getHost(), uri.getPort()));
     this.config = DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSoTimeoutMillis(soTimeout).withInfiniteSoTimeoutMillis(infiniteSoTimeout)
+        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout)
         .withUser(JedisURIHelper.getUser(uri)).withPassword(JedisURIHelper.getPassword(uri))
         .withDatabse(JedisURIHelper.getDBIndex(uri)).withClientName(clientName)
         .withSsl(JedisURIHelper.isRedisSSLScheme(uri)).withSslSocketFactory(sslSocketFactory)

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -67,11 +67,11 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
       final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
       final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier) {
     this.hostAndPort.set(new HostAndPort(host, port));
-    this.config = DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout).withUser(user)
-        .withPassword(password).withDatabse(database).withClientName(clientName)
-        .withSsl(ssl).withSslSocketFactory(sslSocketFactory)
-        .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build();
+    this.config = DefaultJedisClientConfig.builder().connectionTimeoutMillis(connectionTimeout)
+        .socketTimeoutMillis(soTimeout).blockingSocketTimeoutMillis(infiniteSoTimeout).user(user)
+        .password(password).databse(database).clientName(clientName)
+        .ssl(ssl).sslSocketFactory(sslSocketFactory)
+        .sslParameters(sslParameters).hostnameVerifier(hostnameVerifier).build();
   }
 
   JedisFactory(final URI uri, final int connectionTimeout, final int soTimeout,
@@ -93,12 +93,12 @@ class JedisFactory implements PooledObjectFactory<Jedis> {
           "Cannot open Redis connection due invalid URI. %s", uri.toString()));
     }
     this.hostAndPort.set(new HostAndPort(uri.getHost(), uri.getPort()));
-    this.config = DefaultJedisClientConfig.builder().withConnectionTimeoutMillis(connectionTimeout)
-        .withSocketTimeoutMillis(soTimeout).withBlockingSocketTimeoutMillis(infiniteSoTimeout)
-        .withUser(JedisURIHelper.getUser(uri)).withPassword(JedisURIHelper.getPassword(uri))
-        .withDatabse(JedisURIHelper.getDBIndex(uri)).withClientName(clientName)
-        .withSsl(JedisURIHelper.isRedisSSLScheme(uri)).withSslSocketFactory(sslSocketFactory)
-        .withSslParameters(sslParameters).withHostnameVerifier(hostnameVerifier).build();
+    this.config = DefaultJedisClientConfig.builder().connectionTimeoutMillis(connectionTimeout)
+        .socketTimeoutMillis(soTimeout).blockingSocketTimeoutMillis(infiniteSoTimeout)
+        .user(JedisURIHelper.getUser(uri)).password(JedisURIHelper.getPassword(uri))
+        .databse(JedisURIHelper.getDBIndex(uri)).clientName(clientName)
+        .ssl(JedisURIHelper.isRedisSSLScheme(uri)).sslSocketFactory(sslSocketFactory)
+        .sslParameters(sslParameters).hostnameVerifier(hostnameVerifier).build();
   }
 
   public void setHostAndPort(final HostAndPort hostAndPort) {

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -632,7 +632,7 @@ public class JedisClusterTest {
   public void testJedisClusterTimeoutWithConfig() {
     HostAndPort hp = nodeInfo1;
     try (JedisCluster jc = new JedisCluster(hp, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(4000).withSoTimeoutMillis(4000).withPassword("cluster").build(),
+        .withConnectionTimeoutMillis(4000).withSocketTimeoutMillis(4000).withPassword("cluster").build(),
         DEFAULT_REDIRECTIONS, DEFAULT_POOL_CONFIG)) {
 
       jc.getClusterNodes().values().forEach(pool -> {

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -61,7 +61,7 @@ public class JedisClusterTest {
   private static final int DEFAULT_REDIRECTIONS = 5;
   private static final JedisPoolConfig DEFAULT_POOL_CONFIG = new JedisPoolConfig();
   private static final DefaultJedisClientConfig DEFAULT_CLIENT_CONFIG
-      = DefaultJedisClientConfig.builder().withPassword("cluster").build();
+      = DefaultJedisClientConfig.builder().password("cluster").build();
 
   private HostAndPort nodeInfo1 = HostAndPortUtil.getClusterServers().get(0);
   private HostAndPort nodeInfo2 = HostAndPortUtil.getClusterServers().get(1);
@@ -218,7 +218,7 @@ public class JedisClusterTest {
     HostAndPort hp = new HostAndPort("127.0.0.1", 7379);
     String clientName = "config-pattern-app";
     try (JedisCluster jc = new JedisCluster(Collections.singleton(hp),
-        DefaultJedisClientConfig.builder().withPassword("cluster").withClientName(clientName).build(),
+        DefaultJedisClientConfig.builder().password("cluster").clientName(clientName).build(),
         DEFAULT_REDIRECTIONS, DEFAULT_POOL_CONFIG)) {
       jc.getClusterNodes().values().forEach(jedisPool -> {
         try (Jedis jedis = jedisPool.getResource()) {
@@ -632,7 +632,7 @@ public class JedisClusterTest {
   public void testJedisClusterTimeoutWithConfig() {
     HostAndPort hp = nodeInfo1;
     try (JedisCluster jc = new JedisCluster(hp, DefaultJedisClientConfig.builder()
-        .withConnectionTimeoutMillis(4000).withSocketTimeoutMillis(4000).withPassword("cluster").build(),
+        .connectionTimeoutMillis(4000).socketTimeoutMillis(4000).password("cluster").build(),
         DEFAULT_REDIRECTIONS, DEFAULT_POOL_CONFIG)) {
 
       jc.getClusterNodes().values().forEach(pool -> {

--- a/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisPoolWithCompleteCredentialsTest.java
@@ -85,7 +85,7 @@ public class JedisPoolWithCompleteCredentialsTest {
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
     try (JedisPool pool = new JedisPool(config, hnp, DefaultJedisClientConfig.builder()
-        .withUser("acljedis").withPassword("fizzbuzz").withClientName("closable-resuable-pool")
+        .user("acljedis").password("fizzbuzz").clientName("closable-resuable-pool")
         .build())) {
 
       Jedis jedis = pool.getResource();

--- a/src/test/java/redis/clients/jedis/tests/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisTest.java
@@ -68,7 +68,7 @@ public class JedisTest extends JedisCommandTestBase {
       jedis.auth("foobared");
       assertEquals("PONG", jedis.ping());
     }
-    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().withPassword("foobared")
+    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().password("foobared")
         .build())) {
       assertEquals("PONG", jedis.ping());
     }

--- a/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisWithCompleteCredentialsTest.java
@@ -56,8 +56,8 @@ public class JedisWithCompleteCredentialsTest extends JedisCommandTestBase {
       jedis.auth("acljedis", "fizzbuzz");
       assertEquals("PONG", jedis.ping());
     }
-    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().withUser("acljedis")
-        .withPassword("fizzbuzz").build())) {
+    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().user("acljedis")
+        .password("fizzbuzz").build())) {
       assertEquals("PONG", jedis.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisTest.java
@@ -65,7 +65,7 @@ public class SSLJedisTest {
   @Test
   public void connectWithConfig() {
     try (Jedis jedis = new Jedis(new HostAndPort("localhost", 6390), DefaultJedisClientConfig
-        .builder().withSsl(true).build())) {
+        .builder().ssl(true).build())) {
       jedis.auth("foobared");
       assertEquals("PONG", jedis.ping());
     }

--- a/src/test/java/redis/clients/jedis/tests/SSLJedisWithCompleteCredentialsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/SSLJedisWithCompleteCredentialsTest.java
@@ -49,7 +49,7 @@ public class SSLJedisWithCompleteCredentialsTest {
   @Test
   public void connectWithConfig() {
     try (Jedis jedis = new Jedis(new HostAndPort("localhost", 6390), DefaultJedisClientConfig
-        .builder().withSsl(true).build())) {
+        .builder().ssl(true).build())) {
       jedis.auth("acljedis", "fizzbuzz");
       assertEquals("PONG", jedis.ping());
     }


### PR DESCRIPTION
Renamed:
1. soTimeout -> socketTimeout
    - We don't have to follow naming patterns of Java Socket implementation. Many users don't know there is a Java Socket under the hood and the name and the unit (milliseconds) are coming from there. And they get pretty confused. Longer names should at least decrease some confusion.
2. infinite -> blocking
    - It should be more descriptive and easier to understand.
3. Builder methods - removed `with` prefix
    - The World is moving away from `with`, `use`, etc prefixes.