### PR TITLE
Fix: client setname need ignore syntax error in redis4

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -398,7 +398,14 @@ public class Connection implements Closeable {
         if (obj instanceof JedisDataException) {
           JedisDataException e = (JedisDataException)obj;
           String errorMsg = e.getMessage().toUpperCase();
-          if (errorMsg.contains("UNKNOWN") ||
+          /**
+           * 1. Redis 4.0 and before, we need to ignore `Syntax error`.
+           * 2. Redis 5.0 and later, we need to ignore `Unknown subcommand error`.
+           * 3. Because Jedis allows Jedis jedis = new Jedis() in advance, and jedis.auth(password) later,
+           * we need to ignore `NOAUTH errors`.
+           */
+          if (errorMsg.contains("SYNTAX") ||
+              errorMsg.contains("UNKNOWN") ||
               errorMsg.contains("NOAUTH")) { // TODO: not filter out NOAUTH
             // ignore
           } else {


### PR DESCRIPTION
1. Redis [4.0](https://github.com/redis/redis/blob/4.0/src/networking.c#L1744) and before, we need to ignore `Syntax error`. 
2. Redis [5.0](https://github.com/redis/redis/blob/5.0/src/networking.c#L1933) and later, we need to ignore `Unknown subcommand error`.
3. Because Jedis allows Jedis jedis = new Jedis() in advance, and jedis.auth(password) later, we need to ignore `NOAUTH errors`.

We need CIs for different Redis versions (4.0, 5.0, 6.0, 7.0...) to guarantee Jedis backwards compatibility. Before that, we need to mark the test cases differently. I created a new issue https://github.com/redis/jedis/issues/3410 to track this issue.