### PR TITLE
Replace deprecated interface with new interface of JedisPoolConfig

### DIFF
--- a/src/main/java/redis/clients/jedis/ConnectionPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/ConnectionPoolConfig.java
@@ -2,13 +2,15 @@ package redis.clients.jedis;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
+import java.time.Duration;
+
 public class ConnectionPoolConfig extends GenericObjectPoolConfig<Connection> {
 
   public ConnectionPoolConfig() {
     // defaults to make your life with connection pool easier :)
     setTestWhileIdle(true);
-    setMinEvictableIdleTimeMillis(60000);
-    setTimeBetweenEvictionRunsMillis(30000);
+    setMinEvictableIdleTime(Duration.ofMillis(60000));
+    setTimeBetweenEvictionRuns(Duration.ofMillis(30000));
     setNumTestsPerEvictionRun(-1);
   }
 }

--- a/src/main/java/redis/clients/jedis/ConnectionPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/ConnectionPoolConfig.java
@@ -1,8 +1,7 @@
 package redis.clients.jedis;
 
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-
 import java.time.Duration;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 public class ConnectionPoolConfig extends GenericObjectPoolConfig<Connection> {
 

--- a/src/main/java/redis/clients/jedis/JedisPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisPoolConfig.java
@@ -1,8 +1,7 @@
 package redis.clients.jedis;
 
-import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-
 import java.time.Duration;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 public class JedisPoolConfig extends GenericObjectPoolConfig<Jedis> {
 

--- a/src/main/java/redis/clients/jedis/JedisPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisPoolConfig.java
@@ -2,13 +2,15 @@ package redis.clients.jedis;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
+import java.time.Duration;
+
 public class JedisPoolConfig extends GenericObjectPoolConfig<Jedis> {
 
   public JedisPoolConfig() {
     // defaults to make your life with connection pool easier :)
     setTestWhileIdle(true);
-    setMinEvictableIdleTimeMillis(60000);
-    setTimeBetweenEvictionRunsMillis(30000);
+    setMinEvictableIdleTime(Duration.ofMillis(60000));
+    setTimeBetweenEvictionRuns(Duration.ofMillis(30000));
     setNumTestsPerEvictionRun(-1);
   }
 }


### PR DESCRIPTION
function `setMinEvictableIdleTimeMillis` replaced with `setMinEvictableIdleTime`

```java
 /**
     * Sets the value for the {@code minEvictableIdleTime} configuration
     * attribute for pools created with this configuration instance.
     *
     * @param minEvictableIdleTimeMillis The new setting of
     *        {@code minEvictableIdleTime} for this configuration instance
     *
     * @see GenericObjectPool#getMinEvictableIdleDuration()
     * @see GenericKeyedObjectPool#getMinEvictableIdleDuration()
     * @deprecated Use {@link #setMinEvictableIdleTime(Duration)}.
     */
    @Deprecated
    public void setMinEvictableIdleTimeMillis(final long minEvictableIdleTimeMillis) {
        this.minEvictableIdleDuration = Duration.ofMillis(minEvictableIdleTimeMillis);
    }
```

function `setTimeBetweenEvictionRunsMillis` replaced with `setTimeBetweenEvictionRuns`

```java
 /**
     * Sets the value for the {@code timeBetweenEvictionRuns} configuration
     * attribute for pools created with this configuration instance.
     *
     * @param timeBetweenEvictionRunsMillis The new setting of
     *        {@code timeBetweenEvictionRuns} for this configuration
     *        instance
     *
     * @see GenericObjectPool#getDurationBetweenEvictionRuns()
     * @see GenericKeyedObjectPool#getDurationBetweenEvictionRuns()
     * @deprecated Use {@link #setTimeBetweenEvictionRuns(Duration)}.
     */
    @Deprecated
    public void setTimeBetweenEvictionRunsMillis(final long timeBetweenEvictionRunsMillis) {
        setTimeBetweenEvictionRuns(Duration.ofMillis(timeBetweenEvictionRunsMillis));
    }
```