### PR TITLE
Allow calling PUBSUB CHANNELS without a pattern

### DIFF
--- a/src/main/java/redis/clients/jedis/Client.java
+++ b/src/main/java/redis/clients/jedis/Client.java
@@ -958,6 +958,10 @@ public class Client extends BinaryClient implements Commands {
     subscribe(SafeEncoder.encodeMany(channels));
   }
 
+  public void pubsubChannels() {
+    pubsub(Protocol.PUBSUB_CHANNELS);
+  }
+
   public void pubsubChannels(final String pattern) {
     pubsub(Protocol.PUBSUB_CHANNELS, pattern);
   }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3885,6 +3885,12 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     return client.getStatusCodeReply();
   }
 
+  public List<String> pubsubChannels() {
+    checkIsInMultiOrPipeline();
+    client.pubsubChannels();
+    return client.getMultiBulkReply();
+  }
+
   public List<String> pubsubChannels(final String pattern) {
     checkIsInMultiOrPipeline();
     client.pubsubChannels(pattern);

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -78,8 +78,8 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
           Jedis otherJedis = createJedis();
           List<String> activeChannels = otherJedis.pubsubChannels();
           // Since we are utilizing sentinel for the tests, there is an additional
-          // '__sentinel__:hello'
-          // channel that has subscribers and will be returned from PUBSUB CHANNELS.
+          // '__sentinel__:hello' channel that has subscribers and will be returned from PUBSUB
+          // CHANNELS.
           assertTrue(activeChannels.containsAll(expectedActiveChannels));
           unsubscribe();
         }

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -85,7 +85,7 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
   }
 
   @Test
-  public void pubSubChannelsWithArgument() {
+  public void pubSubChannelsWithPattern() {
     final List<String> expectedActiveChannels = Arrays
         .asList("testchan1", "testchan2", "testchan3");
     jedis.subscribe(new JedisPubSub() {

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -65,10 +65,8 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void pubSubChannels() {
-    // Since we are utilizing sentinel for the tests, there is an additional '__sentinel__:hello'
-    // channel that has subscribers.
-    final List<String> expectedActiveChannels = Arrays.asList("testchan1", "testchan2",
-      "testchan3", "__sentinel__:hello");
+    final List<String> expectedActiveChannels = Arrays
+        .asList("testchan1", "testchan2", "testchan3");
     jedis.subscribe(new JedisPubSub() {
       private int count = 0;
 
@@ -79,7 +77,10 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
         if (count == 3) {
           Jedis otherJedis = createJedis();
           List<String> activeChannels = otherJedis.pubsubChannels();
-          assertTrue(expectedActiveChannels.containsAll(activeChannels));
+          // Since we are utilizing sentinel for the tests, there is an additional
+          // '__sentinel__:hello'
+          // channel that has subscribers and will be returned from PUBSUB CHANNELS.
+          assertTrue(activeChannels.containsAll(expectedActiveChannels));
           unsubscribe();
         }
       }

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -65,8 +65,8 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void pubSubChannels() {
-    final List<String> expectedActiveChannels = Arrays
-                                                    .asList("testchan1", "testchan2", "testchan3");
+    final List<String> expectedActiveChannels = Arrays.asList("testchan1", "testchan2",
+      "testchan3", "__sentinel__:hello");
     jedis.subscribe(new JedisPubSub() {
       private int count = 0;
 

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -65,6 +65,8 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void pubSubChannels() {
+    // Since we are utilizing sentinel for the tests, there is an additional '__sentinel__:hello'
+    // channel that has subscribers.
     final List<String> expectedActiveChannels = Arrays.asList("testchan1", "testchan2",
       "testchan3", "__sentinel__:hello");
     jedis.subscribe(new JedisPubSub() {

--- a/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/PublishSubscribeCommandsTest.java
@@ -66,6 +66,27 @@ public class PublishSubscribeCommandsTest extends JedisCommandTestBase {
   @Test
   public void pubSubChannels() {
     final List<String> expectedActiveChannels = Arrays
+                                                    .asList("testchan1", "testchan2", "testchan3");
+    jedis.subscribe(new JedisPubSub() {
+      private int count = 0;
+
+      @Override
+      public void onSubscribe(String channel, int subscribedChannels) {
+        count++;
+        // All channels are subscribed
+        if (count == 3) {
+          Jedis otherJedis = createJedis();
+          List<String> activeChannels = otherJedis.pubsubChannels();
+          assertTrue(expectedActiveChannels.containsAll(activeChannels));
+          unsubscribe();
+        }
+      }
+    }, "testchan1", "testchan2", "testchan3");
+  }
+
+  @Test
+  public void pubSubChannelsWithArgument() {
+    final List<String> expectedActiveChannels = Arrays
         .asList("testchan1", "testchan2", "testchan3");
     jedis.subscribe(new JedisPubSub() {
       private int count = 0;


### PR DESCRIPTION
According to the Redis docs at https://redis.io/commands/PUBSUB#pubsub-channels-pattern PUBSUB CHANNELS should list all channels if no pattern is specified.  Currently Jedis does not support calling `pubSubChannels` without an argument.