### PR TITLE
Add an option to ignore cluster init error

### DIFF
--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -19,6 +19,8 @@ import redis.clients.jedis.exceptions.JedisException;
 
 public class ClusterConnectionProvider implements ConnectionProvider {
 
+  private static final String INIT_NO_ERROR_PROPERTY = "jedis.cluster.initNoError";
+
   protected final JedisClusterInfoCache cache;
 
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig) {
@@ -53,6 +55,9 @@ public class ClusterConnectionProvider implements ConnectionProvider {
       }
     }
 
+    if (System.getProperty(INIT_NO_ERROR_PROPERTY) != null) {
+      return;
+    }
     JedisClusterOperationException uninitializedException
         = new JedisClusterOperationException("Could not initialize cluster slots cache.");
     uninitializedException.addSuppressed(firstException);

--- a/src/test/java/redis/clients/jedis/misc/ClusterInitErrorTest.java
+++ b/src/test/java/redis/clients/jedis/misc/ClusterInitErrorTest.java
@@ -1,0 +1,40 @@
+package redis.clients.jedis.misc;
+
+import java.util.Collections;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPorts;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
+
+public class ClusterInitErrorTest {
+
+  private static final String INIT_NO_ERROR_PROPERTY = "jedis.cluster.initNoError";
+
+  @After
+  public void cleanUp() {
+    System.getProperties().remove(INIT_NO_ERROR_PROPERTY);
+  }
+
+  @Test(expected = JedisClusterOperationException.class)
+  public void initError() {
+    Assert.assertNull(System.getProperty(INIT_NO_ERROR_PROPERTY));
+    try (JedisCluster cluster = new JedisCluster(
+        Collections.singleton(HostAndPorts.getRedisServers().get(0)),
+        DefaultJedisClientConfig.builder().password("foobared").build())) {
+      throw new IllegalStateException("should not reach here");
+    }
+  }
+
+  @Test
+  public void initNoError() {
+    System.setProperty(INIT_NO_ERROR_PROPERTY, "");
+    try (JedisCluster cluster = new JedisCluster(
+        Collections.singleton(HostAndPorts.getRedisServers().get(0)),
+        DefaultJedisClientConfig.builder().password("foobared").build())) {
+      Assert.assertThrows(JedisClusterOperationException.class, () -> cluster.get("foo"));
+    }
+  }
+}


### PR DESCRIPTION
References of inspiration:
- https://github.com/redis/jedis/issues/3392 
- https://stackoverflow.com/questions/76207822/updating-to-spring-boot-3-0-6-jedis-fails-unit-tests-with-jedisclusteroperatio 
- https://stackoverflow.com/questions/76207822/updating-to-spring-boot-3-0-6-jedis-fails-unit-tests-with-jedisclusteroperatio/76224927#comment134405538_76207822 
  > I suggest also filing a ticket with the Jedis driver to have the exception handling improved during slot initialization as the actual error doesn't bubble up. – **mp911de** 
- https://github.com/redis/jedis/issues/3392#issuecomment-1573925414 
  > In my case whole application is not able to start as I am configuring everything on startup, so this is creating tight coupling – @nikhilgurjar 

---

A `JedisClusterOperationException` with message `Could not initialize cluster slots cache.` is thrown during failed cluster initialization. This behavior is introduced since Jedis 4.0.0. To avoid this error, just set `jedis.cluster.initNoError` (any value) system property.