### PR TITLE
Rename xpendingSummary to xpending

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -1764,6 +1764,10 @@ public class BinaryClient extends Connection {
     sendCommand(XREADGROUP, args);
   }
 
+  public void xpending(final byte[] key, final byte[] groupname) {
+    sendCommand(XPENDING, key, groupname);
+  }
+
   public void xpending(byte[] key, byte[] groupname, byte[] start, byte[] end, int count,
       byte[] consumername) {
     if (consumername == null) {
@@ -1771,10 +1775,6 @@ public class BinaryClient extends Connection {
     } else {
       sendCommand(XPENDING, key, groupname, start, end, toByteArray(count), consumername);
     }
-  }
-
-  public void xpendingSummary(final byte[] key, final byte[] groupname) {
-    sendCommand(XPENDING, key, groupname);
   }
 
   public void xclaim(byte[] key, byte[] groupname, byte[] consumername, long minIdleTime,

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -4651,9 +4651,9 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
   }
 
   @Override
-  public Object xpendingSummary(final byte[] key, final byte[] groupname) {
+  public Object xpending(final byte[] key, final byte[] groupname) {
     checkIsInMultiOrPipeline();
-    client.xpendingSummary(key, groupname);
+    client.xpending(key, groupname);
     return client.getOne();
   }
 

--- a/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisCluster.java
@@ -2568,11 +2568,11 @@ public class BinaryJedisCluster implements BinaryJedisClusterCommands,
   }
 
   @Override
-  public Object xpendingSummary(final byte[] key, final byte[] groupname) {
+  public Object xpending(final byte[] key, final byte[] groupname) {
     return new JedisClusterCommand<Object>(connectionHandler, maxAttempts) {
       @Override
       public Object execute(Jedis connection) {
-        return connection.xpendingSummary(key, groupname);
+        return connection.xpending(key, groupname);
       }
     }.runBinary(key);
   }

--- a/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryShardedJedis.java
@@ -1201,9 +1201,9 @@ public class BinaryShardedJedis extends Sharded<Jedis, JedisShardInfo> implement
   }
 
   @Override
-  public Object xpendingSummary(final byte[] key, final byte[] groupname) {
+  public Object xpending(final byte[] key, final byte[] groupname) {
     Jedis j = getShard(key);
-    return j.xpendingSummary(key, groupname);
+    return j.xpending(key, groupname);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -1492,15 +1492,15 @@ public class Client extends BinaryClient implements Commands {
   }
 
   @Override
+  public void xpending(String key, String groupname) {
+    xpending(SafeEncoder.encode(key), SafeEncoder.encode(groupname));
+  }
+
+  @Override
   public void xpending(String key, String groupname, StreamEntryID start, StreamEntryID end,
       int count, String consumername) {
     xpending(SafeEncoder.encode(key), SafeEncoder.encode(groupname), SafeEncoder.encode(start==null ? "-" : start.toString()),
         SafeEncoder.encode(end==null ? "+" : end.toString()), count, consumername == null? null : SafeEncoder.encode(consumername));
-  }
-
-  @Override
-  public void xpendingSummary(String key, String groupname) {
-    xpendingSummary(SafeEncoder.encode(key), SafeEncoder.encode(groupname));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -4231,18 +4231,18 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   @Override
+  public StreamPendingSummary xpending(final String key, final String groupname) {
+    checkIsInMultiOrPipeline();
+    client.xpending(key, groupname);
+    return BuilderFactory.STREAM_PENDING_SUMMARY.build(client.getObjectMultiBulkReply());
+  }
+
+  @Override
   public List<StreamPendingEntry> xpending(final String key, final String groupname,
       final StreamEntryID start, final StreamEntryID end, final int count, final String consumername) {
     checkIsInMultiOrPipeline();
     client.xpending(key, groupname, start, end, count, consumername);
     return BuilderFactory.STREAM_PENDING_ENTRY_LIST.build(client.getObjectMultiBulkReply());
-  }
-
-  @Override
-  public StreamPendingSummary xpendingSummary(final String key, final String groupname) {
-    checkIsInMultiOrPipeline();
-    client.xpendingSummary(key, groupname);
-    return BuilderFactory.STREAM_PENDING_SUMMARY.build(client.getObjectMultiBulkReply());
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -2629,22 +2629,22 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   }
 
   @Override
+  public StreamPendingSummary xpending(final String key, final String groupname) {
+    return new JedisClusterCommand<StreamPendingSummary>(connectionHandler, maxAttempts) {
+      @Override
+      public StreamPendingSummary execute(Jedis connection) {
+        return connection.xpending(key, groupname);
+      }
+    }.run(key);
+  }
+
+  @Override
   public List<StreamPendingEntry> xpending(final String key, final String groupname,
       final StreamEntryID start, final StreamEntryID end, final int count, final String consumername) {
     return new JedisClusterCommand<List<StreamPendingEntry>>(connectionHandler, maxAttempts) {
       @Override
       public List<StreamPendingEntry> execute(Jedis connection) {
         return connection.xpending(key, groupname, start, end, count, consumername);
-      }
-    }.run(key);
-  }
-
-  @Override
-  public StreamPendingSummary xpendingSummary(final String key, final String groupname) {
-    return new JedisClusterCommand<StreamPendingSummary>(connectionHandler, maxAttempts) {
-      @Override
-      public StreamPendingSummary execute(Jedis connection) {
-        return connection.xpendingSummary(key, groupname);
       }
     }.run(key);
   }

--- a/src/main/java/redis/clients/jedis/PipelineBase.java
+++ b/src/main/java/redis/clients/jedis/PipelineBase.java
@@ -2224,6 +2224,18 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
   }
 
   @Override
+  public Response<StreamPendingSummary> xpending(String key, String groupname) {
+    getClient(key).xpending(key, groupname);
+    return getResponse(BuilderFactory.STREAM_PENDING_SUMMARY);
+  }
+
+  @Override
+  public Response<Object> xpending(byte[] key, byte[] groupname) {
+    getClient(key).xpending(key, groupname);
+    return getResponse(BuilderFactory.RAW_OBJECT);
+  }
+
+  @Override
   public Response<List<StreamPendingEntry>> xpending(String key, String groupname,
       StreamEntryID start, StreamEntryID end, int count, String consumername) {
     getClient(key).xpending(key, groupname, start, end, count, consumername);
@@ -2242,18 +2254,6 @@ public abstract class PipelineBase extends Queable implements BinaryRedisPipelin
       byte[] end, int count, byte[] consumername) {
     getClient(key).xpending(key, groupname, start, end, count, consumername);
     return getResponse(BuilderFactory.RAW_OBJECT_LIST);
-  }
-
-  @Override
-  public Response<StreamPendingSummary> xpendingSummary(String key, String groupname) {
-    getClient(key).xpendingSummary(key, groupname);
-    return getResponse(BuilderFactory.STREAM_PENDING_SUMMARY);
-  }
-
-  @Override
-  public Response<Object> xpendingSummary(byte[] key, byte[] groupname) {
-    getClient(key).xpendingSummary(key, groupname);
-    return getResponse(BuilderFactory.RAW_OBJECT);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/ShardedJedis.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedis.java
@@ -1190,16 +1190,16 @@ public class ShardedJedis extends BinaryShardedJedis implements JedisCommands, C
   }
 
   @Override
+  public StreamPendingSummary xpending(String key, String groupname) {
+    Jedis j = getShard(key);
+    return j.xpending(key, groupname);
+  }
+
+  @Override
   public List<StreamPendingEntry> xpending(String key, String groupname, StreamEntryID start,
       StreamEntryID end, int count, String consumername) {
     Jedis j = getShard(key);
     return j.xpending(key, groupname, start, end, count, consumername);
-  }
-
-  @Override
-  public StreamPendingSummary xpendingSummary(String key, String groupname) {
-    Jedis j = getShard(key);
-    return j.xpendingSummary(key, groupname);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisClusterCommands.java
@@ -411,9 +411,9 @@ public interface BinaryJedisClusterCommands {
 
   Long xtrim(byte[] key, long maxLen, boolean approximateLength);
 
-  List<Object> xpending(byte[] key, byte[] groupname, byte[] start, byte[] end, int count, byte[] consumername);
+  Object xpending(final byte[] key, final byte[] groupname);
 
-  Object xpendingSummary(final byte[] key, final byte[] groupname);
+  List<Object> xpending(byte[] key, byte[] groupname, byte[] start, byte[] end, int count, byte[] consumername);
 
   List<byte[]> xclaim(byte[] key, byte[] groupname, byte[] consumername, long minIdleTime, long newIdleTime, int retries, boolean force, byte[][] ids);
 

--- a/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryJedisCommands.java
@@ -441,9 +441,9 @@ public interface BinaryJedisCommands {
 
   Long xtrim(byte[] key, long maxLen, boolean approximateLength);
 
-  List<Object> xpending(byte[] key, byte[] groupname, byte[] start, byte[] end, int count, byte[] consumername);
+  Object xpending(byte[] key, byte[] groupname);
 
-  Object xpendingSummary(byte[] key, byte[] groupname);
+  List<Object> xpending(byte[] key, byte[] groupname, byte[] start, byte[] end, int count, byte[] consumername);
 
   List<byte[]> xclaim(byte[] key, byte[] groupname, byte[] consumername, long minIdleTime, long newIdleTime, int retries, boolean force, byte[]... ids);
 

--- a/src/main/java/redis/clients/jedis/commands/BinaryRedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/BinaryRedisPipeline.java
@@ -399,6 +399,8 @@ public interface BinaryRedisPipeline {
 
   Response<Long> xgroupDelConsumer(byte[] key, byte[] groupname, byte[] consumername);
 
+  Response<Object> xpending(byte[] key, byte[] groupname);
+
   /**
    * @deprecated Use {@link #xpendingBinary(byte[], byte[], byte[], byte[], int, byte[])}.
    */
@@ -406,8 +408,6 @@ public interface BinaryRedisPipeline {
   Response<List<StreamPendingEntry>> xpending(byte[] key, byte[] groupname, byte[] start, byte[] end, int count, byte[] consumername);
 
   Response<List<Object>> xpendingBinary(byte[] key, byte[] groupname, byte[] start, byte[] end, int count, byte[] consumername);
-
-  Response<Object> xpendingSummary(byte[] key, byte[] groupname);
 
   Response<Long> xdel(byte[] key, byte[]... ids);
 

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -483,9 +483,9 @@ public interface Commands {
 
   void xreadGroup(String groupname, String consumer, XReadGroupParams params, Map<String, StreamEntryID> streams);
 
-  void xpending(String key, String groupname, StreamEntryID start, StreamEntryID end, int count, String consumername);
+  void xpending(String key, String groupname);
 
-  void xpendingSummary(String key, String groupname);
+  void xpending(String key, String groupname, StreamEntryID start, StreamEntryID end, int count, String consumername);
 
   void xclaim(String key, String group, String consumername, long minIdleTime, long newIdleTime,
       int retries, boolean force, StreamEntryID... ids);

--- a/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisClusterCommands.java
@@ -463,7 +463,7 @@ public interface JedisClusterCommands {
   List<StreamEntry> xrevrange(String key, StreamEntryID end, StreamEntryID start, int count);
 
   /**
-   * @deprecated Will be removed in future version. Use
+   * @deprecated This will be removed in future version. Use
    * {@link MultiKeyJedisClusterCommands#xread(int, long, java.util.Map.Entry...)}.
    */
   @Deprecated
@@ -517,11 +517,20 @@ public interface JedisClusterCommands {
   Long xgroupDelConsumer( String key, String groupname, String consumername);
 
   /**
-   * @deprecated Will be removed in future version. Use
+   * @deprecated This will be removed in future version. Use
    * {@link MultiKeyJedisClusterCommands#xreadGroup(java.lang.String, java.lang.String, int, long, boolean, java.util.Map.Entry...)}.
    */
   @Deprecated
   List<Map.Entry<String, List<StreamEntry>>> xreadGroup(String groupname, String consumer, int count, long block, boolean noAck, Map.Entry<String, StreamEntryID>... streams);
+
+  /**
+   * XPENDING key group
+   *
+   * @param key
+   * @param groupname
+   * @return
+   */
+  StreamPendingSummary xpending(String key, String groupname);
 
   /**
    * XPENDING key group [start end count] [consumer]
@@ -535,15 +544,6 @@ public interface JedisClusterCommands {
    * @return
    */
   List<StreamPendingEntry> xpending(String key, String groupname, StreamEntryID start, StreamEntryID end, int count, String consumername);
-
-  /**
-   * XPENDING key group
-   *
-   * @param key
-   * @param groupname
-   * @return
-   */
-  StreamPendingSummary xpendingSummary(String key, String groupname);
 
   /**
    * XDEL key ID [ID ...]

--- a/src/main/java/redis/clients/jedis/commands/JedisCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/JedisCommands.java
@@ -526,6 +526,15 @@ public interface JedisCommands {
   Long xgroupDelConsumer( String key, String groupname, String consumername);
 
   /**
+   * XPENDING key group
+   *
+   * @param key
+   * @param groupname
+   * @return
+   */
+  StreamPendingSummary xpending(String key, String groupname);
+
+  /**
    * XPENDING key group [start end count] [consumer]
    *
    * @param key
@@ -536,16 +545,8 @@ public interface JedisCommands {
    * @param consumername
    * @return
    */
-  List<StreamPendingEntry> xpending(String key, String groupname, StreamEntryID start, StreamEntryID end, int count, String consumername);
-
-  /**
-   * XPENDING key group
-   *
-   * @param key
-   * @param groupname
-   * @return
-   */
-  StreamPendingSummary xpendingSummary(String key, String groupname);
+  List<StreamPendingEntry> xpending(String key, String groupname, StreamEntryID start,
+      StreamEntryID end, int count, String consumername);
 
   /**
    * XDEL key ID [ID ...]

--- a/src/main/java/redis/clients/jedis/commands/RedisPipeline.java
+++ b/src/main/java/redis/clients/jedis/commands/RedisPipeline.java
@@ -396,10 +396,10 @@ public interface RedisPipeline {
 
   Response<Long> xgroupDelConsumer( String key, String groupname, String consumername);
 
+  Response<StreamPendingSummary> xpending(String key, String groupname);
+
   Response<List<StreamPendingEntry>> xpending(String key, String groupname,
       StreamEntryID start, StreamEntryID end, int count, String consumername);
-
-  Response<StreamPendingSummary> xpendingSummary(String key, String groupname);
 
   Response<Long> xdel( String key, StreamEntryID... ids);
 

--- a/src/test/java/redis/clients/jedis/tests/commands/StreamsCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/StreamsCommandsTest.java
@@ -431,7 +431,7 @@ public class StreamsCommandsTest extends JedisCommandTestBase {
     assertEquals(map, range.get(0).getValue().get(0).getFields());
 
     // Get the summary about the pending messages
-    StreamPendingSummary pendingSummary = jedis.xpendingSummary("xpendeing-stream", "xpendeing-group");
+    StreamPendingSummary pendingSummary = jedis.xpending("xpendeing-stream", "xpendeing-group");
     assertEquals(1, pendingSummary.getTotal());
     assertEquals(id1, pendingSummary.getMinId());
     assertEquals(1l, pendingSummary.getConsumerMessageCount().get("xpendeing-consumer").longValue());


### PR DESCRIPTION
Because there is no conflict while maintaining Redis command name.