### PR TITLE
Obtain multiple pipelines concurrently. high performance improvement

### DIFF
--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -8,12 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import org.json.JSONArray;
 import org.slf4j.Logger;

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -44,6 +44,13 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
+  /**
+   * default number of processes for sync, if you got enough cores for client
+   * or your cluster nodes more than 3 nodes, you may increase this workers number.
+   * suggest <= cluster nodes
+   */
+  public static volatile int MULTI_NODE_PIPELINE_SYNC_WORKERS = 3;
+
   private final Map<HostAndPort, Queue<Response<?>>> pipelinedResponses;
   private final Map<HostAndPort, Connection> connections;
   private volatile boolean syncing = false;
@@ -51,7 +58,7 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
   private final CommandObjects commandObjects;
   private GraphCommandObjects graphCommandObjects;
 
-  private final ExecutorService executorService = Executors.newFixedThreadPool(Protocol.CLUSTER_PIPELINE_SYNC_WORKERS);
+  private final ExecutorService executorService = Executors.newFixedThreadPool(MULTI_NODE_PIPELINE_SYNC_WORKERS);
 
   public MultiNodePipelineBase(CommandObjects commandObjects) {
     pipelinedResponses = new LinkedHashMap<>();

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -117,7 +117,7 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
 
     CountDownLatch countDownLatch = new CountDownLatch(pipelinedResponses.size());
     Iterator<Map.Entry<HostAndPort, Queue<Response<?>>>> pipelinedResponsesIterator
-            = pipelinedResponses.entrySet().iterator();
+        = pipelinedResponses.entrySet().iterator();
     while (pipelinedResponsesIterator.hasNext()) {
       Map.Entry<HostAndPort, Queue<Response<?>>> entry = pipelinedResponsesIterator.next();
       HostAndPort nodeKey = entry.getKey();

--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -53,8 +54,7 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
   private final CommandObjects commandObjects;
   private GraphCommandObjects graphCommandObjects;
 
-  private final ExecutorService executorService = new ThreadPoolExecutor(3, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
-          new ArrayBlockingQueue<>(3));
+  private final ExecutorService executorService = Executors.newFixedThreadPool(Protocol.CLUSTER_PIPELINE_SYNC_WORKERS);
 
   public MultiNodePipelineBase(CommandObjects commandObjects) {
     pipelinedResponses = new LinkedHashMap<>();

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -23,6 +23,13 @@ public final class Protocol {
   public static final int DEFAULT_DATABASE = 0;
   public static final int CLUSTER_HASHSLOTS = 16384;
 
+  /**
+   * default number of processes for sync, if you got enough cores for client
+   * or your cluster nodes more than 3 nodes, you may increase this workers number.
+   * suggest <= cluster nodes
+   */
+  public static final int CLUSTER_PIPELINE_SYNC_WORKERS = 3;
+
   public static final Charset CHARSET = StandardCharsets.UTF_8;
 
   public static final byte DOLLAR_BYTE = '$';

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -23,13 +23,6 @@ public final class Protocol {
   public static final int DEFAULT_DATABASE = 0;
   public static final int CLUSTER_HASHSLOTS = 16384;
 
-  /**
-   * default number of processes for sync, if you got enough cores for client
-   * or your cluster nodes more than 3 nodes, you may increase this workers number.
-   * suggest <= cluster nodes
-   */
-  public static final int CLUSTER_PIPELINE_SYNC_WORKERS = 3;
-
   public static final Charset CHARSET = StandardCharsets.UTF_8;
 
   public static final byte DOLLAR_BYTE = '$';


### PR DESCRIPTION
multiple pipelines sync concurrently will improvement the performance  under  redis cluster model
A 5-node cluster, vertically representing the results from the same batch
Extraordinary Suggestion: Convert sync to multi-threaded execution, which can improve performance by about 80%

![image](https://user-images.githubusercontent.com/10794822/227183937-089dbfb3-1bdf-44a1-9125-a6d794b51cbc.png)
