### PR TITLE
Disabling doctests on tag

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -2,6 +2,8 @@ name: Documentation Tests
 
 on:
   push:
+    tags-ignore:
+      - '*'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Ensuring doctests do not run on tag, since they have already run when integrated.