### PR TITLE
Improve safety of MultiNodePipelineBase under multi-thread

### DIFF
--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -73,10 +73,16 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
       queue = pipelinedResponses.get(nodeKey);
       connection = connections.get(nodeKey);
     } else {
-      queue = new LinkedList<>();
-      connection = getConnection(nodeKey);
-      pipelinedResponses.put(nodeKey, queue);
-      connections.put(nodeKey, connection);
+      pipelinedResponses.putIfAbsent(nodeKey, new LinkedList<>());
+      queue = pipelinedResponses.get(nodeKey);
+
+      Connection newOne = getConnection(nodeKey);
+      connections.putIfAbsent(nodeKey, newOne);
+      connection = connections.get(nodeKey);
+      if (connection != newOne) {
+        log.debug("Duplicate connection to {}, close it", nodeKey);
+        IOUtils.closeQuietly(newOne);
+      }
     }
 
     connection.sendCommand(commandObject.getArguments());
@@ -1005,7 +1011,7 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
   }
 
   @Override
-  public Response<List<Double>> zmscore(String key, String... members) {    
+  public Response<List<Double>> zmscore(String key, String... members) {
     return appendCommand(commandObjects.zmscore(key, members));
   }
 

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -80,7 +80,7 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
       connections.putIfAbsent(nodeKey, newOne);
       connection = connections.get(nodeKey);
       if (connection != newOne) {
-        log.debug("Duplicate connection to {}, close it", nodeKey);
+        log.debug("Duplicate connection to {}, closing it.", nodeKey);
         IOUtils.closeQuietly(newOne);
       }
     }


### PR DESCRIPTION
MultiNodePipelineBase is not safe in multi-thread when it used the same nodeKey to call appendCommand()

it would cause connection leak，because the map: connections just can record one connection for one nodeKey and there is no lock to protect it;
