### PR TITLE
Resolve XADD conflicts

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -8165,7 +8165,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
-  public StreamEntryID xadd_v2(final String key, final XAddParams params, final Map<String, String> hash) {
+  public StreamEntryID xadd(final String key, final XAddParams params, final Map<String, String> hash) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.xadd(key, params, hash));
   }

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -1212,7 +1212,7 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
   }
 
   @Override
-  public Response<StreamEntryID> xadd_v2(String key, XAddParams params, Map<String, String> hash) {
+  public Response<StreamEntryID> xadd(String key, XAddParams params, Map<String, String> hash) {
     return appendCommand(commandObjects.xadd(key, params, hash));
   }
 

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -1222,7 +1222,7 @@ public class Pipeline extends Queable  implements PipelineCommands, PipelineBina
   }
 
   @Override
-  public Response<StreamEntryID> xadd_v2(String key, XAddParams params, Map<String, String> hash) {
+  public Response<StreamEntryID> xadd(String key, XAddParams params, Map<String, String> hash) {
     return appendCommand(commandObjects.xadd(key, params, hash));
   }
 

--- a/src/main/java/redis/clients/jedis/StreamEntryID.java
+++ b/src/main/java/redis/clients/jedis/StreamEntryID.java
@@ -2,6 +2,7 @@ package redis.clients.jedis;
 
 import java.io.IOException;
 import java.io.Serializable;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
 
@@ -64,10 +65,18 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
     this(0, 0L);
   }
 
+  public StreamEntryID(byte[] id) {
+    this(SafeEncoder.encode(id));
+  }
+
   public StreamEntryID(String id) {
     String[] split = id.split("-");
     this.time = Long.parseLong(split[0]);
     this.sequence = Long.parseLong(split[1]);
+  }
+
+  public StreamEntryID(long time) {
+    this(time, 0);
   }
 
   public StreamEntryID(long time, long sequence) {

--- a/src/main/java/redis/clients/jedis/TransactionBase.java
+++ b/src/main/java/redis/clients/jedis/TransactionBase.java
@@ -1266,7 +1266,7 @@ public abstract class TransactionBase extends Queable implements PipelineCommand
   }
 
   @Override
