### PR TITLE
Allow to override sharded jedis pooled object factory

### DIFF
--- a/src/main/java/redis/clients/jedis/ShardedJedisPool.java
+++ b/src/main/java/redis/clients/jedis/ShardedJedisPool.java
@@ -34,7 +34,12 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
 
   public ShardedJedisPool(final GenericObjectPoolConfig<ShardedJedis> poolConfig,
       List<JedisShardInfo> shards, Hashing algo, Pattern keyTagPattern) {
-    super(poolConfig, new ShardedJedisFactory(shards, algo, keyTagPattern));
+    this(poolConfig, new ShardedJedisFactory(shards, algo, keyTagPattern));
+  }
+
+  public ShardedJedisPool(final GenericObjectPoolConfig<ShardedJedis> poolConfig,
+      PooledObjectFactory<ShardedJedis> shardedJedisPooledObjectFactory) {
+    super(poolConfig, shardedJedisPooledObjectFactory);
   }
 
   @Override
@@ -55,7 +60,7 @@ public class ShardedJedisPool extends Pool<ShardedJedis> {
   /**
    * PoolableObjectFactory custom impl.
    */
-  private static class ShardedJedisFactory implements PooledObjectFactory<ShardedJedis> {
+  public static class ShardedJedisFactory implements PooledObjectFactory<ShardedJedis> {
 
     private final List<JedisShardInfo> shards;
     private final Hashing algo;

--- a/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ShardedJedisPoolTest.java
@@ -8,7 +8,9 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +21,7 @@ import redis.clients.jedis.JedisShardInfo;
 import redis.clients.jedis.ShardedJedis;
 import redis.clients.jedis.ShardedJedisPool;
 import redis.clients.jedis.exceptions.JedisExhaustedPoolException;
+import redis.clients.jedis.util.Hashing;
 
 public class ShardedJedisPoolTest {
   private static HostAndPort redis1 = HostAndPortUtil.getRedisServers().get(0);
@@ -226,6 +229,30 @@ public class ShardedJedisPoolTest {
     } finally {
       jedis2.close();
     }
+  }
+
+  @Test
+  public void checkOverrideFactoryValidateMethod() {
+    AtomicInteger counter = new AtomicInteger(0);
+
+    ShardedJedisPool.ShardedJedisFactory overriddenFactory = new ShardedJedisPool.ShardedJedisFactory(
+        shards, Hashing.MURMUR_HASH, null) {
+      @Override public boolean validateObject(PooledObject<ShardedJedis> pooledShardedJedis) {
+        counter.incrementAndGet();
+        return super.validateObject(pooledShardedJedis);
+      }
+    };
+
+    GenericObjectPoolConfig<ShardedJedis> poolConfig = new GenericObjectPoolConfig<>();
+    poolConfig.setTestOnReturn(true);
+    ShardedJedisPool pool = new ShardedJedisPool(poolConfig, overriddenFactory);
+    try (ShardedJedis jedis = pool.getResource();) {
+      jedis.set("foo", "bar");
+      assertEquals(0, counter.get());
+    }
+    assertEquals(1, counter.get());
+
+    pool.destroy();
   }
 
 }


### PR DESCRIPTION
Hi,

I want to be able to override default ShardedJedisFactory from ShardedJedisPool.

main reason: current validateObject() method uses PING-PONG mechanism that looks quite expensive when setTestOnReturn(true)/setTestOnBorrow(true) are set and a lot of shards are used.

I want to try something like:
```
@Override
public boolean validateObject(PooledObject<ShardedJedis> pooledShardedJedis) {
  try {
    ShardedJedis jedis = pooledShardedJedis.getObject();
    for (Jedis shard : jedis.getAllShards()) {
      if (shard.isBroken() || !shard.isConnected()) {
        return false;
      }
    }
    return true;
  } catch (RuntimeException ex) {
    return false;
  }
}
```
for our projects at https://github.com/hhru

But I am afraid what merging same code in current implementation is quite dangerous due to possible backward compatibility broke.

So I add required constructor to ShardedJedisPool and make ShardedJedisFactory public to allow in-place override. (which is tested by new unit-test)

Also fixed some code-smells (catch generic Exception instead of just Runtime, make slowlog test more stable by truncating initial state)


Feel free to ask any questions.
Excuse me for my english - I am not native speaker :)