### PR TITLE
Ignore testing 'invalid multibulk length'

### DIFF
--- a/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
+++ b/src/test/java/redis/clients/jedis/tests/ConnectionTest.java
@@ -8,8 +8,6 @@ import org.junit.Test;
 
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Protocol.Command;
-import redis.clients.jedis.commands.ProtocolCommand;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public class ConnectionTest {
@@ -60,29 +58,6 @@ public class ConnectionTest {
     client = new Connection("localhost", 6379);
     client.connect();
     client.close();
-  }
-
-  @Test
-  public void getErrorMultibulkLength() throws Exception {
-    class TestConnection extends Connection {
-      public TestConnection() {
-        super("localhost", 6379);
-      }
-
-      @Override
-      public void sendCommand(ProtocolCommand cmd, byte[]... args) {
-        super.sendCommand(cmd, args);
-      }
-    }
-
-    TestConnection conn = new TestConnection();
-
-    try {
-      conn.sendCommand(Command.HMSET, new byte[1024 * 1024 + 1][0]);
-      fail("Should throw exception");
-    } catch (JedisConnectionException jce) {
-      assertEquals("ERR Protocol error: invalid multibulk length", jce.getMessage());
-    }
   }
 
   @Test


### PR DESCRIPTION
Ignoring due to PR https://github.com/redis/redis/pull/9528 is merged in commit https://github.com/redis/redis/commit/93e85347136a483047e92a3a7554f428d6260b0c.