### PR TITLE
support the SCAN TYPE option

### DIFF
--- a/src/main/java/redis/clients/jedis/params/ScanParams.java
+++ b/src/main/java/redis/clients/jedis/params/ScanParams.java
@@ -2,6 +2,7 @@ package redis.clients.jedis.params;
 
 import static redis.clients.jedis.Protocol.Keyword.COUNT;
 import static redis.clients.jedis.Protocol.Keyword.MATCH;
+import static redis.clients.jedis.Protocol.Keyword.TYPE;
 
 import java.nio.ByteBuffer;
 import java.util.EnumMap;
@@ -38,6 +39,14 @@ public class ScanParams implements IParams {
    */
   public ScanParams count(final Integer count) {
     params.put(COUNT, ByteBuffer.wrap(Protocol.toByteArray(count)));
+    return this;
+  }
+
+  /**
+   * @see <a href="https://redis.io/commands/scan#the-type-option">TYPE option in Redis documentation</a>
+   */
+  public ScanParams type(final String type) {
+    params.put(TYPE, ByteBuffer.wrap(SafeEncoder.encode(type)));
     return this;
   }
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/SetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SetCommandsTest.java
@@ -632,4 +632,28 @@ public class SetCommandsTest extends JedisCommandsTestBase {
 
     assertFalse(bResult.getResult().isEmpty());
   }
+
+  @Test
+  public void scanType() {
+    ScanParams params = new ScanParams();
+    params.type("set");
+
+    jedis.sadd("foo", "a1", "a2", "a3", "a4", "a5");
+
+    ScanResult<String> result = jedis.scan(SCAN_POINTER_START, params);
+
+    assertFalse(result.getResult().isEmpty());
+    assertEquals("foo", result.getResult().get(0));
+
+    // binary
+    params = new ScanParams();
+    params.type("set");
+
+    jedis.sadd(bfoo, bbar1, bbar2, bbar3);
+    ScanResult<byte[]> bResult = jedis.scan(SCAN_POINTER_START_BINARY, params);
+
+    assertFalse(bResult.getResult().isEmpty());
+    assertEquals(1, result.getResult().size());
+    assertEquals("foo", result.getResult().get(0));
+  }
 }


### PR DESCRIPTION
Added method to provide an easy support to the [TYPE](https://redis.io/commands/scan#the-type-option) option of the SCAN command