### PR TITLE
Message and format locale junit adjustments

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/AccessControlListCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AccessControlListCommandsTest.java
@@ -14,7 +14,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.Arrays;
 import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -285,11 +290,14 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
     jedis2.close();
     jedis2.auth(USER_NAME, USER_PASSWORD);
 
+    final List<String> nopermKeys = Arrays.asList("NOPERM No permissions to access a key",
+        "NOPERM this user has no permissions to access one of the keys used as arguments");
+
     try {
       jedis2.set("foo", "bar");
       fail("Should throw a NOPERM exception");
     } catch (JedisAccessControlException e) {
-      assertEquals("NOPERM No permissions to access a key", e.getMessage());
+      MatcherAssert.assertThat(e.getMessage(), Matchers.isIn(nopermKeys));
     }
 
     // allow user to access a subset of the key
@@ -304,7 +312,7 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
       jedis2.set("zap:3", "c");
       fail("Should throw a NOPERM exception");
     } catch (JedisAccessControlException e) {
-      assertEquals("NOPERM No permissions to access a key", e.getMessage());
+      MatcherAssert.assertThat(e.getMessage(), Matchers.isIn(nopermKeys));
     }
   }
 

--- a/src/test/java/redis/clients/jedis/modules/search/DocumentTest.java
+++ b/src/test/java/redis/clients/jedis/modules/search/DocumentTest.java
@@ -1,18 +1,16 @@
 package redis.clients.jedis.modules.search;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 import redis.clients.jedis.search.Document;
 import redis.clients.jedis.util.SafeEncoder;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class DocumentTest {
 
@@ -40,8 +38,9 @@ public class DocumentTest {
     assertEquals(id, read.getId());
     assertEquals(score, read.getScore(), 0d);
     assertArrayEquals(payload, read.getPayload());
-    String exp = String.format("id:%s, score: %.1f, payload:%s, properties:%s",
-            id, score, SafeEncoder.encode(payload), "[string=c, float=12.0]") ;
+
+    String exp = String.format(Locale.US, "id:%s, score: %.1f, payload:%s, properties:%s", id,
+        score, SafeEncoder.encode(payload), "[string=c, float=12.0]");
     assertEquals(exp, read.toString());
     assertEquals("c", read.getString("string"));
     assertEquals(Double.valueOf(12d), read.get("float"));
@@ -57,8 +56,8 @@ public class DocumentTest {
     byte[] payload = "1a".getBytes();
     Document document = new Document(id, map, score, payload);
 
-    String expected = String.format("id:%s, score: %.1f, payload:%s, properties:%s",
-            id, score, SafeEncoder.encode(payload), "[string=c, float=12.0]") ;
+    String expected = String.format(Locale.US, "id:%s, score: %.1f, payload:%s, properties:%s", id,
+        score, SafeEncoder.encode(payload), "[string=c, float=12.0]");
     assertEquals(expected, document.toString());
   }
 
@@ -71,8 +70,8 @@ public class DocumentTest {
     map.put("float", 12d);
     Document document = new Document(id, map, score);
 
-    String expected = String.format("id:%s, score: %.1f, payload:%s, properties:%s",
-            id, score, null, "[string=c, float=12.0]") ;
+    String expected = String.format(Locale.US, "id:%s, score: %.1f, payload:%s, properties:%s", id,
+        score, null, "[string=c, float=12.0]");
     assertEquals(expected, document.toString());
   }
 }


### PR DESCRIPTION
1. Done some adjustments related at the error message '**noperm**' for **keys** adding the new one to the assertion test;
2. Forced the string's '**format**' method with a **default locale** to ensure the decimal number formated will have the same separator decimal as the assertion's message.

### Result
![Screenshot from 2023-03-13 21-41-02](https://user-images.githubusercontent.com/9445673/224863167-7daa4a73-ab0b-4fb1-88df-3b1541999ddb.png)

_PR_ related to issue [#3315](https://github.com/redis/jedis/issues/3315).
