### PR TITLE
Fix jedis#hdel docs

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -5687,8 +5687,8 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   /**
-   * Remove the specified field(s) from a hash stored at key.
-   * Specified fields that do not exist within this hash are ignored.
+   * Remove the specified field(s) from a hash stored at key. Specified fields that do not exist
+   * within this hash are ignored.
    * <p>
    * <b>Time complexity:</b> O(1)
    * @param key

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -5687,13 +5687,15 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   /**
-   * Remove the specified field from an hash stored at key.
+   * Remove the specified field(s) from a hash stored at key.
+   * Specified fields that do not exist within this hash are ignored.
    * <p>
    * <b>Time complexity:</b> O(1)
    * @param key
    * @param fields
-   * @return If the field was present in the hash it is deleted and 1 is returned, otherwise 0 is
-   *         returned and no operation is performed.
+   * @return The number of fields that were removed from the hash, not including specified but
+   *         non-existing fields. If key does not exist, it is treated as an empty hash and this
+   *         command returns 0.
    */
   @Override
   public long hdel(final String key, final String... fields) {

--- a/src/test/java/redis/clients/jedis/commands/jedis/HashesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/HashesCommandsTest.java
@@ -200,7 +200,7 @@ public class HashesCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void hdel() {
-    Map<String, String> hash = new HashMap<String, String>();
+    Map<String, String> hash = new HashMap<>();
     hash.put("bar", "car");
     hash.put("car", "bar");
     jedis.hmset("foo", hash);
@@ -211,7 +211,7 @@ public class HashesCommandsTest extends JedisCommandsTestBase {
     assertNull(jedis.hget("foo", "bar"));
 
     // Binary
-    Map<byte[], byte[]> bhash = new HashMap<byte[], byte[]>();
+    Map<byte[], byte[]> bhash = new HashMap<>();
     bhash.put(bbar, bcar);
     bhash.put(bcar, bbar);
     jedis.hmset(bfoo, bhash);
@@ -220,6 +220,13 @@ public class HashesCommandsTest extends JedisCommandsTestBase {
     assertEquals(0, jedis.hdel(bfoo, bfoo));
     assertEquals(1, jedis.hdel(bfoo, bbar));
     assertNull(jedis.hget(bfoo, bbar));
+
+    // Deleting multiple fields returns the right value.
+    jedis.hmset("foo", hash);
+    assertEquals(2, jedis.hdel("foo", "bar", "car", "dne"));
+
+    jedis.hmset(bfoo, bhash);
+    assertEquals(2, jedis.hdel(bfoo, bbar, bcar, bbar1));
   }
 
   @Test


### PR DESCRIPTION
This is a non-breaking change that simply updates the documentation for `Jedis#hdel` and adds a test that proves the functionality is what is specified.

Previously, Jedis's docs suggested that the `hdel` operation always returned 1L for a successful deletion, or 0L for an unsuccessful deletion.

Redis [official docs](https://redis.io/commands/hdel/) state:

> **Return**
> [Integer reply](https://redis.io/docs/reference/protocol-spec#resp-integers): the number of fields that were removed from the hash, not including specified but non existing fields.
