### PR TITLE
Fix jedis & pipeline has the same client result in thread issue

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -4015,12 +4015,14 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   @Override
   public void close() {
     if (dataSource != null) {
-      Pool<Jedis> pool = this.dataSource;
-      this.dataSource = null;
-      if (isBroken()) {
-        pool.returnBrokenResource(this);
-      } else {
-        pool.returnResource(this);
+      if(pipeline == null){
+        Pool<Jedis> pool = this.dataSource;
+        this.dataSource = null;
+        if (isBroken()) {
+          pool.returnBrokenResource(this);
+        } else {
+          pool.returnResource(this);
+        }
       }
     } else {
       super.close();
@@ -4646,5 +4648,12 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     } finally {
       client.rollbackTimeout();
     }
+  }
+
+  @Override
+  public Pipeline pipelined() {
+    Pipeline pipeline = super.pipelined();
+    pipeline.setJedis(this);
+    return pipeline;
   }
 }

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -4015,14 +4015,12 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   @Override
   public void close() {
     if (dataSource != null) {
-      if(pipeline == null){
-        Pool<Jedis> pool = this.dataSource;
-        this.dataSource = null;
-        if (isBroken()) {
-          pool.returnBrokenResource(this);
-        } else {
-          pool.returnResource(this);
-        }
+      Pool<Jedis> pool = this.dataSource;
+      this.dataSource = null;
+      if (isBroken()) {
+        pool.returnBrokenResource(this);
+      } else {
+        pool.returnResource(this);
       }
     } else {
       super.close();
@@ -4648,12 +4646,5 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     } finally {
       client.rollbackTimeout();
     }
-  }
-
-  @Override
-  public Pipeline pipelined() {
-    Pipeline pipeline = super.pipelined();
-    pipeline.setJedis(this);
-    return pipeline;
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -378,4 +378,11 @@ public class JedisPool extends Pool<Jedis> {
       }
     }
   }
+
+  public Pipeline getPipeline() {
+    Jedis jedis = this.getResource();
+    Pipeline pipeline = jedis.pipelined();
+    pipeline.setJedis(jedis);
+    return pipeline;
+  }
 }

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -99,17 +99,10 @@ public class Pipeline extends MultiKeyPipelineBase implements Closeable {
    * commands you execute.
    */
   public void sync() {
-    try{
-      if (getPipelinedResponseLength() > 0) {
-        List<Object> unformatted = client.getMany(getPipelinedResponseLength());
-        for (Object o : unformatted) {
-          generateResponse(o);
-        }
-      }
-    }finally {
-      if(jedis != null){
-        jedis.pipeline = null;
-        jedis.close();
+    if (getPipelinedResponseLength() > 0) {
+      List<Object> unformatted = client.getMany(getPipelinedResponseLength());
+      for (Object o : unformatted) {
+        generateResponse(o);
       }
     }
   }
@@ -165,7 +158,13 @@ public class Pipeline extends MultiKeyPipelineBase implements Closeable {
 
   @Override
   public void close() {
-    clear();
+    try{
+      clear();
+    }finally {
+      if(jedis != null){
+        jedis.close();
+      }
+    }
   }
 
   public Response<String> watch(String... keys) {

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -67,7 +67,7 @@ public class Pipeline extends MultiKeyPipelineBase implements Closeable {
     this.client = client;
   }
 
-  public void setJedis(Jedis jedis){
+  protected void setJedis(Jedis jedis){
     this.jedis = jedis;
   }
 

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -9,6 +9,7 @@ import redis.clients.jedis.exceptions.JedisDataException;
 public class Pipeline extends MultiKeyPipelineBase implements Closeable {
 
   private MultiResponseBuilder currentMulti;
+  private Jedis jedis;
 
   private class MultiResponseBuilder extends Builder<List<Object>> {
     private List<Response<?>> responses = new ArrayList<>();
@@ -66,6 +67,10 @@ public class Pipeline extends MultiKeyPipelineBase implements Closeable {
     this.client = client;
   }
 
+  public void setJedis(Jedis jedis){
+    this.jedis = jedis;
+  }
+
   @Override
   protected Client getClient(byte[] key) {
     return client;
@@ -94,10 +99,17 @@ public class Pipeline extends MultiKeyPipelineBase implements Closeable {
    * commands you execute.
    */
   public void sync() {
-    if (getPipelinedResponseLength() > 0) {
-      List<Object> unformatted = client.getMany(getPipelinedResponseLength());
-      for (Object o : unformatted) {
-        generateResponse(o);
+    try{
+      if (getPipelinedResponseLength() > 0) {
+        List<Object> unformatted = client.getMany(getPipelinedResponseLength());
+        for (Object o : unformatted) {
+          generateResponse(o);
+        }
+      }
+    }finally {
+      if(jedis != null){
+        jedis.pipeline = null;
+        jedis.close();
       }
     }
   }


### PR DESCRIPTION
### Description
the pipeline has the same client with the jedis which get from jedis pool, if the jedis return to the pool, but the pipeline is still working, then the buf in RedisOutputStream maybe override, it will result in the wrong redis comand flush to redis server.