-  public Response<StreamEntryID> xadd_v2(String key, XAddParams params, Map<String, String> hash) {
+  public Response<StreamEntryID> xadd(String key, XAddParams params, Map<String, String> hash) {
     return appendCommand(commandObjects.xadd(key, params, hash));
   }
 

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -2329,7 +2329,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
-  public StreamEntryID xadd_v2(String key, XAddParams params, Map<String, String> hash) {
+  public StreamEntryID xadd(String key, XAddParams params, Map<String, String> hash) {
     return executeCommand(commandObjects.xadd(key, params, hash));
   }
 

--- a/src/main/java/redis/clients/jedis/commands/StreamCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StreamCommands.java
@@ -27,11 +27,7 @@ public interface StreamCommands {
    * @param params
    * @return the ID of the added entry
    */
-  default StreamEntryID xadd(String key, Map<String, String> hash, XAddParams params) {
-    return xadd_v2(key, params, hash);
-  }
-
-  StreamEntryID xadd_v2(String key, XAddParams params, Map<String, String> hash);
+  StreamEntryID xadd(String key, XAddParams params, Map<String, String> hash);
 
   /**
    * XLEN key

--- a/src/main/java/redis/clients/jedis/commands/StreamCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StreamCommands.java
@@ -27,6 +27,11 @@ public interface StreamCommands {
    * @param params
    * @return the ID of the added entry
    */
+  // Legacy
+  default StreamEntryID xadd(String key, Map<String, String> hash, XAddParams params) {
+    return xadd(key, params, hash);
+  }
+
   StreamEntryID xadd(String key, XAddParams params, Map<String, String> hash);
 
   /**

--- a/src/main/java/redis/clients/jedis/commands/StreamPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StreamPipelineCommands.java
@@ -28,11 +28,7 @@ public interface StreamPipelineCommands {
    * @param params
    * @return the ID of the added entry
    */
-  default Response<StreamEntryID> xadd(String key, Map<String, String> hash, XAddParams params) {
-    return xadd_v2(key, params, hash);
-  }
-
-  Response<StreamEntryID> xadd_v2(String key, XAddParams params, Map<String, String> hash);
+  Response<StreamEntryID> xadd(String key, XAddParams params, Map<String, String> hash);
 
   /**
    * XLEN key

--- a/src/main/java/redis/clients/jedis/commands/StreamPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StreamPipelineCommands.java
@@ -28,6 +28,11 @@ public interface StreamPipelineCommands {
    * @param params
    * @return the ID of the added entry
    */
+  // Legacy
+  default Response<StreamEntryID> xadd(String key, Map<String, String> hash, XAddParams params) {
+    return xadd(key, params, hash);
+  }
+
   Response<StreamEntryID> xadd(String key, XAddParams params, Map<String, String> hash);
 
   /**

--- a/src/main/java/redis/clients/jedis/params/XAddParams.java
+++ b/src/main/java/redis/clients/jedis/params/XAddParams.java
@@ -7,11 +7,12 @@ import static redis.clients.jedis.Protocol.Keyword.NOMKSTREAM;
 
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.StreamEntryID;
 import redis.clients.jedis.util.SafeEncoder;
 
 public class XAddParams implements IParams {
 
-  private String id;
+  private StreamEntryID id = StreamEntryID.NEW_ENTRY;
 
   private Long maxLen;
 
@@ -34,9 +35,13 @@ public class XAddParams implements IParams {
     return this;
   }
 
-  public XAddParams id(String id) {
+  public XAddParams id(StreamEntryID id) {
     this.id = id;
     return this;
+  }
+
+  public XAddParams id(byte[] id) {
+    return id(new StreamEntryID(id));
   }
 
   public XAddParams maxLen(long maxLen) {
@@ -96,10 +101,6 @@ public class XAddParams implements IParams {
       args.add(Protocol.toByteArray(limit));
     }
 
-    if (id != null) {
-      args.add(SafeEncoder.encode(id));
-    } else {
-      args.add(Protocol.BYTES_ASTERISK);
-    }
+    args.add(SafeEncoder.encode(id.toString()));
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
@@ -88,6 +88,13 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xaddWithParams() {
 
     try {
+      jedis.xadd("stream1", new HashMap<>(), XAddParams.xAddParams());
+      fail();
+    } catch (JedisDataException expected) {
+      assertTrue(expected.getMessage().contains("wrong number of arguments"));
+    }
+
+    try {
       jedis.xadd("stream1", XAddParams.xAddParams(), new HashMap<>());
       fail();
     } catch (JedisDataException expected) {
@@ -100,7 +107,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map2 = new HashMap<>();
     map2.put("f1", "v1");
     map2.put("f2", "v2");
-    StreamEntryID id2 = jedis.xadd("xadd-stream1", XAddParams.xAddParams(), map2);
+    StreamEntryID id2 = jedis.xadd("xadd-stream1", map2, XAddParams.xAddParams());
     assertTrue(id2.compareTo(id1) > 0);
 
     Map<String, String> map3 = new HashMap<>();
@@ -112,7 +119,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     map4.put("f2", "v2");
     map4.put("f3", "v3");
     StreamEntryID idIn = new StreamEntryID(id3.getTime() + 1, 1L);
-    StreamEntryID id4 = jedis.xadd("xadd-stream2", XAddParams.xAddParams().id(idIn), map4);
+    StreamEntryID id4 = jedis.xadd("xadd-stream2", map4, XAddParams.xAddParams().id(idIn));
     assertEquals(idIn, id4);
     assertTrue(id4.compareTo(id3) > 0);
 
@@ -125,7 +132,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map6 = new HashMap<>();
     map6.put("f4", "v4");
     map6.put("f5", "v5");
-    StreamEntryID id6 = jedis.xadd("xadd-stream2", XAddParams.xAddParams().maxLen(3).exactTrimming(), map6);
+    StreamEntryID id6 = jedis.xadd("xadd-stream2", map6, XAddParams.xAddParams().maxLen(3).exactTrimming());
     assertTrue(id6.compareTo(id5) > 0);
     assertEquals(3L, jedis.xlen("xadd-stream2"));
 
@@ -135,7 +142,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     assertFalse(jedis.exists("xadd-stream3"));
 
     // minid
-    jedis.xadd("xadd-stream3", XAddParams.xAddParams().minId("2").id(new StreamEntryID(2)), map6);
+    jedis.xadd("xadd-stream3", map6, XAddParams.xAddParams().minId("2").id(new StreamEntryID(2)));
     assertEquals(1L, jedis.xlen("xadd-stream3"));
     jedis.xadd("xadd-stream3", XAddParams.xAddParams().minId("4").id(new StreamEntryID(3)), map6);
     assertEquals(0L, jedis.xlen("xadd-stream3"));

--- a/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
@@ -40,7 +40,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     try {
       Map<String, String> map1 = new HashMap<>();
-      jedis.xadd("stream1", StreamEntryID.NEW_ENTRY, map1);
+      jedis.xadd("stream1", (StreamEntryID) null, map1);
       fail();
     } catch (JedisDataException expected) {
       assertTrue(expected.getMessage().contains("wrong number of arguments"));
@@ -48,19 +48,19 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map1 = new HashMap<>();
     map1.put("f1", "v1");
-    StreamEntryID id1 = jedis.xadd("xadd-stream1", StreamEntryID.NEW_ENTRY, map1);
+    StreamEntryID id1 = jedis.xadd("xadd-stream1", (StreamEntryID) null, map1);
     assertNotNull(id1);
 
     Map<String, String> map2 = new HashMap<>();
     map2.put("f1", "v1");
     map2.put("f2", "v2");
-    StreamEntryID id2 = jedis.xadd("xadd-stream1", StreamEntryID.NEW_ENTRY, map2);
+    StreamEntryID id2 = jedis.xadd("xadd-stream1", (StreamEntryID) null, map2);
     assertTrue(id2.compareTo(id1) > 0);
 
     Map<String, String> map3 = new HashMap<>();
     map3.put("f2", "v2");
     map3.put("f3", "v3");
-    StreamEntryID id3 = jedis.xadd("xadd-stream2", StreamEntryID.NEW_ENTRY, map3);
+    StreamEntryID id3 = jedis.xadd("xadd-stream2", (StreamEntryID) null, map3);
 
     Map<String, String> map4 = new HashMap<>();
     map4.put("f2", "v2");
@@ -73,7 +73,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map5 = new HashMap<>();
     map5.put("f4", "v4");
     map5.put("f5", "v5");
-    StreamEntryID id5 = jedis.xadd("xadd-stream2", StreamEntryID.NEW_ENTRY, map5);
+    StreamEntryID id5 = jedis.xadd("xadd-stream2", (StreamEntryID) null, map5);
     assertTrue(id5.compareTo(id4) > 0);
 //
 //    Map<String, String> map6 = new HashMap<>();
@@ -94,7 +94,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
       assertTrue(expected.getMessage().contains("wrong number of arguments"));
     }
 
-    StreamEntryID id1 = jedis.xadd("xadd-stream1", StreamEntryID.NEW_ENTRY, Collections.singletonMap("f1", "v1"));
+    StreamEntryID id1 = jedis.xadd("xadd-stream1", (StreamEntryID) null, Collections.singletonMap("f1", "v1"));
     assertNotNull(id1);
 
     Map<String, String> map2 = new HashMap<>();
@@ -146,10 +146,10 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map1 = new HashMap<>();
     map1.put("f1", "v1");
 
-    StreamEntryID id1 = jedis.xadd("xdel-stream", StreamEntryID.NEW_ENTRY, map1);
+    StreamEntryID id1 = jedis.xadd("xdel-stream", (StreamEntryID) null, map1);
     assertNotNull(id1);
 
-    StreamEntryID id2 = jedis.xadd("xdel-stream", StreamEntryID.NEW_ENTRY, map1);
+    StreamEntryID id2 = jedis.xadd("xdel-stream", (StreamEntryID) null, map1);
     assertNotNull(id2);
     assertEquals(2L, jedis.xlen("xdel-stream"));
 
@@ -163,10 +163,10 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xlen-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xlen-stream", (StreamEntryID) null, map);
     assertEquals(1L, jedis.xlen("xlen-stream"));
 
-    jedis.xadd("xlen-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xlen-stream", (StreamEntryID) null, map);
     assertEquals(2L, jedis.xlen("xlen-stream"));
   }
 
@@ -178,8 +178,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    StreamEntryID id1 = jedis.xadd("xrange-stream", StreamEntryID.NEW_ENTRY, map);
-    StreamEntryID id2 = jedis.xadd("xrange-stream", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id1 = jedis.xadd("xrange-stream", (StreamEntryID) null, map);
+    StreamEntryID id2 = jedis.xadd("xrange-stream", (StreamEntryID) null, map);
     List<StreamEntry> range2 = jedis.xrange("xrange-stream", (StreamEntryID) null,
       (StreamEntryID) null, 3);
     assertEquals(2, range2.size());
@@ -196,7 +196,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     List<StreamEntry> range6 = jedis.xrange("xrange-stream", id2, null, 4);
     assertEquals(1, range6.size());
 
-    StreamEntryID id3 = jedis.xadd("xrange-stream", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id3 = jedis.xadd("xrange-stream", (StreamEntryID) null, map);
     List<StreamEntry> range7 = jedis.xrange("xrange-stream", id3, id3, 4);
     assertEquals(1, range7.size());
 
@@ -208,8 +208,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xrangeExclusive() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    String id1 = jedis.xadd("xrange-stream", StreamEntryID.NEW_ENTRY, map).toString();
-    jedis.xadd("xrange-stream", StreamEntryID.NEW_ENTRY, map);
+    String id1 = jedis.xadd("xrange-stream", (StreamEntryID) null, map).toString();
+    jedis.xadd("xrange-stream", (StreamEntryID) null, map);
 
     List<StreamEntry> range2 = jedis.xrange("xrange-stream", id1, "+", 2);
     assertEquals(2, range2.size());
@@ -229,8 +229,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    StreamEntryID id1 = jedis.xadd("xread-stream1", StreamEntryID.NEW_ENTRY, map);
-    StreamEntryID id2 = jedis.xadd("xread-stream2", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id1 = jedis.xadd("xread-stream1", (StreamEntryID) null, map);
+    StreamEntryID id2 = jedis.xadd("xread-stream2", (StreamEntryID) null, map);
 
     // Read only a single Stream
     List<Entry<String, List<StreamEntry>>> streams1 = jedis.xread(XReadParams.xReadParams().count(1).block(1), streamQeury1);
@@ -270,7 +270,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     }, "xread-block-0-thread");
     t.start();
     Thread.sleep(1000);
-    StreamEntryID addedId = jedis.xadd("block0-stream", StreamEntryID.NEW_ENTRY, Collections.singletonMap("foo", "bar"));
+    StreamEntryID addedId = jedis.xadd("block0-stream", (StreamEntryID) null, Collections.singletonMap("foo", "bar"));
     t.join();
     assertEquals(addedId, readId.get());
   }
@@ -281,7 +281,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     map1.put("f1", "v1");
 
     for (int i = 1; i <= 5; i++) {
-      jedis.xadd("xtrim-stream", StreamEntryID.NEW_ENTRY, map1);
+      jedis.xadd("xtrim-stream", (StreamEntryID) null, map1);
     }
     assertEquals(5L, jedis.xlen("xtrim-stream"));
 
@@ -314,8 +314,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    StreamEntryID id1 = jedis.xadd("xrevrange-stream", StreamEntryID.NEW_ENTRY, map);
-    StreamEntryID id2 = jedis.xadd("xrevrange-stream", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id1 = jedis.xadd("xrevrange-stream", (StreamEntryID) null, map);
+    StreamEntryID id2 = jedis.xadd("xrevrange-stream", (StreamEntryID) null, map);
     List<StreamEntry> range2 = jedis.xrange("xrevrange-stream", (StreamEntryID) null,
       (StreamEntryID) null, 3);
     assertEquals(2, range2.size());
@@ -332,7 +332,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     List<StreamEntry> range6 = jedis.xrevrange("xrevrange-stream", null, id2, 4);
     assertEquals(1, range6.size());
 
-    StreamEntryID id3 = jedis.xadd("xrevrange-stream", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id3 = jedis.xadd("xrevrange-stream", (StreamEntryID) null, map);
     List<StreamEntry> range7 = jedis.xrevrange("xrevrange-stream", id3, id3, 4);
     assertEquals(1, range7.size());
 
@@ -344,8 +344,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xrevrangeExclusive() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    String id1 = jedis.xadd("xrange-stream", StreamEntryID.NEW_ENTRY, map).toString();
-    jedis.xadd("xrange-stream", StreamEntryID.NEW_ENTRY, map);
+    String id1 = jedis.xadd("xrange-stream", (StreamEntryID) null, map).toString();
+    jedis.xadd("xrange-stream", (StreamEntryID) null, map);
 
     List<StreamEntry> range2 = jedis.xrevrange("xrange-stream", "+", id1, 2);
     assertEquals(2, range2.size());
@@ -359,7 +359,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map = new HashMap<String, String>();
     map.put("f1", "v1");
-    StreamEntryID id1 = jedis.xadd("xgroup-stream", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id1 = jedis.xadd("xgroup-stream", (StreamEntryID) null, map);
 
     assertEquals("OK", jedis.xgroupCreate("xgroup-stream", "consumer-group-name", null, false));
 
@@ -378,7 +378,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     // Simple xreadGroup with NOACK
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xreadGroup-stream1", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xreadGroup-stream1", (StreamEntryID) null, map);
     jedis.xgroupCreate("xreadGroup-stream1", "xreadGroup-group", null, false);
     Map<String, StreamEntryID> streamQeury1 = Collections.singletonMap("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
     List<Entry<String, List<StreamEntry>>> range = jedis.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
@@ -386,8 +386,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     assertEquals(1, range.size());
     assertEquals(1, range.get(0).getValue().size());
 
-    jedis.xadd("xreadGroup-stream1", StreamEntryID.NEW_ENTRY, map);
-    jedis.xadd("xreadGroup-stream2", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xreadGroup-stream1", (StreamEntryID) null, map);
+    jedis.xadd("xreadGroup-stream2", (StreamEntryID) null, map);
     jedis.xgroupCreate("xreadGroup-stream2", "xreadGroup-group", null, false);
 
     // Read only a single Stream
@@ -406,7 +406,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     assertEquals(2, streams2.size());
 
     // Read only fresh messages
-    StreamEntryID id4 = jedis.xadd("xreadGroup-stream1", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id4 = jedis.xadd("xreadGroup-stream1", (StreamEntryID) null, map);
     Map<String, StreamEntryID> streamQeuryFresh = Collections.singletonMap("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
     List<Entry<String, List<StreamEntry>>> streams3 = jedis.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(4).block(100).noAck(), streamQeuryFresh);
@@ -419,7 +419,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map = new HashMap<String, String>();
     map.put("f1", "v1");
-    jedis.xadd("xack-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xack-stream", (StreamEntryID) null, map);
 
     jedis.xgroupCreate("xack-stream", "xack-group", null, false);
 
@@ -439,7 +439,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xpendingWithParams() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    StreamEntryID id1 = jedis.xadd("xpendeing-stream", StreamEntryID.NEW_ENTRY, map);
+    StreamEntryID id1 = jedis.xadd("xpendeing-stream", (StreamEntryID) null, map);
 
     assertEquals("OK", jedis.xgroupCreate("xpendeing-stream", "xpendeing-group", null, false));
 
@@ -478,7 +478,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xclaimWithParams() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xpendeing-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xpendeing-stream", (StreamEntryID) null, map);
 
     assertEquals("OK", jedis.xgroupCreate("xpendeing-stream", "xpendeing-group", null, false));
 
@@ -508,7 +508,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xclaimJustId() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xpendeing-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xpendeing-stream", (StreamEntryID) null, map);
 
     assertEquals("OK", jedis.xgroupCreate("xpendeing-stream", "xpendeing-group", null, false));
 
@@ -537,7 +537,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xautoclaim() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xpending-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xpending-stream", (StreamEntryID) null, map);
 
     assertEquals("OK", jedis.xgroupCreate("xpending-stream", "xpending-group", null, false));
 
@@ -567,7 +567,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xautoclaimBinary() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xpending-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xpending-stream", XAddParams.xAddParams(), map);
 
     assertEquals("OK", jedis.xgroupCreate("xpending-stream", "xpending-group", null, false));
 
@@ -599,7 +599,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xautoclaimJustId() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xpending-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xpending-stream", (StreamEntryID) null, map);
 
     assertEquals("OK", jedis.xgroupCreate("xpending-stream", "xpending-group", null, false));
 
@@ -629,7 +629,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
   public void xautoclaimJustIdBinary() {
     Map<String, String> map = new HashMap<>();
     map.put("f1", "v1");
-    jedis.xadd("xpending-stream", StreamEntryID.NEW_ENTRY, map);
+    jedis.xadd("xpending-stream", XAddParams.xAddParams(), map);
 
     assertEquals("OK", jedis.xgroupCreate("xpending-stream", "xpending-group", null, false));
 
@@ -671,9 +671,9 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     Map<String, String> map1 = new HashMap<>();
     map1.put(F1, V1);
-    StreamEntryID id1 = jedis.xadd(STREAM_NAME, StreamEntryID.NEW_ENTRY, map1);
+    StreamEntryID id1 = jedis.xadd(STREAM_NAME, (StreamEntryID) null, map1);
     map1.put(F1, V2);
-    StreamEntryID id2 = jedis.xadd(STREAM_NAME, StreamEntryID.NEW_ENTRY, map1);
+    StreamEntryID id2 = jedis.xadd(STREAM_NAME, (StreamEntryID) null, map1);
     assertNotNull(id1);
     StreamInfo streamInfo = jedis.xinfoStream(STREAM_NAME);
     assertNotNull(id2);
@@ -759,8 +759,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map = new HashMap<>();
     map.put("a", "b");
     Pipeline p = jedis.pipelined();
-    Response<StreamEntryID> id1 = p.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
-    Response<StreamEntryID> id2 = p.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
+    Response<StreamEntryID> id1 = p.xadd("stream1", (StreamEntryID) null, map);
+    Response<StreamEntryID> id2 = p.xadd("stream1", (StreamEntryID) null, map);
     Response<List<StreamEntry>> results = p.xrange("stream1", (StreamEntryID) null, (StreamEntryID) null, 2);
     p.sync();
 
@@ -782,8 +782,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map = new HashMap<>();
     map.put("a", "b");
     Transaction t = jedis.multi();
-    Response<StreamEntryID> id1 = t.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
-    Response<StreamEntryID> id2 = t.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
+    Response<StreamEntryID> id1 = t.xadd("stream1", (StreamEntryID) null, map);
+    Response<StreamEntryID> id2 = t.xadd("stream1", (StreamEntryID) null, map);
     Response<List<StreamEntry>> results = t.xrange("stream1", (StreamEntryID) null, (StreamEntryID) null, 2);
     t.exec();
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
@@ -759,8 +759,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map = new HashMap<>();
     map.put("a", "b");
     Pipeline p = jedis.pipelined();
-    Response<StreamEntryID> id1 = p.xadd("stream1", (StreamEntryID) null, map);
-    Response<StreamEntryID> id2 = p.xadd("stream1", (StreamEntryID) null, map);
+    Response<StreamEntryID> id1 = p.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
+    Response<StreamEntryID> id2 = p.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
     Response<List<StreamEntry>> results = p.xrange("stream1", (StreamEntryID) null, (StreamEntryID) null, 2);
     p.sync();
 
@@ -782,8 +782,8 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     Map<String, String> map = new HashMap<>();
     map.put("a", "b");
     Transaction t = jedis.multi();
-    Response<StreamEntryID> id1 = t.xadd("stream1", (StreamEntryID) null, map);
-    Response<StreamEntryID> id2 = t.xadd("stream1", (StreamEntryID) null, map);
+    Response<StreamEntryID> id1 = t.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
+    Response<StreamEntryID> id2 = t.xadd("stream1", StreamEntryID.NEW_ENTRY, map);
     Response<List<StreamEntry>> results = t.xrange("stream1", (StreamEntryID) null, (StreamEntryID) null, 2);
     t.exec();
 


### PR DESCRIPTION
Apparently, I had named a method `xadd_v2` to work on it later but forgot about it. I am now a bit confused others noticed it (and agreed) or not.

The reason behind the naming is a conflict which is because of supporting `null` as StreamEntryID. According to [XADD](https://redis.io/commands/xadd) params and Jedis' usual approach, XAddParams should precede hash (Map). But this is conflicting with existing *usages* of xadd method with untyped null.

We have several options:

1. Keep everything as is
2. Keep everything as is but remove xadd_v2 method
3. Keep the null support but the null must be typed (StreamEntryID)
4. Revoke null support which Jedis almost always does

Please mention any other option that we can discuss.

Currently this PR is using option (3).