### PR TITLE
Renew cluster slots strategy update

### DIFF
--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -23,13 +23,13 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   protected final JedisClusterInfoCache cache;
 
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig) {
-    this.cache = new JedisClusterInfoCache(clientConfig);
+    this.cache = new JedisClusterInfoCache(clientConfig, clusterNodes);
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
       GenericObjectPoolConfig<Connection> poolConfig) {
-    this.cache = new JedisClusterInfoCache(clientConfig, poolConfig);
+    this.cache = new JedisClusterInfoCache(clientConfig, poolConfig, clusterNodes);
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 


### PR DESCRIPTION
This PR solves #2551, a problem solving scenario is as follows:

1) JedisCluster jc = new JedisCluster(vip);  // now `vip -> ip1`
2) change `vip -> ip2`
3) renewClusterSlots just use getShuffledNodesPool, that is `ip1`
4) connect to `ip1`, and will never connect to `ip2`

The new strategy is as follows:
1. First, if jedis(meet JedisRedirectionException) is available, use jedis renew.
2. Then, we use startNodes to try, as long as startNodes is available,
    whether it is vip, domain, or physical ip, it will succeed.
3. Finally, we go back to the ShuffledNodesPool and try the remaining physical nodes.