### PR TITLE
Added Jedis Cluster Flush All capability.

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -2966,4 +2966,14 @@ public class JedisCluster extends BinaryJedisCluster implements JedisClusterComm
   private static String[] getKeys(final Map<String, ?> map) {
     return map.keySet().toArray(new String[map.size()]);
   }
+
+  public boolean flushAll() {
+    return new JedisClusterCommand<Boolean>(connectionHandler, maxAttempts, maxTotalRetriesDuration) {
+      @Override
+      public Boolean execute(Jedis connection) {
+        connection.flushAll();
+        return true;
+      }
+    }.runWithAllNodes((a, b) -> a && b, true);
+  }
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterCommandTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterCommandTest.java
@@ -368,4 +368,38 @@ public class JedisClusterCommandTest {
     inOrder.verify(connectionHandler).getConnectionFromSlot(anyInt());
     inOrder.verifyNoMoreInteractions();
   }
+
+  @Test
+  public void runWithAllNodes() {
+    JedisSlotBasedConnectionHandler connectionHandler = mock(JedisSlotBasedConnectionHandler.class);
+
+    boolean result = new JedisClusterCommand<Boolean>(connectionHandler, 3,
+            Duration.ZERO) {
+      @Override
+      public Boolean execute(Jedis connection) {
+        return true;
+      }
+    }.runWithAllNodes((a,b) -> a && b, true);
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void runWithAllNodesNoFailureThrownOnExceptionFromJedisCluster() {
+    JedisSlotBasedConnectionHandler connectionHandler = mock(JedisSlotBasedConnectionHandler.class);
+
+    JedisClusterCommand<Boolean> testMe = new JedisClusterCommand<Boolean>(connectionHandler, 3,
+            Duration.ZERO) {
+      @Override
+      public Boolean execute(Jedis connection) {
+        throw new JedisConnectionException("Dummy Exception");
+      }
+    };
+
+    try {
+      testMe.runWithAllNodes((a,b) -> a && b, true);
+    } catch (Exception e) {
+      fail("Exception was thrown");
+    }
+  }
 }

--- a/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/tests/JedisClusterTest.java
@@ -898,4 +898,22 @@ public class JedisClusterTest {
     }
     return false;
   }
+
+  @Test
+  public void testFlushAll() {
+    Set<HostAndPort> jedisClusterNode = new HashSet<HostAndPort>();
+    jedisClusterNode.add(new HostAndPort(nodeInfo1.getHost(), nodeInfo1.getPort()));
+
+    try (JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+            DEFAULT_REDIRECTIONS, "cluster", DEFAULT_POOL_CONFIG)) {
+
+      jc.set("Key", "Value");
+
+      assertEquals(jc.exists("Key"), true);
+
+      jc.flushAll();
+
+      assertEquals(jc.exists("Key"), false);
+    }
+  }
 }


### PR DESCRIPTION
Capability :

* Flush all capability for Jedis Cluster clients
* Future capability of running library functions on all nodes capability

Code Change
* JedisCluster.java : Flush all command added
* JedisClusterCommand.java : Added capability to execute commands on all nodes participating in the cluster. This does not throw errors
* JedisClusterTest.java : Test for flush all function
* JedisClusterCommandTest.java : Test for execute command on all nodes function