### PR TITLE
Support parsing '-nan'

### DIFF
--- a/src/main/java/redis/clients/jedis/util/DoublePrecision.java
+++ b/src/main/java/redis/clients/jedis/util/DoublePrecision.java
@@ -26,6 +26,7 @@ public final class DoublePrecision {
           return Double.NEGATIVE_INFINITY;
 
         case "nan":
+        case "-nan": // for some module commands // TODO: remove
           return Double.NaN;
 
         default:

--- a/src/test/java/redis/clients/jedis/modules/graph/GraphValuesTest.java
+++ b/src/test/java/redis/clients/jedis/modules/graph/GraphValuesTest.java
@@ -38,4 +38,12 @@ public class GraphValuesTest extends RedisModuleCommandsTestBase {
     Record r = rs.iterator().next();
     assertEquals(Double.NaN, r.getValue(0), 0d);
   }
+
+  @Test
+  public void parseMinusNaN() {
+    ResultSet rs = client.graphQuery("db", "RETURN sqrt(-1)");
+    assertEquals(1, rs.size());
+    Record r = rs.iterator().next();
+    assertEquals(Double.NaN, r.getValue(0), 0d);
+  }
 }


### PR DESCRIPTION
Due to usages of `sprintf(str, "%.15g", d);` when d is NaN.

From @LiorKogan: "We should treat `-nan` as `nan`".

References:
- https://github.com/RedisGraph/RedisGraph/issues/2930