### PR TITLE
Git ignore Redis7.0 appendonlydir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tags
 *.aof
 *.rdb
 redis-git
+appendonlydir/


### PR DESCRIPTION
Redis 7.0 [Multi-Part-AOF](https://github.com/redis/redis/blob/7.0/00-RELEASENOTES#L217) create this config in `redis.conf`: 
```
appenddirname "appendonlydir"
```
when Jedis use Redis7.0 test, we need add it in .gitignore.