### PR TITLE
Warn about NoReachableNodeException extending ClusterOperationException #2409

### DIFF
--- a/src/main/java/redis/clients/jedis/exceptions/JedisNoReachableClusterNodeException.java
+++ b/src/main/java/redis/clients/jedis/exceptions/JedisNoReachableClusterNodeException.java
@@ -1,5 +1,8 @@
 package redis.clients.jedis.exceptions;
 
+/**
+ * WARNING: This exception will extend {@link JedisClusterOperationException} in upcoming major release.
+ */
 public class JedisNoReachableClusterNodeException extends JedisConnectionException {
     private static final long serialVersionUID = 3878122572474110407L;
 


### PR DESCRIPTION
Warn about JedisNoReachableClusterNodeException should extend JedisClusterOperationException (II) #2409