### PR TITLE
Make GSON and org.json dependencies optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,13 @@
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
 			<version>20220924</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.8.9</version>
+			<optional>true</optional>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Stop requiring GSON and org.json dependencies by declaring them 'optional' in the pom file as described in https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html

This change will break existing projects that use the JSON jedis feature and don't have explicit dependencies to GSON and org.json. Projects that don't use JSON would not longer have unwanted dependencies in their class-path

See https://github.com/redis/jedis/issues/2961 and https://github.com/redis/jedis/pull/2962 for more information and rationale.