### PR TITLE
Add test for BuilderFactory.build

### DIFF
--- a/src/test/java/redis/clients/jedis/BuilderTest.java
+++ b/src/test/java/redis/clients/jedis/BuilderTest.java
@@ -1,7 +1,6 @@
 package redis.clients.jedis;
 
 import static org.junit.Assert.assertEquals;
-import static redis.clients.jedis.BuilderFactory.DOUBLE;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -20,8 +19,8 @@ public class BuilderTest {
     assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), build);
 
     try {
-      build = DOUBLE.build("".getBytes());
-      Assert.fail("testDouble should have thrown NumberFormatException");
+      BuilderFactory.DOUBLE.build("".getBytes());
+      Assert.fail("Empty String should throw NumberFormatException.");
     } catch (NumberFormatException expected) {
       Assert.assertEquals("empty String", expected.getMessage());
     }

--- a/src/test/java/redis/clients/jedis/BuilderTest.java
+++ b/src/test/java/redis/clients/jedis/BuilderTest.java
@@ -18,16 +18,10 @@ public class BuilderTest {
     assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), build);
     build = BuilderFactory.DOUBLE.build("-inf".getBytes());
     assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), build);
-  }
 
-  @Test
-  public void testBuild() {
     try {
-      Double build = DOUBLE.build("".getBytes());
-      build = DOUBLE.build("inf".getBytes());
-      build = DOUBLE.build("+inf".getBytes());
-      build = DOUBLE.build("-inf".getBytes());
-      Assert.fail("testBuild should have thrown NumberFormatException");
+      build = DOUBLE.build("".getBytes());
+      Assert.fail("testDouble should have thrown NumberFormatException");
     } catch (NumberFormatException expected) {
       Assert.assertEquals("empty String", expected.getMessage());
     }

--- a/src/test/java/redis/clients/jedis/BuilderTest.java
+++ b/src/test/java/redis/clients/jedis/BuilderTest.java
@@ -1,7 +1,9 @@
 package redis.clients.jedis;
 
 import static org.junit.Assert.assertEquals;
+import static redis.clients.jedis.BuilderFactory.DOUBLE;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 public class BuilderTest {
@@ -16,5 +18,18 @@ public class BuilderTest {
     assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), build);
     build = BuilderFactory.DOUBLE.build("-inf".getBytes());
     assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), build);
+  }
+
+  @Test
+  public void testBuild() {
+    try {
+      Double build = DOUBLE.build("".getBytes());
+      build = DOUBLE.build("inf".getBytes());
+      build = DOUBLE.build("+inf".getBytes());
+      build = DOUBLE.build("-inf".getBytes());
+      Assert.fail("testBuild should have thrown NumberFormatException");
+    } catch (NumberFormatException expected) {
+      Assert.assertEquals("empty String", expected.getMessage());
+    }
   }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that a `java.lang.NumberFormatException` is thrown when the parameter `data` is set to `""`.
This tests the method [`BuilderFactory$8.build`](https://github.com/redis/jedis/blob/d6ba80a544d2300e526e5e61cd163fd9d4a85721/src/main/java/redis/clients/jedis/BuilderFactory.java#L119).
This test is based on the test [`buildDouble`](https://github.com/redis/jedis/blob/d6ba80a544d2300e526e5e61cd163fd9d4a85721/src/test/java/redis/clients/jedis/BuilderTest.java#L10).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))