### PR TITLE
Replace `synchronized` with `j.u.c.l.ReentrantLock` for Loom

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -4432,20 +4432,20 @@ public class CommandObjects {
    * @see DefaultGsonObjectMapper
    */
   private JsonObjectMapper getJsonObjectMapper() {
-      JsonObjectMapper localRef = this.jsonObjectMapper;
-      if (Objects.isNull(localRef)) {
-          mapperLock.lock();
-          
-          try {
-              localRef = this.jsonObjectMapper;
-              if (Objects.isNull(localRef)) {
-                  this.jsonObjectMapper = localRef = new DefaultGsonObjectMapper();
-              }
-          } finally {
-              mapperLock.unlock();
-          }
+    JsonObjectMapper localRef = this.jsonObjectMapper;
+    if (Objects.isNull(localRef)) {
+      mapperLock.lock();
+
+      try {
+        localRef = this.jsonObjectMapper;
+        if (Objects.isNull(localRef)) {
+          this.jsonObjectMapper = localRef = new DefaultGsonObjectMapper();
+        }
+      } finally {
+        mapperLock.unlock();
       }
-      return localRef;
+      }
+    return localRef;
   }
 
   public void setJsonObjectMapper(JsonObjectMapper jsonObjectMapper) {

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -4427,7 +4427,11 @@ public class CommandObjects {
   /**
    * Get the instance for JsonObjectMapper if not null, otherwise a new instance reference with
    * default implementation will be created and returned.
-   *
+   * <p>This process of checking whether or not
+   * the instance reference exists follows <a
+   * href="https://en.wikipedia.org/wiki/Double-checked_locking#Usage_in_Java"
+   * target="_blank">'double-checked lock optimization'</a> approach to reduce the overhead of
+   * acquiring a lock by testing the lock criteria (the "lock hint") before acquiring the lock.</p>
    * @return the JsonObjectMapper instance reference
    * @see DefaultGsonObjectMapper
    */

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -4444,7 +4444,7 @@ public class CommandObjects {
       } finally {
         mapperLock.unlock();
       }
-      }
+    }
     return localRef;
   }
 

--- a/src/main/java/redis/clients/jedis/graph/GraphCommandObjects.java
+++ b/src/main/java/redis/clients/jedis/graph/GraphCommandObjects.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 
 import redis.clients.jedis.Builder;
@@ -106,9 +108,7 @@ public class GraphCommandObjects {
   }
 
   private void createBuilder(String graphName) {
-    synchronized (builders) {
-      builders.putIfAbsent(graphName, new ResultSetBuilder(new GraphCacheImpl(graphName)));
-    }
+      builders.computeIfAbsent(graphName, graphNameKey -> new ResultSetBuilder(new GraphCacheImpl(graphNameKey)));
   }
 
   private class GraphCacheImpl implements GraphCache {
@@ -144,6 +144,8 @@ public class GraphCommandObjects {
     private final String name;
     private final String query;
     private final List<String> data = new CopyOnWriteArrayList<>();
+    
+    private final Lock dataLock = new ReentrantLock(true);
 
     /**
      *
@@ -164,14 +166,18 @@ public class GraphCommandObjects {
      */
     public String getCachedData(int index) {
       if (index >= data.size()) {
-        synchronized (data) {
+        dataLock.lock();
+        
+        try {
           if (index >= data.size()) {
             getProcedureInfo();
           }
+        } finally {
+          dataLock.unlock();
         }
       }
+      
       return data.get(index);
-
     }
 
     /**

--- a/src/main/java/redis/clients/jedis/graph/GraphCommandObjects.java
+++ b/src/main/java/redis/clients/jedis/graph/GraphCommandObjects.java
@@ -108,7 +108,7 @@ public class GraphCommandObjects {
   }
 
   private void createBuilder(String graphName) {
-      builders.computeIfAbsent(graphName, graphNameKey -> new ResultSetBuilder(new GraphCacheImpl(graphNameKey)));
+    builders.computeIfAbsent(graphName, graphNameKey -> new ResultSetBuilder(new GraphCacheImpl(graphNameKey)));
   }
 
   private class GraphCacheImpl implements GraphCache {

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
@@ -1,13 +1,12 @@
 package redis.clients.jedis.mcf;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.util.IOUtils;
-
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author Allen Terleto (aterleto)

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
@@ -6,6 +6,9 @@ import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.providers.MultiClusterPooledConnectionProvider;
 import redis.clients.jedis.util.IOUtils;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 /**
  * @author Allen Terleto (aterleto)
  * <p>
@@ -17,6 +20,7 @@ import redis.clients.jedis.util.IOUtils;
  */
 @Experimental
 public class CircuitBreakerFailoverBase implements AutoCloseable {
+    private final Lock lock = new ReentrantLock(true);
 
     protected final MultiClusterPooledConnectionProvider provider;
 
@@ -32,28 +36,33 @@ public class CircuitBreakerFailoverBase implements AutoCloseable {
     /**
      * Functional interface wrapped in retry and circuit breaker logic to handle open circuit breaker failure scenarios
      */
-    protected synchronized void clusterFailover(CircuitBreaker circuitBreaker) {
+    protected void clusterFailover(CircuitBreaker circuitBreaker) {
+        lock.lock();
+        
+        try {
+            // Check state to handle race conditions since incrementActiveMultiClusterIndex() is non-idempotent
+            if (!CircuitBreaker.State.FORCED_OPEN.equals(circuitBreaker.getState())) {
 
-        // Check state to handle race conditions since incrementActiveMultiClusterIndex() is non-idempotent
-        if (!CircuitBreaker.State.FORCED_OPEN.equals(circuitBreaker.getState())) {
+                // Transitions state machine to a FORCED_OPEN state, stopping state transition, metrics and event publishing.
+                // To recover/transition from this forced state the user will need to manually failback
+                circuitBreaker.transitionToForcedOpenState();
 
-            // Transitions state machine to a FORCED_OPEN state, stopping state transition, metrics and event publishing.
-            // To recover/transition from this forced state the user will need to manually failback
-            circuitBreaker.transitionToForcedOpenState();
+                // Incrementing the activeMultiClusterIndex will allow subsequent calls to the executeCommand()
+                // to use the next cluster's connection pool - according to the configuration's prioritization/order
+                int activeMultiClusterIndex = provider.incrementActiveMultiClusterIndex();
 
-            // Incrementing the activeMultiClusterIndex will allow subsequent calls to the executeCommand()
-            // to use the next cluster's connection pool - according to the configuration's prioritization/order
-            int activeMultiClusterIndex = provider.incrementActiveMultiClusterIndex();
+                // Implementation is optionally provided during configuration. Typically, used for activeMultiClusterIndex persistence or custom logging
+                provider.runClusterFailoverPostProcessor(activeMultiClusterIndex);
+            }
 
-            // Implementation is optionally provided during configuration. Typically, used for activeMultiClusterIndex persistence or custom logging
-            provider.runClusterFailoverPostProcessor(activeMultiClusterIndex);
-        }
-
-        // Once the priority list is exhausted only a manual failback can open the circuit breaker so all subsequent operations will fail
-        else if (provider.isLastClusterCircuitBreakerForcedOpen()) {
-            throw new JedisConnectionException("Cluster/database endpoint could not failover since the MultiClusterClientConfig was not " +
-                                               "provided with an additional cluster/database endpoint according to its prioritized sequence. " +
-                                               "If applicable, consider failing back OR restarting with an available cluster/database endpoint");
+            // Once the priority list is exhausted only a manual failback can open the circuit breaker so all subsequent operations will fail
+            else if (provider.isLastClusterCircuitBreakerForcedOpen()) {
+                throw new JedisConnectionException("Cluster/database endpoint could not failover since the MultiClusterClientConfig was not " +
+                                                   "provided with an additional cluster/database endpoint according to its prioritized sequence. " +
+                                                   "If applicable, consider failing back OR restarting with an available cluster/database endpoint");
+            }
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
## Goal

In Sep 2023, JDK 21 will be released. One of the most anticipated feature - Project Loom aka Virtual threads.

One of the problems with the current implementation, are `synchronized` blocks:
> However, not all Java constructs have been retrofitted that way. Such operations include synchronized methods and code blocks. Using them causes the virtual thread to become pinned to the carrier thread. When a thread is pinned, blocking operations will block the underlying carrier thread—precisely as it would happen in pre-Loom times.

From here: https://softwaremill.com/what-is-blocking-in-loom/#synchronization-problems

The main goal of this PR is to replace `synchronized` blocks with `ReentrantLock`s who are not susceptible to this problem.

## Approach

My approach was quite simple: replace `synchronized` blocks with `ReentrantLock`'s. However, in a few cases, though, I believe we can get rid of synchronization at all:

1. This code was written by @clebersonp:
```java
 private JsonObjectMapper getJsonObjectMapper() {
    JsonObjectMapper localRef = this.jsonObjectMapper;
    if (Objects.isNull(localRef)) {
      synchronized (this) {
        localRef = this.jsonObjectMapper;
        if (Objects.isNull(localRef)) {
          this.jsonObjectMapper = localRef = new DefaultGsonObjectMapper();
        }
      }
    }
    return localRef;
  }
```
I replaced it with:
```java
  private JsonObjectMapper getJsonObjectMapper() {
    if (Objects.isNull(this.jsonObjectMapper)) {
        this.jsonObjectMapper = new DefaultGsonObjectMapper();
    }
    
    return this.jsonObjectMapper;
  }
```
The field `jsonObjectMapper` marked as `volatile`, thus we establish connection (acquire-release) between thread which writes to this field and other threads which will read this field.

However, there is still a scenario when multiple threads will enter this method at the same time and see `null`: all of them will create an object and write it to a variable. This won't cause any problems since the `DefaultGsonObjectMapper` is stateless, but the object creation operation itself may be more costly than lock acquisition. Do you think it is worthwhile to return the lock here?

2. This code was written by @sazzad16: 

```java
  private void createBuilder(String graphName) {
    synchronized (builders) {
      builders.putIfAbsent(graphName, new ResultSetBuilder(new GraphCacheImpl(graphName)));
    }
  }
```
Since `builders` is `ConcurrentHashMap`, we can avoid synchronization and either use `putIfAbsent` or, if creation of `ResultSetBuilder` and `GraphCacheImpl` is expensive, use `computeIfAbsent`:
```java
builders.computeIfAbsent(graphName, graphNameKey -> new ResultSetBuilder(new GraphCacheImpl(graphNameKey)));
```

## Alternative
It worth mentioning a [comment](https://www.reddit.com/r/java/comments/14vrfim/comment/jrgkeja/?utm_source=share&utm_medium=web2x&context=3) on Reddit left by Ron Pressler (Project Loom lead) that the work on making `synchronized` not pin is underway. 

Leave `synchronized` blocks as is and wait for next version of JDK (22+).