### PR TITLE
Test: Intermediate sync() works in regular Pipeline

### DIFF
--- a/src/test/java/redis/clients/jedis/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/PipeliningTest.java
@@ -90,6 +90,59 @@ public class PipeliningTest extends JedisCommandsTestBase {
   }
 
   @Test
+  public void intermediateSyncs() {
+    jedis.set("string", "foo");
+    jedis.lpush("list", "foo");
+    jedis.hset("hash", "foo", "bar");
+    jedis.zadd("zset", 1, "foo");
+    jedis.sadd("set", "foo");
+    jedis.setrange("setrange", 0, "0123456789");
+    byte[] bytesForSetRange = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    jedis.setrange("setrangebytes".getBytes(), 0, bytesForSetRange);
+
+    Pipeline p = jedis.pipelined();
+    Response<String> string = p.get("string");
+    Response<String> list = p.lpop("list");
+    Response<String> hash = p.hget("hash", "foo");
+    Response<List<String>> zset = p.zrange("zset", 0, -1);
+    Response<String> set = p.spop("set");
+    Response<Boolean> blist = p.exists("list");
+    p.sync();
+
+    assertEquals("foo", string.get());
+    assertEquals("foo", list.get());
+    assertEquals("bar", hash.get());
+    assertEquals("foo", zset.get().iterator().next());
+    assertEquals("foo", set.get());
+    assertEquals(false, blist.get());
+
+    Response<Double> zincrby = p.zincrby("zset", 1, "foo");
+    Response<Long> zcard = p.zcard("zset");
+    p.lpush("list", "bar");
+    Response<List<String>> lrange = p.lrange("list", 0, -1);
+    Response<Map<String, String>> hgetAll = p.hgetAll("hash");
+    p.sadd("set", "foo");
+    p.sync();
+
+    assertEquals(Double.valueOf(2), zincrby.get());
+    assertEquals(Long.valueOf(1), zcard.get());
+    assertEquals(1, lrange.get().size());
+    assertNotNull(hgetAll.get().get("foo"));
+
+    Response<Set<String>> smembers = p.smembers("set");
+    Response<List<Tuple>> zrangeWithScores = p.zrangeWithScores("zset", 0, -1);
+    Response<String> getrange = p.getrange("setrange", 1, 3);
+    Response<byte[]> getrangeBytes = p.getrange("setrangebytes".getBytes(), 6, 8);
+    p.sync();
+
+    assertEquals(1, smembers.get().size());
+    assertEquals(1, zrangeWithScores.get().size());
+    assertEquals("123", getrange.get());
+    byte[] expectedGetRangeBytes = { 6, 7, 8 };
+    assertArrayEquals(expectedGetRangeBytes, getrangeBytes.get());
+  }
+
+  @Test
   public void pipelineResponseWithData() {
     jedis.zadd("zset", 1, "foo");
 


### PR DESCRIPTION
A test showing that intermediate sync() calls work in classic Pipeline bound to single connection.