### PR TITLE
Small fix in JedisClusterInfoCache.discoverClusterNodesAndSlots.

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,13 +1,34 @@
 name-template: '$NEXT_MAJOR_VERSION'
-tag-template: 'jedis-$NEXT_MAJOR_VERSION'
+tag-template: 'v$NEXT_MAJOR_VERSION'
+autolabeler:
+  - label: 'chore'
+    files:
+      - '*.md'
+      - '.github/*'
+  - label: 'bug'
+    branch:
+      - '/bug-.+'
+  - label: 'chore'
+    branch:
+      - '/chore-.+'
+  - label: 'feature'
+    branch:
+      - '/feature-.+'
 categories:
-  - title: 'Features'
+  - title: 'Breaking Changes'
     labels:
-      - 'ENHANCEMENT'
-  - title: 'Bug Fixes'
+      - 'breakingchange'
+  - title: '🚀 New Features'
     labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
       - 'BUG'
-  - title: 'Maintenance'
+  - title: '🧰 Maintenance'
     label: 'chore'
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
@@ -19,5 +40,6 @@ template: |
 
   ## Contributors
   We'd like to thank all the contributors who worked on this release!
-  
+
   $CONTRIBUTORS
+

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -104,12 +104,10 @@ public class JedisClusterInfoCache {
   }
 
   public void discoverClusterNodesAndSlots(Jedis jedis) {
+    List<Object> slots = jedis.clusterSlots();
     w.lock();
-
     try {
       reset();
-      List<Object> slots = jedis.clusterSlots();
-
       for (Object slotInfoObj : slots) {
         List<Object> slotInfo = (List<Object>) slotInfoObj;
 


### PR DESCRIPTION
### Description:
The change calls `Jedis.cluserSlots` before `reset `is called instead of the other way around.

### Why the change?
the `reset` function deletes the `nodes `and `slots `fields.
If the `Jedis.clusterSlots` throws an exception in the try-catch block
the function fails and the data is deleted.
It would be nicer if the data (nodes and slots) were left untouched if jedis.clusterSlots throws an exception.