### PR TITLE
Remove slave to jedisPool mapping

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -162,7 +162,6 @@ public class JedisClusterInfoCache {
           }
 
           HostAndPort targetNode = generateHostAndPort(hostInfos);
-          setupNodeIfNotExist(targetNode);
           if (i == MASTER_NODE_INDEX) {
             assignSlotsToNode(slotNums, targetNode);
           }


### PR DESCRIPTION
Recently occurred such a problem in our project: There are some redis clusters on K8s deployed and managed by us, after the business service runs for a period of time using one of the RedisCluster (cluster A), one of the shards of the cluster fails, and then the business service connects to another cluster(cluster B) through the JedisCluster.

In some cases, such as redis on K8s or some cloud service platforms, there may be situations where the redis node address has been reused by another redis cluster, for example:

```
Cluster A:
192.168.1.100:6379 master		192.168.1.103:6379 slave
192.168.1.101:6379 master		192.168.1.104:6379 slave
192.168.1.102:6379 master		192.168.1.105:6379 slave (down and change to another IP)
Cluster B:
192.168.1.200:6379 master		192.168.1.203:6379 slave
192.168.1.201:6379 master		192.168.1.204:6379 slave
192.168.1.202:6379 master		192.168.1.105:6379 slave (reuse the ip)
```

But the `nodes` map in `JedisInfoCache` saves the mapping of all master and slave nodes to `JedisPool`. However, the slave->JedisPool has not been updated or reset in any way during the long-running after the initialization of JedisCluster. If the address of the slave (who has down and change to another address) is reused by other clusters and this cluster fails, JedisPool is randomly selected from the `nodes` map  for service discovery, and another cluster may be discoverd, causing read and write requests to be sent to other clusters incorrectly.

So I think that the slave->JedisPool mapping should not be saved, because they are not checked after initialization but may be selected for disovery after failure.