### PR TITLE
A demo of redis version tag proposal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ stop:
 
 test: compile-module start
 	sleep 2
-	mvn -Dtest=${SKIP_SSL}${TEST} clean compile test
+	mvn -Dredisversion=${REDIS_VERSION} -Dtest=${SKIP_SSL}${TEST} clean compile test
 	make stop
 
 package: start

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,16 @@
 			<artifactId>gson</artifactId>
 			<version>2.10.1</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>1.9.2</version>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
@@ -1,7 +1,7 @@
 package redis.clients.jedis.commands.jedis;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
@@ -19,7 +19,7 @@ public abstract class JedisCommandsTestBase {
     super();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
 //    jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().timeoutMillis(500).password("foobared").build());
     jedis = new Jedis(hnp, DefaultJedisClientConfig.builder()
@@ -27,7 +27,7 @@ public abstract class JedisCommandsTestBase {
     jedis.flushAll();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     jedis.close();
   }

--- a/src/test/java/redis/clients/jedis/commands/jedis/SetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SetCommandsTest.java
@@ -285,6 +285,7 @@ public class SetCommandsTest extends JedisCommandsTestBase {
   }
 
   @Test
+  @EnabledOnRedis({RedisType.REDIS_UNSTABLE, RedisType.REDIS_7})
   public void smismember() {
     jedis.sadd("foo", "a", "b");
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/SetCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SetCommandsTest.java
@@ -19,7 +19,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.versiontag.EnabledOnRedis;
+import redis.clients.jedis.versiontag.RedisType;
 
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
@@ -323,6 +325,7 @@ public class SetCommandsTest extends JedisCommandsTestBase {
   }
 
   @Test
+  @EnabledOnRedis({RedisType.REDIS_UNSTABLE, RedisType.REDIS_7})
   public void sinterstore() {
     jedis.sadd("foo", "a");
     jedis.sadd("foo", "b");
@@ -356,6 +359,7 @@ public class SetCommandsTest extends JedisCommandsTestBase {
   }
 
   @Test
+  @EnabledOnRedis({RedisType.REDIS_UNSTABLE, RedisType.REDIS_7})
   public void sintercard() {
     jedis.sadd("foo", "a");
     jedis.sadd("foo", "b");

--- a/src/test/java/redis/clients/jedis/versiontag/CustomExecutionCondition.java
+++ b/src/test/java/redis/clients/jedis/versiontag/CustomExecutionCondition.java
@@ -1,0 +1,46 @@
+package redis.clients.jedis.versiontag;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static java.lang.System.getenv;
+
+public class CustomExecutionCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        Optional<EnabledOnRedis> optional = AnnotationUtils.findAnnotation(context.getElement(),
+                EnabledOnRedis.class);
+
+        if (optional.isPresent()) {
+            List<RedisType> typeList = Arrays.asList(optional.get().value());
+            String type = System.getProperty("redisversion");
+            if (type.isEmpty()) type = "REDIS_UNSTABLE";
+
+            RedisType Redis_type = null;
+            try {
+                Redis_type = Enum.valueOf(RedisType.class, type.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                System.out.println(e.getMessage());
+                System.out.println("Supported engines are: ");
+                for (RedisType et : RedisType.values()) {
+                    System.out.println(et.name());
+                }
+                System.exit(1);
+            }
+
+            if (typeList.contains(Redis_type)) {
+                return ConditionEvaluationResult.enabled("Test is enabled for engine " + Redis_type.name());
+            } else {
+                return ConditionEvaluationResult.disabled("Test is disabled for engine " + Redis_type.name());
+            }
+        }
+        return ConditionEvaluationResult.enabled("@EnabledOnEngine is not present");
+    }
+}

--- a/src/test/java/redis/clients/jedis/versiontag/CustomExecutionCondition.java
+++ b/src/test/java/redis/clients/jedis/versiontag/CustomExecutionCondition.java
@@ -21,7 +21,7 @@ public class CustomExecutionCondition implements ExecutionCondition {
         if (optional.isPresent()) {
             List<RedisType> typeList = Arrays.asList(optional.get().value());
             String type = System.getProperty("redisversion");
-            if (type.isEmpty()) type = "REDIS_UNSTABLE";
+            if (type == null || type.isEmpty()) type = "REDIS_UNSTABLE";
 
             RedisType Redis_type = null;
             try {

--- a/src/test/java/redis/clients/jedis/versiontag/EnabledOnRedis.java
+++ b/src/test/java/redis/clients/jedis/versiontag/EnabledOnRedis.java
@@ -1,0 +1,15 @@
+package redis.clients.jedis.versiontag;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.*;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Documented
+@ExtendWith(CustomExecutionCondition.class)
+public @interface EnabledOnRedis {
+    RedisType[] value();
+}
+

--- a/src/test/java/redis/clients/jedis/versiontag/RedisType.java
+++ b/src/test/java/redis/clients/jedis/versiontag/RedisType.java
@@ -1,0 +1,8 @@
+package redis.clients.jedis.versiontag;
+
+public enum RedisType {
+    REDIS_6,
+    REDIS_7,
+    REDIS_UNSTABLE
+}
+


### PR DESCRIPTION
### This is a demo for annotating the compatible Redis version of the test cases in [SetCommandsTest](https://github.com/cjx-zar/jedis/blob/master/src/test/java/redis/clients/jedis/commands/jedis/SetCommandsTest.java). #3471 

#### In [RedisType](https://github.com/cjx-zar/jedis/blob/master/src/test/java/redis/clients/jedis/versiontag/RedisType.java), we can define all compatible Redis versions. Then we use "@EnabledOnRedis" to specify that certain test cases can only be run on their compatible Redis versions.

#### When testing, we can use "mvn -Dredisversion=redis_xx" to set the version of Redis. 

#### For example, in SetCommandsTest, Redis 6.0 does not support "sintercard", "sinterstore", and "smismember" commands, and we can skip these cases using "mvn -Dredisversion=redis_6".