### PR TITLE
Prevent test base classes from testing

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/unified/SortedSetCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/SortedSetCommandsTestBase.java
@@ -29,7 +29,7 @@ import redis.clients.jedis.resps.ScanResult;
 import redis.clients.jedis.resps.Tuple;
 import redis.clients.jedis.util.SafeEncoder;
 
-public class SortedSetCommandsTestBase extends UnifiedJedisCommandsTestBase {
+public abstract class SortedSetCommandsTestBase extends UnifiedJedisCommandsTestBase {
   final byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
   final byte[] bbar = { 0x05, 0x06, 0x07, 0x08 };
   final byte[] bcar = { 0x09, 0x0A, 0x0B, 0x0C };


### PR DESCRIPTION
This PR is in response of #2734. SortedSetCommandsTestBase is the only class that missed `abstract`.