### PR TITLE
Compatible JDK for JEDIS libraries in README (minor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ The most recent version of this library supports redis version [5.0](https://git
 
 The table below highlights version compatibility of the most-recent library versions and Redis versions. Compatibility means communication features, and Redis command capabilities.
 
-| Library version | Supported redis versions |
-|-----------------|-------------------|
-| 3.9+ | 5.0 and 6.2 Family of releases |
-| >= 4.0 | Version 5.0 to current |
+| Library version | Supported redis versions | Compatible JDK  |
+|-----------------|-------------------|-------------------|
+| 3.9+ | 5.0 and 6.2 Family of releases | 8, 11 |
+| >= 4.0 | Version 5.0 to current | 8, 11, 17 |
 
 ## Getting started
 


### PR DESCRIPTION
Simply add information about JDK versions compatible with the Jedis library in the README.MD

As resolved in Jedis Google Group in this conversation
https://groups.google.com/g/jedis_redis/c/eQGPCSSfvO4