### PR TITLE
Allow exclusion of org.json dependency

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -3,9 +3,6 @@ package redis.clients.jedis;
 import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.resps.StreamConsumerFullInfo;
@@ -1584,51 +1581,6 @@ public final class BuilderFactory {
         }
       }
       return classes;
-    }
-  };
-
-  public static final Builder<Object> JSON_OBJECT = new Builder<Object>() {
-    @Override
-    public Object build(Object data) {
-      if (data == null) return null;
-
-      if (!(data instanceof byte[])) return data;
-
-      String str = STRING.build(data);
-      if (str.charAt(0) == '{') {
-        try {
-          return new JSONObject(str);
-        } catch (Exception ex) { }
-      } else if (str.charAt(0) == '[') {
-        try {
-          return new JSONArray(str);
-        } catch (Exception ex) { }
-      }
-      return str;
-    }
-  };
-
-  public static final Builder<JSONArray> JSON_ARRAY = new Builder<JSONArray>() {
-    @Override
-    public JSONArray build(Object data) {
-      if (data == null) return null;
-      String str = STRING.build(data);
-      try {
-        return new JSONArray(str);
-      } catch (JSONException ex) {
-        // This is not necessary but we are doing this just to make is safer
-        // for com.vaadin.external.google:android-json library
-        throw new JedisException(ex);
-      }
-    }
-  };
-
-  public static final Builder<List<JSONArray>> JSON_ARRAY_LIST = new Builder<List<JSONArray>>() {
-    @Override
-    public List<JSONArray> build(Object data) {
-      if (data == null) return null;
-      List<Object> list = (List<Object>) data;
-      return list.stream().map(o -> JSON_ARRAY.build(o)).collect(Collectors.toList());
     }
   };
 

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -3327,7 +3327,7 @@ public class CommandObjects {
   }
 
   public final CommandObject<Object> jsonGet(String key, Path2... paths) {
-    return new CommandObject<>(commandArguments(JsonCommand.GET).key(key).addObjects((Object[]) paths), BuilderFactory.JSON_OBJECT);
+    return new CommandObject<>(commandArguments(JsonCommand.GET).key(key).addObjects((Object[]) paths), JsonBuilderFactory.JSON_OBJECT);
   }
 
   public final CommandObject<Object> jsonGet(String key, Path... paths) {
@@ -3343,7 +3343,7 @@ public class CommandObjects {
   }
 
   public final CommandObject<List<JSONArray>> jsonMGet(Path2 path, String... keys) {
-    return new CommandObject<>(commandArguments(JsonCommand.MGET).keys((Object[]) keys).add(path), BuilderFactory.JSON_ARRAY_LIST);
+    return new CommandObject<>(commandArguments(JsonCommand.MGET).keys((Object[]) keys).add(path), JsonBuilderFactory.JSON_ARRAY_LIST);
   }
 
   public final <T> CommandObject<List<T>> jsonMGet(Path path, Class<T> clazz, String... keys) {
@@ -3419,7 +3419,7 @@ public class CommandObjects {
   }
 
   public final CommandObject<JSONArray> jsonNumIncrBy(String key, Path2 path, double value) {
-    return new CommandObject<>(commandArguments(JsonCommand.NUMINCRBY).key(key).add(path).add(value), BuilderFactory.JSON_ARRAY);
+    return new CommandObject<>(commandArguments(JsonCommand.NUMINCRBY).key(key).add(path).add(value), JsonBuilderFactory.JSON_ARRAY);
   }
 
   public final CommandObject<Double> jsonNumIncrBy(String key, Path path, double value) {

--- a/src/main/java/redis/clients/jedis/JsonBuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/JsonBuilderFactory.java
@@ -1,0 +1,70 @@
+package redis.clients.jedis;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import redis.clients.jedis.exceptions.JedisException;
+
+final class JsonBuilderFactory {
+
+  private JsonBuilderFactory() {
+  }
+
+  static final Builder<Object> JSON_OBJECT = new Builder<Object>() {
+    @Override
+    public Object build(Object data) {
+      if (data == null) {
+        return null;
+      }
+
+      if (!(data instanceof byte[])) {
+        return data;
+      }
+
+      String str = BuilderFactory.STRING.build(data);
+      if (str.charAt(0) == '{') {
+        try {
+          return new JSONObject(str);
+        } catch (Exception ex) {
+        }
+      } else if (str.charAt(0) == '[') {
+        try {
+          return new JSONArray(str);
+        } catch (Exception ex) {
+        }
+      }
+      return str;
+    }
+  };
+
+  static final Builder<JSONArray> JSON_ARRAY = new Builder<JSONArray>() {
+    @Override
+    public JSONArray build(Object data) {
+      if (data == null) {
+        return null;
+      }
+      String str = BuilderFactory.STRING.build(data);
+      try {
+        return new JSONArray(str);
+      } catch (JSONException ex) {
+        // This is not necessary but we are doing this just to make is safer
+        // for com.vaadin.external.google:android-json library
+        throw new JedisException(ex);
+      }
+    }
+  };
+
+  static final Builder<List<JSONArray>> JSON_ARRAY_LIST = new Builder<List<JSONArray>>() {
+    @Override
+    public List<JSONArray> build(Object data) {
+      if (data == null) {
+        return null;
+      }
+      List<Object> list = (List<Object>) data;
+      return list.stream().map(o -> JSON_ARRAY.build(o)).collect(Collectors.toList());
+    }
+  };
+
+}


### PR DESCRIPTION
Move creation of the JSON command builders to a separate class which is initialized only when any of the JSON methods are being used. This allows org.json transitive Maven dependency to be excluded for the applications which don't use JSON methods.

See #2961 and #2962 for more information and rationale. Similar to #3223