### PR TITLE
Fix binary value in comment in test code src/test/java/redis/clients/jedis/commands/jedis/BitCommandsTest.java

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/BitCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/BitCommandsTest.java
@@ -35,6 +35,7 @@ public class BitCommandsTest extends JedisCommandsTestBase {
     String foo = "foo";
 
     jedis.set(foo, String.valueOf(0));
+    //  string "0" with bits: 0011 0000
 
     jedis.setbit(foo, 3, true);
     jedis.setbit(foo, 7, true);
@@ -42,7 +43,8 @@ public class BitCommandsTest extends JedisCommandsTestBase {
     jedis.setbit(foo, 39, true);
 
     /*
-     * byte: 0 1 2 3 4 bit: 00010001 / 00000100 / 00000000 / 00000000 / 00000001
+     * bit:  00110001 / 00000100 / 00000000 / 00000000 / 00000001
+     * byte: 0          1          2          3          4
      */
     long offset = jedis.bitpos(foo, true);
     assertEquals(2, offset);
@@ -69,6 +71,7 @@ public class BitCommandsTest extends JedisCommandsTestBase {
     byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
 
     jedis.set(bfoo, Protocol.toByteArray(0));
+    // bits: 0011 0000
 
     jedis.setbit(bfoo, 3, true);
     jedis.setbit(bfoo, 7, true);
@@ -76,7 +79,8 @@ public class BitCommandsTest extends JedisCommandsTestBase {
     jedis.setbit(bfoo, 39, true);
 
     /*
-     * byte: 0 1 2 3 4 bit: 00010001 / 00000100 / 00000000 / 00000000 / 00000001
+     * bit:  00110001 / 00000100 / 00000000 / 00000000 / 00000001
+     * byte: 0          1          2          3          4
      */
     long offset = jedis.bitpos(bfoo, true);
     assertEquals(2, offset);
@@ -107,7 +111,8 @@ public class BitCommandsTest extends JedisCommandsTestBase {
     }
 
     /*
-     * byte: 0 bit: 11111111
+     * bit:  11111111
+     * byte: 0
      */
     long offset = jedis.bitpos(foo, false);
     // offset should be last index + 1
@@ -124,7 +129,8 @@ public class BitCommandsTest extends JedisCommandsTestBase {
     }
 
     /*
-     * byte: 0 1 2 3 4 bit: 11111111 / 11111111 / 11111111 / 11111111 / 11111111
+     * bit:  11111111 / 11111111 / 11111111 / 11111111 / 11111111
+     * byte: 0          1          2          3          4
      */
     long offset = jedis.bitpos(foo, false, new BitPosParams(2, 3));
     // offset should be -1

--- a/src/test/java/redis/clients/jedis/commands/unified/BitCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/BitCommandsTestBase.java
@@ -35,6 +35,7 @@ public abstract class BitCommandsTestBase extends UnifiedJedisCommandsTestBase {
     String foo = "foo";
 
     jedis.set(foo, String.valueOf(0));
+    //  string "0" with bits: 0011 0000
 
     jedis.setbit(foo, 3, true);
     jedis.setbit(foo, 7, true);
@@ -42,7 +43,8 @@ public abstract class BitCommandsTestBase extends UnifiedJedisCommandsTestBase {
     jedis.setbit(foo, 39, true);
 
     /*
-     * byte: 0 1 2 3 4 bit: 00010001 / 00000100 / 00000000 / 00000000 / 00000001
+     * bit:  00110001 / 00000100 / 00000000 / 00000000 / 00000001
+     * byte: 0          1          2          3          4
      */
     long offset = jedis.bitpos(foo, true);
     assertEquals(2, offset);
@@ -69,6 +71,7 @@ public abstract class BitCommandsTestBase extends UnifiedJedisCommandsTestBase {
     byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
 
     jedis.set(bfoo, Protocol.toByteArray(0));
+    // bits: 0011 0000
 
     jedis.setbit(bfoo, 3, true);
     jedis.setbit(bfoo, 7, true);
@@ -76,7 +79,8 @@ public abstract class BitCommandsTestBase extends UnifiedJedisCommandsTestBase {
     jedis.setbit(bfoo, 39, true);
 
     /*
-     * byte: 0 1 2 3 4 bit: 00010001 / 00000100 / 00000000 / 00000000 / 00000001
+     * bit:  00110001 / 00000100 / 00000000 / 00000000 / 00000001
+     * byte: 0          1          2          3          4
      */
     long offset = jedis.bitpos(bfoo, true);
     assertEquals(2, offset);
@@ -107,7 +111,8 @@ public abstract class BitCommandsTestBase extends UnifiedJedisCommandsTestBase {
     }
 
     /*
-     * byte: 0 bit: 11111111
+     * bit:  11111111
+     * byte: 0
      */
     long offset = jedis.bitpos(foo, false);
     // offset should be last index + 1
@@ -124,7 +129,8 @@ public abstract class BitCommandsTestBase extends UnifiedJedisCommandsTestBase {
     }
 
     /*
-     * byte: 0 1 2 3 4 bit: 11111111 / 11111111 / 11111111 / 11111111 / 11111111
+     * bit:  11111111 / 11111111 / 11111111 / 11111111 / 11111111
+     * byte: 0          1          2          3          4
      */
     long offset = jedis.bitpos(foo, false, new BitPosParams(2, 3));
     // offset should be -1


### PR DESCRIPTION
When first setting "0" (string) to redis, the bits are actually 0011 0000, instead of number 0 with bits 0000 0000.

Goods new is: all the code logic are correct.   The problem only exists in the comment.
