### PR TITLE
Add ShardedJedisPoolConfig

### DIFF
--- a/src/main/java/redis/clients/jedis/ShardedJedisPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPoolConfig.java
@@ -1,0 +1,13 @@
+package redis.clients.jedis;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+public class ShardedJedisPoolConfig extends GenericObjectPoolConfig<ShardedJedis> {
+  public ShardedJedisPoolConfig() {
+    // defaults to make your life with connection pool easier :)
+    setTestWhileIdle(true);
+    setMinEvictableIdleTimeMillis(60000);
+    setTimeBetweenEvictionRunsMillis(30000);
+    setNumTestsPerEvictionRun(-1);
+  }
+}

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
@@ -18,6 +18,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.ShardedJedis;
 import redis.clients.jedis.ShardedJedisPool;
+import redis.clients.jedis.ShardedJedisPoolConfig;
 import redis.clients.jedis.exceptions.JedisExhaustedPoolException;
 
 public class ShardedJedisPoolTest {
@@ -43,8 +44,7 @@ public class ShardedJedisPoolTest {
 
   @Test
   public void checkConnections() {
-    ShardedJedisPool pool = new ShardedJedisPool(new GenericObjectPoolConfig<ShardedJedis>(),
-        shards);
+    ShardedJedisPool pool = new ShardedJedisPool(new ShardedJedisPoolConfig(), shards);
     ShardedJedis jedis = pool.getResource();
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
@@ -53,9 +53,8 @@ public class ShardedJedisPoolTest {
   }
 
   @Test
-  public void checkCloseableConnections() throws Exception {
-    ShardedJedisPool pool = new ShardedJedisPool(new GenericObjectPoolConfig<ShardedJedis>(),
-        shards);
+  public void checkCloseableConnections() {
+    ShardedJedisPool pool = new ShardedJedisPool(new ShardedJedisPoolConfig(), shards);
     ShardedJedis jedis = pool.getResource();
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
@@ -66,8 +65,7 @@ public class ShardedJedisPoolTest {
 
   @Test
   public void checkConnectionWithDefaultPort() {
-    ShardedJedisPool pool = new ShardedJedisPool(new GenericObjectPoolConfig<ShardedJedis>(),
-        shards);
+    ShardedJedisPool pool = new ShardedJedisPool(new ShardedJedisPoolConfig(), shards);
     ShardedJedis jedis = pool.getResource();
     jedis.set("foo", "bar");
     assertEquals("bar", jedis.get("foo"));
@@ -77,8 +75,7 @@ public class ShardedJedisPoolTest {
 
   @Test
   public void checkJedisIsReusedWhenReturned() {
-    ShardedJedisPool pool = new ShardedJedisPool(new GenericObjectPoolConfig<ShardedJedis>(),
-        shards);
+    ShardedJedisPool pool = new ShardedJedisPool(new ShardedJedisPoolConfig(), shards);
     ShardedJedis jedis = pool.getResource();
     jedis.set("foo", "0");
     jedis.close();
@@ -91,8 +88,7 @@ public class ShardedJedisPoolTest {
 
   @Test
   public void checkPoolRepairedWhenJedisIsBroken() {
-    ShardedJedisPool pool = new ShardedJedisPool(new GenericObjectPoolConfig<ShardedJedis>(),
-        shards);
+    ShardedJedisPool pool = new ShardedJedisPool(new ShardedJedisPoolConfig(), shards);
     ShardedJedis jedis = pool.getResource();
     jedis.disconnect();
     jedis.close();
@@ -105,7 +101,7 @@ public class ShardedJedisPoolTest {
 
   @Test(expected = JedisExhaustedPoolException.class)
   public void checkPoolOverflow() {
-    GenericObjectPoolConfig<ShardedJedis> config = new GenericObjectPoolConfig<ShardedJedis>();
+    GenericObjectPoolConfig<ShardedJedis> config = new ShardedJedisPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
 
@@ -120,7 +116,7 @@ public class ShardedJedisPoolTest {
 
   @Test
   public void shouldNotShareInstances() {
-    GenericObjectPoolConfig<ShardedJedis> config = new GenericObjectPoolConfig<ShardedJedis>();
+    GenericObjectPoolConfig<ShardedJedis> config = new ShardedJedisPoolConfig();
     config.setMaxTotal(2);
 
     ShardedJedisPool pool = new ShardedJedisPool(config, shards);
@@ -133,8 +129,7 @@ public class ShardedJedisPoolTest {
 
   @Test
   public void checkFailedJedisServer() {
-    ShardedJedisPool pool = new ShardedJedisPool(new GenericObjectPoolConfig<ShardedJedis>(),
-        shards);
+    ShardedJedisPool pool = new ShardedJedisPool(new ShardedJedisPoolConfig(), shards);
     ShardedJedis jedis = pool.getResource();
     jedis.incr("foo");
     jedis.close();
@@ -157,7 +152,7 @@ public class ShardedJedisPoolTest {
     shards.add(new JedisShardInfo("redis://:foobared@localhost:6380"));
     shards.add(new JedisShardInfo("redis://:foobared@localhost:6379"));
 
-    GenericObjectPoolConfig<ShardedJedis> redisConfig = new GenericObjectPoolConfig<ShardedJedis>();
+    GenericObjectPoolConfig<ShardedJedis> redisConfig = new ShardedJedisPoolConfig();
     ShardedJedisPool pool = new ShardedJedisPool(redisConfig, shards);
 
     Jedis[] jedises = pool.getResource().getAllShards().toArray(new Jedis[2]);
@@ -187,7 +182,7 @@ public class ShardedJedisPoolTest {
     shards.add(new JedisShardInfo(new URI("redis://:foobared@localhost:6380")));
     shards.add(new JedisShardInfo(new URI("redis://:foobared@localhost:6379")));
 
-    GenericObjectPoolConfig<ShardedJedis> redisConfig = new GenericObjectPoolConfig<ShardedJedis>();
+    GenericObjectPoolConfig<ShardedJedis> redisConfig = new ShardedJedisPoolConfig();
     ShardedJedisPool pool = new ShardedJedisPool(redisConfig, shards);
 
     Jedis[] jedises = pool.getResource().getAllShards().toArray(new Jedis[2]);
@@ -203,7 +198,7 @@ public class ShardedJedisPoolTest {
 
   @Test
   public void checkResourceIsCloseable() throws URISyntaxException {
-    GenericObjectPoolConfig<ShardedJedis> config = new GenericObjectPoolConfig<ShardedJedis>();
+    GenericObjectPoolConfig<ShardedJedis> config = new ShardedJedisPoolConfig();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
 

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
@@ -22,8 +22,8 @@ import redis.clients.jedis.ShardedJedisPoolConfig;
 import redis.clients.jedis.exceptions.JedisExhaustedPoolException;
 
 public class ShardedJedisPoolTest {
-  private static HostAndPort redis1 = HostAndPortUtil.getRedisServers().get(0);
-  private static HostAndPort redis2 = HostAndPortUtil.getRedisServers().get(1);
+  private static final HostAndPort redis1 = HostAndPortUtil.getRedisServers().get(0);
+  private static final HostAndPort redis2 = HostAndPortUtil.getRedisServers().get(1);
 
   private List<JedisShardInfo> shards;
 
@@ -148,7 +148,7 @@ public class ShardedJedisPoolTest {
     j.set("foo", "bar");
     j.disconnect();
 
-    List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
+    List<JedisShardInfo> shards = new ArrayList<>();
     shards.add(new JedisShardInfo("redis://:foobared@localhost:6380"));
     shards.add(new JedisShardInfo("redis://:foobared@localhost:6379"));
 
@@ -178,7 +178,7 @@ public class ShardedJedisPoolTest {
     j.set("foo", "bar");
     j.disconnect();
 
-    List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
+    List<JedisShardInfo> shards = new ArrayList<>();
     shards.add(new JedisShardInfo(new URI("redis://:foobared@localhost:6380")));
     shards.add(new JedisShardInfo(new URI("redis://:foobared@localhost:6379")));
 
@@ -202,7 +202,7 @@ public class ShardedJedisPoolTest {
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
 
-    List<JedisShardInfo> shards = new ArrayList<JedisShardInfo>();
+    List<JedisShardInfo> shards = new ArrayList<>();
     shards.add(new JedisShardInfo(new URI("redis://:foobared@localhost:6380")));
     shards.add(new JedisShardInfo(new URI("redis://:foobared@localhost:6379")));
 
@@ -215,11 +215,8 @@ public class ShardedJedisPoolTest {
       jedis.close();
     }
 
-    ShardedJedis jedis2 = pool.getResource();
-    try {
+    try (ShardedJedis jedis2 = pool.getResource()) {
       assertEquals(jedis, jedis2);
-    } finally {
-      jedis2.close();
     }
   }
 


### PR DESCRIPTION
Before, in our project we used to initialise `ShardedJedisPool` with `JedisPoolConfig`, which has become impossible with 3.6.0. This PR fixes that by adding `ShardedJedisPoolConfig`. This became necessary after `Jedis` was added as the type for `GenericObjectPoolConfig` in `JedisPoolConfig`:
 https://github.com/redis/jedis/pull/2391/files#diff-ac2ef340a5aeeb15580f83c0849cf4bb80d86e041a4f3a8797f891af12a8cd4dR5