### PR TITLE
Use `Charset` instead of `String` for `Protocol#CHARSET`

### DIFF
--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -1,6 +1,8 @@
 package redis.clients.jedis;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -29,7 +31,7 @@ public final class Protocol {
   public static final int DEFAULT_TIMEOUT = 2000;
   public static final int DEFAULT_DATABASE = 0;
 
-  public static final String CHARSET = "UTF-8";
+  public static final Charset CHARSET = StandardCharsets.UTF_8;
 
   public static final byte DOLLAR_BYTE = '$';
   public static final byte ASTERISK_BYTE = '*';

--- a/src/main/java/redis/clients/jedis/util/SafeEncoder.java
+++ b/src/main/java/redis/clients/jedis/util/SafeEncoder.java
@@ -25,22 +25,14 @@ public final class SafeEncoder {
   }
 
   public static byte[] encode(final String str) {
-    try {
-      if (str == null) {
-        throw new IllegalArgumentException("null value cannot be sent to redis");
-      }
-      return str.getBytes(Protocol.CHARSET);
-    } catch (UnsupportedEncodingException e) {
-      throw new JedisException(e);
+    if (str == null) {
+      throw new IllegalArgumentException("null value cannot be sent to redis");
     }
+    return str.getBytes(Protocol.CHARSET);
   }
 
   public static String encode(final byte[] data) {
-    try {
-      return new String(data, Protocol.CHARSET);
-    } catch (UnsupportedEncodingException e) {
-      throw new JedisException(e);
-    }
+    return new String(data, Protocol.CHARSET);
   }
 
   /**


### PR DESCRIPTION
# Description

This replaces the type of `Protocol#CHARSET` with `Charset` type which is less error-prone to use and initializes it with a constant from `StandardCharsets`.

This also updates all (2) usages which relied on `String` being used (i.e. `try-catch` are removed as they were catching `UnsupportedEncodingException`).

# Motivation

Using `Charset` instead of raw string allows less error-prone code and allows to omit unneeded `UnsupportedEncodingException` catching.

# Problems

This is technically a breaking change as API users relying on this field type being of type `String` may have the following incompatibilities: 

- *source*: if someone used the `String` value such as by using `Charset.forName(Protocol.CHARSET)` than this calls will no longer compiler

- *binary*: if the compiler used by them failed to inline the constant (although it had to) then `getstatic` may fail, although it is very unlikely as the inlining compiler behaviour is specified

However, as the next version (4.0.0) is going to be a major release, such impact is SemVer-compatible and its impact is not that serious and old code can be easily refactored.

# Alternatives

- Introduce a new constant: add something like
```java
public static final Charset CHARSET_OBJECT = StandardCharsets.UTF_8;
```
to hold the `Charset`-typed object, but it is counterintiutive and leads to dependency on legacy / not-that-good API design flaws.

- Do nothing: rely on current `String` field