### PR TITLE
Limit the access of setDataSource in Jedis

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3953,7 +3953,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     }
   }
 
-  public void setDataSource(Pool<Jedis> jedisPool) {
+  protected void setDataSource(Pool<Jedis> jedisPool) {
     this.dataSource = jedisPool;
   }
 


### PR DESCRIPTION
https://github.com/redis/jedis/blob/10b195f210769a0dca7826d06dafe75f6b99de41/src/main/java/redis/clients/jedis/Jedis.java#L3956-L3958

`setDataSource` is one, if not the most, key part in maintaining thread concurrency in Jedis. We may/should consider limiting access of this method to reduce concurrency related issues.

`protected` modifier seems a reasonable choice.