### PR TITLE
Standalone mode do not implements samplekey commands in pipeline

### DIFF
--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -21,6 +21,8 @@ import redis.clients.jedis.bloom.*;
 import redis.clients.jedis.commands.PipelineBinaryCommands;
 import redis.clients.jedis.commands.PipelineCommands;
 import redis.clients.jedis.commands.RedisModulePipelineCommands;
+import redis.clients.jedis.commands.SampleBinaryKeyedPipelineCommands;
+import redis.clients.jedis.commands.SampleKeyedPipelineCommands;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.graph.GraphCommandObjects;
 import redis.clients.jedis.graph.ResultSet;
@@ -40,7 +42,7 @@ import redis.clients.jedis.util.IOUtils;
 import redis.clients.jedis.util.KeyValue;
 
 public abstract class MultiNodePipelineBase implements PipelineCommands, PipelineBinaryCommands,
-    RedisModulePipelineCommands, Closeable {
+    SampleKeyedPipelineCommands, SampleBinaryKeyedPipelineCommands, RedisModulePipelineCommands, Closeable {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -4329,10 +4331,6 @@ public abstract class MultiNodePipelineBase implements PipelineCommands, Pipelin
     return appendCommand(commandObjects.graphProfile(graphName, query));
   }
   // RedisGraph commands
-
-  public Response<Long> waitReplicas(int replicas, long timeout) {
-    return appendCommand(commandObjects.waitReplicas(replicas, timeout));
-  }
 
   public void setJsonObjectMapper(JsonObjectMapper jsonObjectMapper) {
     this.commandObjects.setJsonObjectMapper(jsonObjectMapper);

--- a/src/main/java/redis/clients/jedis/Pipeline.java
+++ b/src/main/java/redis/clients/jedis/Pipeline.java
@@ -1625,46 +1625,6 @@ public class Pipeline extends Queable implements PipelineCommands, PipelineBinar
   }
 
   @Override
-  public Response<Long> waitReplicas(String sampleKey, int replicas, long timeout) {
-    return appendCommand(commandObjects.waitReplicas(sampleKey, replicas, timeout));
-  }
-
-  @Override
-  public Response<Object> eval(String script, String sampleKey) {
-    return appendCommand(commandObjects.eval(script, sampleKey));
-  }
-
-  @Override
-  public Response<Object> evalsha(String sha1, String sampleKey) {
-    return appendCommand(commandObjects.evalsha(sha1, sampleKey));
-  }
-
-  @Override
-  public Response<List<Boolean>> scriptExists(String sampleKey, String... sha1) {
-    return appendCommand(commandObjects.scriptExists(sampleKey, sha1));
-  }
-
-  @Override
-  public Response<String> scriptLoad(String script, String sampleKey) {
-    return appendCommand(commandObjects.scriptLoad(script, sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(String sampleKey) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(String sampleKey, FlushMode flushMode) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey, flushMode));
-  }
-
-  @Override
-  public Response<String> scriptKill(String sampleKey) {
-    return appendCommand(commandObjects.scriptKill(sampleKey));
-  }
-
-  @Override
   public Response<Object> fcall(byte[] name, List<byte[]> keys, List<byte[]> args) {
     return appendCommand(commandObjects.fcall(name, keys, args));
   }
@@ -2443,46 +2403,6 @@ public class Pipeline extends Queable implements PipelineCommands, PipelineBinar
 
   public Response<LCSMatchResult> strAlgoLCSStrings(byte[] strA, byte[] strB, StrAlgoLCSParams params) {
     return appendCommand(commandObjects.strAlgoLCSStrings(strA, strB, params));
-  }
-
-  @Override
-  public Response<Long> waitReplicas(byte[] sampleKey, int replicas, long timeout) {
-    return appendCommand(commandObjects.waitReplicas(sampleKey, replicas, timeout));
-  }
-
-  @Override
-  public Response<Object> eval(byte[] script, byte[] sampleKey) {
-    return appendCommand(commandObjects.eval(script, sampleKey));
-  }
-
-  @Override
-  public Response<Object> evalsha(byte[] sha1, byte[] sampleKey) {
-    return appendCommand(commandObjects.evalsha(sha1, sampleKey));
-  }
-
-  @Override
-  public Response<List<Boolean>> scriptExists(byte[] sampleKey, byte[]... sha1s) {
-    return appendCommand(commandObjects.scriptExists(sampleKey, sha1s));
-  }
-
-  @Override
-  public Response<byte[]> scriptLoad(byte[] script, byte[] sampleKey) {
-    return appendCommand(commandObjects.scriptLoad(script, sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(byte[] sampleKey) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(byte[] sampleKey, FlushMode flushMode) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey, flushMode));
-  }
-
-  @Override
-  public Response<String> scriptKill(byte[] sampleKey) {
-    return appendCommand(commandObjects.scriptKill(sampleKey));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/TransactionBase.java
+++ b/src/main/java/redis/clients/jedis/TransactionBase.java
@@ -1722,47 +1722,6 @@ public abstract class TransactionBase extends Queable implements PipelineCommand
     return appendCommand(commandObjects.evalshaReadonly(sha1, keys, args));
   }
 
-
-  @Override
-  public Response<Long> waitReplicas(String sampleKey, int replicas, long timeout) {
-    return appendCommand(commandObjects.waitReplicas(sampleKey, replicas, timeout));
-  }
-
-  @Override
-  public Response<Object> eval(String script, String sampleKey) {
-    return appendCommand(commandObjects.eval(script, sampleKey));
-  }
-
-  @Override
-  public Response<Object> evalsha(String sha1, String sampleKey) {
-    return appendCommand(commandObjects.evalsha(sha1, sampleKey));
-  }
-
-  @Override
-  public Response<List<Boolean>> scriptExists(String sampleKey, String... sha1) {
-    return appendCommand(commandObjects.scriptExists(sampleKey, sha1));
-  }
-
-  @Override
-  public Response<String> scriptLoad(String script, String sampleKey) {
-    return appendCommand(commandObjects.scriptLoad(script, sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(String sampleKey) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(String sampleKey, FlushMode flushMode) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey, flushMode));
-  }
-
-  @Override
-  public Response<String> scriptKill(String sampleKey) {
-    return appendCommand(commandObjects.scriptKill(sampleKey));
-  }
-
   @Override
   public Response<Object> fcall(byte[] name, List<byte[]> keys, List<byte[]> args) {
     return appendCommand(commandObjects.fcall(name, keys, args));
@@ -2542,46 +2501,6 @@ public abstract class TransactionBase extends Queable implements PipelineCommand
 
   public Response<LCSMatchResult> strAlgoLCSStrings(byte[] strA, byte[] strB, StrAlgoLCSParams params) {
     return appendCommand(commandObjects.strAlgoLCSStrings(strA, strB, params));
-  }
-
-  @Override
-  public Response<Long> waitReplicas(byte[] sampleKey, int replicas, long timeout) {
-    return appendCommand(commandObjects.waitReplicas(sampleKey, replicas, timeout));
-  }
-
-  @Override
-  public Response<Object> eval(byte[] script, byte[] sampleKey) {
-    return appendCommand(commandObjects.eval(script, sampleKey));
-  }
-
-  @Override
-  public Response<Object> evalsha(byte[] sha1, byte[] sampleKey) {
-    return appendCommand(commandObjects.evalsha(sha1, sampleKey));
-  }
-
-  @Override
-  public Response<List<Boolean>> scriptExists(byte[] sampleKey, byte[]... sha1s) {
-    return appendCommand(commandObjects.scriptExists(sampleKey, sha1s));
-  }
-
-  @Override
-  public Response<byte[]> scriptLoad(byte[] script, byte[] sampleKey) {
-    return appendCommand(commandObjects.scriptLoad(script, sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(byte[] sampleKey) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey));
-  }
-
-  @Override
-  public Response<String> scriptFlush(byte[] sampleKey, FlushMode flushMode) {
-    return appendCommand(commandObjects.scriptFlush(sampleKey, flushMode));
-  }
-
-  @Override
-  public Response<String> scriptKill(byte[] sampleKey) {
-    return appendCommand(commandObjects.scriptKill(sampleKey));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/commands/PipelineBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/PipelineBinaryCommands.java
@@ -4,5 +4,5 @@ public interface PipelineBinaryCommands extends KeyPipelineBinaryCommands,
     StringPipelineBinaryCommands, ListPipelineBinaryCommands, HashPipelineBinaryCommands,
     SetPipelineBinaryCommands, SortedSetPipelineBinaryCommands, GeoPipelineBinaryCommands,
     HyperLogLogPipelineBinaryCommands, StreamPipelineBinaryCommands,
-    ScriptingKeyPipelineBinaryCommands, SampleBinaryKeyedPipelineCommands, FunctionPipelineBinaryCommands {
+    ScriptingKeyPipelineBinaryCommands, FunctionPipelineBinaryCommands {
 }

--- a/src/main/java/redis/clients/jedis/commands/PipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/PipelineCommands.java
@@ -3,5 +3,5 @@ package redis.clients.jedis.commands;
 public interface PipelineCommands extends KeyPipelineCommands, StringPipelineCommands,
     ListPipelineCommands, HashPipelineCommands, SetPipelineCommands, SortedSetPipelineCommands,
     GeoPipelineCommands, HyperLogLogPipelineCommands, StreamPipelineCommands,
-    ScriptingKeyPipelineCommands, SampleKeyedPipelineCommands, FunctionPipelineCommands {
+    ScriptingKeyPipelineCommands, FunctionPipelineCommands {
 }


### PR DESCRIPTION
In standalone mode, pipeline commands do not need to implement samplekeyed commands. This pull request modifies the inheritance relationship of PipelineCommands and removes the relevant implementation commands.

