### PR TITLE
Jedis should close tcp connection gracefully

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryClient.java
+++ b/src/main/java/redis/clients/jedis/BinaryClient.java
@@ -164,6 +164,11 @@ public class BinaryClient extends Connection {
     super.close();
   }
 
+  public void closeGracefully() {
+    db = 0;
+    super.disconnectGracefully();
+  }
+
   public void resetState() {
     if (isInWatch()) {
       unwatch();

--- a/src/main/java/redis/clients/jedis/BinaryJedis.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedis.java
@@ -335,6 +335,10 @@ public class BinaryJedis implements BasicCommands, BinaryJedisCommands, MultiKey
     client.close();
   }
 
+  public void closeGracefully() {
+    client.closeGracefully();
+  }
+
   @Override
   public int getDB() {
     return client.getDB();

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -260,6 +260,21 @@ public class Connection implements Closeable {
     }
   }
 
+  public void disconnectGracefully() {
+    if (isConnected()) {
+      try {
+        outputStream.flush();
+        socket.setSoLinger(false, 1);
+        socket.close();
+      } catch (IOException ex) {
+        broken = true;
+        throw new JedisConnectionException(ex);
+      } finally {
+        IOUtils.closeQuietly(socket);
+      }
+    }
+  }
+
   public boolean isConnected() {
     return socket != null && socket.isBound() && !socket.isClosed() && socket.isConnected()
         && !socket.isInputShutdown() && !socket.isOutputShutdown();

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -4027,6 +4027,20 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
     }
   }
 
+  public void closeGracefully() {
+      if (dataSource != null) {
+          Pool<Jedis> pool = this.dataSource;
+          this.dataSource = null;
+          if (isBroken()) {
+              pool.returnBrokenResource(this);
+          } else {
+              pool.returnResource(this);
+          }
+      } else {
+          super.closeGracefully();
+      }
+  }
+
   protected void setDataSource(Pool<Jedis> jedisPool) {
     this.dataSource = jedisPool;
   }


### PR DESCRIPTION
As ISSUE #2251  #2252 report,  jedis should close a tcp connection gracefully.

For compatibility of api behavior,  add a method to close tcp connection gracefully for avoid RST message.

In `closeGracefully()`, invoke socket.setSoLinger(false, 1) before close connection. 

The result shown in the figure below.

![normal](https://user-images.githubusercontent.com/19649281/137766872-c6704588-336b-4593-bfa4-a1853a6f0655.png)


