### PR TITLE
support jedis migrate keys encoded by gdk 

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3889,7 +3889,7 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   @Override
-  public List<byte[]> clusterGetBytesKeysInSlot(final int slot, final int count) {
+  public List<byte[]> clusterGetKeysInSlotBinary(final int slot, final int count) {
     checkIsInMultiOrPipeline();
     client.clusterGetKeysInSlot(slot, count);
     return client.getBinaryMultiBulkReply();

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -3889,6 +3889,13 @@ public class Jedis extends BinaryJedis implements JedisCommands, MultiKeyCommand
   }
 
   @Override
+  public List<byte[]> clusterGetBytesKeysInSlot(final int slot, final int count) {
+    checkIsInMultiOrPipeline();
+    client.clusterGetKeysInSlot(slot, count);
+    return client.getBinaryMultiBulkReply();
+  }
+
+  @Override
   public String clusterSetSlotNode(final int slot, final String nodeId) {
     checkIsInMultiOrPipeline();
     client.clusterSetSlotNode(slot, nodeId);

--- a/src/main/java/redis/clients/jedis/commands/ClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/ClusterCommands.java
@@ -26,6 +26,8 @@ public interface ClusterCommands {
 
   List<String> clusterGetKeysInSlot(int slot, int count);
 
+  List<byte[]> clusterGetBytesKeysInSlot(int slot, int count);
+
   String clusterSetSlotNode(int slot, String nodeId);
 
   String clusterSetSlotMigrating(int slot, String nodeId);

--- a/src/main/java/redis/clients/jedis/commands/ClusterCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/ClusterCommands.java
@@ -26,7 +26,7 @@ public interface ClusterCommands {
 
   List<String> clusterGetKeysInSlot(int slot, int count);
 
-  List<byte[]> clusterGetBytesKeysInSlot(int slot, int count);
+  List<byte[]> clusterGetKeysInSlotBinary(int slot, int count);
 
   String clusterSetSlotNode(int slot, String nodeId);
 

--- a/src/main/java/redis/clients/jedis/commands/Commands.java
+++ b/src/main/java/redis/clients/jedis/commands/Commands.java
@@ -475,6 +475,10 @@ public interface Commands {
 
   void migrate(String host, int port, int destinationDB, int timeout, MigrateParams params, String... keys);
 
+  void migrate(String host, int port, byte[] key, int destinationDB, int timeout);
+
+  void migrate(String host, int port, int destinationDB, int timeout, MigrateParams params, byte[]... keys);
+
   void clientKill(String ipPort);
 
   void clientKill(String ip, int port);

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -130,7 +130,7 @@ public class ClusterCommandsTest {
   }
 
   @Test
-  public void clusterGetByteKeysInSlot() {
+  public void clusterGetKeysInSlotBinary() {
     node1.clusterAddSlots(500);
     List<byte[]> keys = node1.clusterGetKeysInSlotBinary(500, 1);
     assertEquals(0, keys.size());

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -130,6 +130,13 @@ public class ClusterCommandsTest {
   }
 
   @Test
+  public void clusterGetByteKeysInSlot() {
+    node1.clusterAddSlots(500);
+    List<byte[]> keys = node1.clusterGetBytesKeysInSlot(500, 1);
+    assertEquals(0, keys.size());
+  }
+
+  @Test
   public void clusterSetSlotNode() {
     String[] nodes = node1.clusterNodes().split("\n");
     String nodeId = nodes[0].split(" ")[0];

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -132,7 +132,7 @@ public class ClusterCommandsTest {
   @Test
   public void clusterGetByteKeysInSlot() {
     node1.clusterAddSlots(500);
-    List<byte[]> keys = node1.clusterGetBytesKeysInSlot(500, 1);
+    List<byte[]> keys = node1.clusterGetKeysInSlotBinary(500, 1);
     assertEquals(0, keys.size());
   }
 

--- a/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/tests/commands/ClusterCommandsTest.java
@@ -131,8 +131,8 @@ public class ClusterCommandsTest {
 
   @Test
   public void clusterGetKeysInSlotBinary() {
-    node1.clusterAddSlots(500);
-    List<byte[]> keys = node1.clusterGetKeysInSlotBinary(500, 1);
+    node1.clusterAddSlots(501);
+    List<byte[]> keys = node1.clusterGetKeysInSlotBinary(501, 1);
     assertEquals(0, keys.size());
   }
 


### PR DESCRIPTION
### Expected behavior

use `migrate` function migrate value success when the key contains china string encoded by gbk.

### Actual behavior

use `migrate` function migrate value failed when the key contains china strings encoded by gbk.

### Steps to reproduce:

1. write china strings encoded by gdb use hiredis.
2. use `clusterGetKeysInSlot` get all keys in slot.
3. migrate keys to other node. its failed due to jedis decode strings by utf-8.

### Redis / Jedis Configuration

#### Jedis version:2.8.2

#### Redis version:5.0.4

#### Java version:1.8


issus: https://github.com/redis/jedis/issues/2688