### PR TITLE
Easy PooledConnectionProvider with GenericObjectPoolConfig

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPooled.java
+++ b/src/main/java/redis/clients/jedis/JedisPooled.java
@@ -355,7 +355,7 @@ public class JedisPooled extends UnifiedJedis {
   }
 
   public JedisPooled(final HostAndPort hostAndPort, final GenericObjectPoolConfig<Connection> poolConfig) {
-    this(new ConnectionFactory(hostAndPort), poolConfig);
+    this(hostAndPort, DefaultJedisClientConfig.builder().build(), poolConfig);
   }
 
   public JedisPooled(final GenericObjectPoolConfig<Connection> poolConfig, final HostAndPort hostAndPort,
@@ -365,7 +365,7 @@ public class JedisPooled extends UnifiedJedis {
 
   public JedisPooled(final HostAndPort hostAndPort, final JedisClientConfig clientConfig,
       final GenericObjectPoolConfig<Connection> poolConfig) {
-    this(new ConnectionFactory(hostAndPort, clientConfig), poolConfig);
+    this(new PooledConnectionProvider(hostAndPort, clientConfig, poolConfig));
   }
 
   public JedisPooled(final GenericObjectPoolConfig<Connection> poolConfig,

--- a/src/main/java/redis/clients/jedis/providers/PooledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/PooledConnectionProvider.java
@@ -20,14 +20,20 @@ public class PooledConnectionProvider implements ConnectionProvider {
   }
 
   public PooledConnectionProvider(HostAndPort hostAndPort, JedisClientConfig clientConfig) {
-    this(new ConnectionFactory(hostAndPort, clientConfig));
+    this(hostAndPort, clientConfig, new GenericObjectPoolConfig<>());
+  }
+
+  public PooledConnectionProvider(HostAndPort hostAndPort, JedisClientConfig clientConfig,
+      GenericObjectPoolConfig<Connection> poolConfig) {
+    this(new ConnectionFactory(hostAndPort, clientConfig), poolConfig);
   }
 
   public PooledConnectionProvider(PooledObjectFactory<Connection> factory) {
     this(factory, new GenericObjectPoolConfig<>());
   }
 
-  public PooledConnectionProvider(PooledObjectFactory<Connection> factory, GenericObjectPoolConfig<Connection> poolConfig) {
+  public PooledConnectionProvider(PooledObjectFactory<Connection> factory,
+      GenericObjectPoolConfig<Connection> poolConfig) {
     this(new ConnectionPool(factory, poolConfig));
   }
 


### PR DESCRIPTION
Add an easy PooledConnectionProvider constructor taking GenericObjectPoolConfig.