### PR TITLE
Catch JedisException in executeCommand

### DIFF
--- a/src/main/java/redis/clients/jedis/executors/ClusterCommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/executors/ClusterCommandExecutor.java
@@ -58,7 +58,7 @@ public class ClusterCommandExecutor implements CommandExecutor {
 
       } catch (JedisClusterOperationException jnrcne) {
         throw jnrcne;
-      } catch (JedisConnectionException jce) {
+      } catch (JedisException jce) {
         lastException = jce;
         ++consecutiveConnectionFailures;
         log.debug("Failed connecting to Redis: {}", connection, jce);


### PR DESCRIPTION
Hey, I wonder why not catch JedisException in executeCommand?  If the node died, the `connection.getResource()`will possibly throw a `JedisException` not `JedisConnectionException`, right?