### PR TITLE
Modify MEMORY USAGE tests

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
@@ -218,6 +218,9 @@ public class ControlCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void memoryUsageString() {
+    // Note: It has been recommended not to base MEMORY USAGE test on exact value, as this may
+    // subject to be 'tuned' especially targetting a major Redis release.
+
     jedis.set("foo", "bar");
     long usage = jedis.memoryUsage("foo");
     assertTrue(usage >= 30);
@@ -226,13 +229,16 @@ public class ControlCommandsTest extends JedisCommandTestBase {
     jedis.lpush("foobar", "fo", "ba", "sha");
     usage = jedis.memoryUsage("foobar", 2);
     assertTrue(usage >= 110);
-    assertTrue(usage <= 180);
+    assertTrue(usage <= 190);
 
     assertNull(jedis.memoryUsage("roo", 2));
   }
 
   @Test
   public void memoryUsageBinary() {
+    // Note: It has been recommended not to base MEMORY USAGE test on exact value, as this may
+    // subject to be 'tuned' especially targetting a major Redis release.
+
     byte[] bfoo = {0x01, 0x02, 0x03, 0x04};
     byte[] bbar = {0x05, 0x06, 0x07, 0x08};
     byte[] bfoobar = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
@@ -244,7 +250,7 @@ public class ControlCommandsTest extends JedisCommandTestBase {
 
     jedis.lpush(bfoobar, new byte[]{0x01, 0x02}, new byte[]{0x05, 0x06}, new byte[]{0x00});
     usage = jedis.memoryUsage(bfoobar, 2);
-    assertTrue(usage >= 120);
+    assertTrue(usage >= 110);
     assertTrue(usage <= 190);
 
     assertNull(jedis.memoryUsage("roo", 2));

--- a/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
@@ -218,8 +218,8 @@ public class ControlCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void memoryUsageString() {
-    // Note: It has been recommended not to base MEMORY USAGE test on exact value, as this may
-    // subject to be 'tuned' especially targetting a major Redis release.
+    // Note: It has been recommended not to base MEMORY USAGE test on exact value, as the response
+    // may subject to be 'tuned' especially targeting a major Redis release.
 
     jedis.set("foo", "bar");
     long usage = jedis.memoryUsage("foo");
@@ -236,8 +236,8 @@ public class ControlCommandsTest extends JedisCommandTestBase {
 
   @Test
   public void memoryUsageBinary() {
-    // Note: It has been recommended not to base MEMORY USAGE test on exact value, as this may
-    // subject to be 'tuned' especially targetting a major Redis release.
+    // Note: It has been recommended not to base MEMORY USAGE test on exact value, as the response
+    // may subject to be 'tuned' especially targeting a major Redis release.
 
     byte[] bfoo = {0x01, 0x02, 0x03, 0x04};
     byte[] bbar = {0x05, 0x06, 0x07, 0x08};

--- a/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ControlCommandsTest.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.tests.commands;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -218,15 +219,16 @@ public class ControlCommandsTest extends JedisCommandTestBase {
   @Test
   public void memoryUsageString() {
     jedis.set("foo", "bar");
-    Long usage = jedis.memoryUsage("foo");
-    assertEquals(53, (long) usage);
+    long usage = jedis.memoryUsage("foo");
+    assertTrue(usage >= 30);
+    assertTrue(usage <= 80);
 
     jedis.lpush("foobar", "fo", "ba", "sha");
     usage = jedis.memoryUsage("foobar", 2);
-    assertEquals(144, (long) usage);
+    assertTrue(usage >= 110);
+    assertTrue(usage <= 180);
 
-    usage = jedis.memoryUsage("roo", 2);
-    assertEquals(null, usage);
+    assertNull(jedis.memoryUsage("roo", 2));
   }
 
   @Test
@@ -236,14 +238,15 @@ public class ControlCommandsTest extends JedisCommandTestBase {
     byte[] bfoobar = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
 
     jedis.set(bfoo, bbar);
-    Long usage = jedis.memoryUsage(bfoo);
-    assertEquals(54, (long) usage);
+    long usage = jedis.memoryUsage(bfoo);
+    assertTrue(usage >= 30);
+    assertTrue(usage <= 80);
 
     jedis.lpush(bfoobar, new byte[]{0x01, 0x02}, new byte[]{0x05, 0x06}, new byte[]{0x00});
     usage = jedis.memoryUsage(bfoobar, 2);
-    assertEquals(150, (long) usage);
+    assertTrue(usage >= 120);
+    assertTrue(usage <= 190);
 
-    usage = jedis.memoryUsage("roo", 2);
-    assertEquals(null, usage);
+    assertNull(jedis.memoryUsage("roo", 2));
   }
 }


### PR DESCRIPTION
According to Redis developers, MEMORY USAGE response should not be tested with exact values.