### PR TITLE
Add active detection in sentinel mode,Reconstruct sentinel mode Listener

### DIFF
--- a/src/main/java/redis/clients/jedis/SentinelMasterActiveDetectListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterActiveDetectListener.java
@@ -1,0 +1,80 @@
+package redis.clients.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * active detect master node .in case of the subscribe message  lost
+ * @see  SentinelMasterSubscribeListener  subscribe failover message from "+switch-master" channel
+ *
+ */
+public abstract class SentinelMasterActiveDetectListener extends Thread implements SentinelMasterListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SentinelMasterActiveDetectListener.class);
+
+    private List<String> currentHostMaster;
+    private HostAndPort sentinel;
+    private JedisClientConfig jedisClientConfig;
+    private String masterName;
+    private long activeDetectIntervalTimeMillis = 5 * 1000;
+
+    private AtomicBoolean running = new AtomicBoolean(false);
+    private volatile Jedis j;
+
+    public SentinelMasterActiveDetectListener(HostAndPort currentHostMaster, HostAndPort sentinel,
+                                              JedisClientConfig jedisClientConfig, String masterName,
+                                              long activeDetectIntervalTimeMillis) {
+        super(String.format("SentinelMasterActiveDetectListener-%s-[%s:%d]", masterName, sentinel.getHost(), sentinel.getPort()));
+        this.currentHostMaster = Arrays.asList(currentHostMaster.getHost(), String.valueOf(currentHostMaster.getPort()));
+        this.sentinel = sentinel;
+        this.jedisClientConfig = jedisClientConfig;
+        this.masterName = masterName;
+        this.activeDetectIntervalTimeMillis = activeDetectIntervalTimeMillis;
+    }
+
+    @Override
+    public void shutdown() {
+        LOG.info("Shutting down active detect listener on {}", sentinel);
+        running.set(false);
+        if (j != null) {
+            j.close();
+        }
+    }
+
+    @Override
+    public void run() {
+        LOG.info("Start active detect listener on {},interval {} ms", sentinel, activeDetectIntervalTimeMillis);
+        running.set(true);
+        j = new Jedis(sentinel, jedisClientConfig);
+        while (running.get()) {
+            try {
+                Thread.sleep(activeDetectIntervalTimeMillis);
+
+                if (j == null || j.isBroken() || !j.isConnected()) {
+                    j = new Jedis(sentinel, jedisClientConfig);
+                }
+
+                List<String> masterAddr = j.sentinelGetMasterAddrByName(masterName);
+                if (masterAddr == null || masterAddr.size() != 2) {
+                    LOG.warn("Can not get master addr, master name: {}. Sentinel: {}", masterName, sentinel);
+                    continue;
+                }
+
+                if (!currentHostMaster.equals(masterAddr)) {
+                    LOG.info("Found master node change from {} to{} ", currentHostMaster, masterAddr);
+                    onChange(new HostAndPort(masterAddr.get(0), Integer.parseInt(masterAddr.get(1))));
+                    this.currentHostMaster = masterAddr;
+                }
+            } catch (Exception e) {
+                // TO  ensure the thread running, catch all exception
+                LOG.error("Active detect listener failed ", e);
+            }
+        }
+    }
+
+    public abstract void onChange(HostAndPort hostAndPort);
+}

--- a/src/main/java/redis/clients/jedis/SentinelMasterListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterListener.java
@@ -1,0 +1,15 @@
+package redis.clients.jedis;
+
+/**
+ *  interface for monitor the master failover under sentinel mode
+ *  We offer two implementation  options
+ *  @see SentinelMasterSubscribeListener Passive subscription
+ *  @see SentinelMasterActiveDetectListener Active detection
+ */
+public interface SentinelMasterListener {
+    void start();
+
+    void shutdown();
+
+    void onChange(HostAndPort hostAndPort);
+}

--- a/src/main/java/redis/clients/jedis/SentinelMasterSubscribeListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterSubscribeListener.java
@@ -1,0 +1,132 @@
+package redis.clients.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.exceptions.JedisException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * subscribe failover message from "+switch-master" channel , the default listener mode use this
+ * @see  SentinelMasterActiveDetectListener  active detect master node .in case of the subscribe message  lost
+ *
+ */
+public abstract class SentinelMasterSubscribeListener extends Thread implements SentinelMasterListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SentinelMasterSubscribeListener.class);
+
+    private String masterName;
+    private HostAndPort sentinel;
+    private JedisClientConfig sentinelClientConfig;
+    private long subscribeRetryWaitTimeMillis = 5000;
+    private volatile Jedis j;
+    private AtomicBoolean running = new AtomicBoolean(false);
+
+
+    public SentinelMasterSubscribeListener(String masterName, HostAndPort sentinel, JedisClientConfig sentinelClientConfig,
+                                          long subscribeRetryWaitTimeMillis) {
+        super(String.format("SentinelMaterSubscribeListener-%s-[%s:%d]", masterName, sentinel.getHost(), sentinel.getPort()));
+        this.masterName = masterName;
+        this.sentinel = sentinel;
+        this.sentinelClientConfig = sentinelClientConfig;
+        this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
+    }
+
+    @Override
+    public void run() {
+
+        LOG.info("start on:{}", sentinel);
+
+        running.set(true);
+
+        while (running.get()) {
+
+            try {
+                // double check that it is not being shutdown
+                if (!running.get()) {
+                    break;
+                }
+
+                j = new Jedis(sentinel, sentinelClientConfig);
+
+                // code for active refresh
+                List<String> masterAddr = j.sentinelGetMasterAddrByName(masterName);
+                if (masterAddr == null || masterAddr.size() != 2) {
+                    LOG.warn("Can not get master addr, master name: {}. Sentinel: {}.", masterName,
+                            sentinel);
+                } else {
+                    onChange(toHostAndPort(masterAddr));
+                }
+
+                j.subscribe(new JedisPubSub() {
+                    @Override
+                    public void onMessage(String channel, String message) {
+                        LOG.debug("Sentinel {} published: {}.", sentinel, message);
+
+                        String[] switchMasterMsg = message.split(" ");
+
+                        if (switchMasterMsg.length > 3) {
+
+                            if (masterName.equals(switchMasterMsg[0])) {
+                                LOG.info("Receive switch-master message:{} from {}.", message, channel);
+                                onChange(toHostAndPort(Arrays.asList(switchMasterMsg[3], switchMasterMsg[4])));
+                            } else {
+                                LOG.debug(
+                                        "Ignoring message on +switch-master for master name {}, our master name is {}",
+                                        switchMasterMsg[0], masterName);
+                            }
+
+                        } else {
+                            LOG.error("Invalid message received on Sentinel {} on channel +switch-master: {}",
+                                    sentinel, message);
+                        }
+                    }
+                }, "+switch-master");
+
+            } catch (JedisException e) {
+
+                if (running.get()) {
+                    LOG.error("Lost connection to Sentinel at {}. Sleeping {}ms and retrying.", sentinel, subscribeRetryWaitTimeMillis, e);
+                    try {
+                        Thread.sleep(subscribeRetryWaitTimeMillis);
+                    } catch (InterruptedException e1) {
+                        LOG.error("Sleep interrupted: ", e1);
+                    }
+                } else {
+                    LOG.debug("Unsubscribing from Sentinel at {}", sentinel);
+                }
+            } finally {
+                if (j != null) {
+                    j.close();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        try {
+            LOG.debug("Shutting down subscribe listener on {}", sentinel);
+            running.set(false);
+            // This isn't good, the Jedis object is not thread safe
+            if (j != null) {
+                j.close();
+            }
+        } catch (RuntimeException e) {
+            LOG.error("Caught exception while shutting down: ", e);
+        }
+    }
+
+
+    @Override
+    public abstract void onChange(HostAndPort hostAndPort);
+
+    private HostAndPort toHostAndPort(List<String> getMasterAddrByNameResult) {
+        String host = getMasterAddrByNameResult.get(0);
+        int port = Integer.parseInt(getMasterAddrByNameResult.get(1));
+
+        return new HostAndPort(host, port);
+    }
+}

--- a/src/main/java/redis/clients/jedis/SentinelPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/SentinelPoolConfig.java
@@ -1,0 +1,44 @@
+package redis.clients.jedis;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+public class SentinelPoolConfig extends GenericObjectPoolConfig {
+
+    private boolean enableActiveDetectListener = false;
+    private long activeDetectIntervalTimeMillis = 5 * 1000;
+
+    private boolean enableDefaultSubscribeListener = true;
+    private long subscribeRetryWaitTimeMillis = 5 * 1000;
+
+    public boolean isEnableActiveDetectListener() {
+        return enableActiveDetectListener;
+    }
+
+    public void setEnableActiveDetectListener(boolean enableActiveDetectListener) {
+        this.enableActiveDetectListener = enableActiveDetectListener;
+    }
+
+    public long getActiveDetectIntervalTimeMillis() {
+        return activeDetectIntervalTimeMillis;
+    }
+
+    public void setActiveDetectIntervalTimeMillis(long activeDetectIntervalTimeMillis) {
+        this.activeDetectIntervalTimeMillis = activeDetectIntervalTimeMillis;
+    }
+
+    public boolean isEnableDefaultSubscribeListener() {
+        return enableDefaultSubscribeListener;
+    }
+
+    public void setEnableDefaultSubscribeListener(boolean enableDefaultSubscribeListener) {
+        this.enableDefaultSubscribeListener = enableDefaultSubscribeListener;
+    }
+
+    public long getSubscribeRetryWaitTimeMillis() {
+        return subscribeRetryWaitTimeMillis;
+    }
+
+    public void setSubscribeRetryWaitTimeMillis(long subscribeRetryWaitTimeMillis) {
+        this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
+    }
+}

--- a/src/test/java/redis/clients/jedis/SentinelMasterListenerTest.java
+++ b/src/test/java/redis/clients/jedis/SentinelMasterListenerTest.java
@@ -1,0 +1,190 @@
+package redis.clients.jedis;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import redis.clients.jedis.providers.SentineledConnectionProvider;
+
+import static org.junit.Assert.*;
+
+public class SentinelMasterListenerTest {
+    private static final String MASTER_NAME = "mymaster";
+
+    public static final HostAndPort sentinel1 = HostAndPorts.getSentinelServers().get(0);
+    public static final HostAndPort sentinel2 = HostAndPorts.getSentinelServers().get(1);
+
+    public final Set<String> sentinels = new HashSet<>();
+
+    public final Set<HostAndPort> hostAndPortsSentinels = new HashSet<>();
+
+    @Before
+    public void setUp() throws Exception {
+        sentinels.clear();
+        hostAndPortsSentinels.clear();
+
+        sentinels.add(sentinel1.toString());
+        sentinels.add(sentinel2.toString());
+
+        hostAndPortsSentinels.add(sentinel1);
+        hostAndPortsSentinels.add(sentinel2);
+    }
+
+    @Test
+    public void testSentinelMasterSubscribeListener() {
+        // case 1: default : subscribe on ,active off
+        SentinelPoolConfig config = new SentinelPoolConfig();
+
+        JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000,
+                "foobared", 2);
+        HostAndPort hostPort1 = pool.getResource().connection.getHostAndPort();
+
+        Jedis sentinel = new Jedis(sentinel1);
+        sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+        try {
+            Thread.sleep(20000); // sleep. let the failover finish
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        HostAndPort hostPort2 = pool.getResource().connection.getHostAndPort();
+
+        pool.destroy();
+        assertNotEquals(hostPort1, hostPort2);
+    }
+
+    @Test
+    public void testSentinelMasterActiveDetectListener() {
+        // case 2: subscribe off ,active on
+        SentinelPoolConfig config = new SentinelPoolConfig();
+        config.setEnableActiveDetectListener(true);
+        config.setEnableDefaultSubscribeListener(false);
+
+        JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000,
+                "foobared", 2);
+        HostAndPort hostPort1 = pool.getResource().connection.getHostAndPort();
+
+        Jedis sentinel = new Jedis(sentinel1);
+        sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+        try {
+            Thread.sleep(20000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        HostAndPort hostPort2 = pool.getResource().connection.getHostAndPort();
+
+        pool.destroy();
+        assertNotEquals(hostPort1, hostPort2);
+    }
+
+    @Test
+    public void testALLSentinelMasterListener() {
+        // case 2: subscribe on ,active on
+        SentinelPoolConfig config = new SentinelPoolConfig();
+        config.setEnableActiveDetectListener(true);
+        config.setEnableDefaultSubscribeListener(true);
+        config.setActiveDetectIntervalTimeMillis(5 * 1000);
+        config.setSubscribeRetryWaitTimeMillis(5 * 1000);
+
+        JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000,
+                "foobared", 2);
+        HostAndPort hostPort1 = pool.getResource().connection.getHostAndPort();
+
+        Jedis sentinel = new Jedis(sentinel1);
+        sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+        try {
+            Thread.sleep(20000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        HostAndPort hostPort2 = pool.getResource().connection.getHostAndPort();
+
+        pool.destroy();
+        assertNotEquals(hostPort1, hostPort2);
+    }
+
+    @Test
+    public void testSentinelMasterSubscribeListenerForSentineledConnectionProvider() {
+        SentinelPoolConfig config = new SentinelPoolConfig();
+
+        SentineledConnectionProvider sentineledConnectionProvider = new SentineledConnectionProvider(MASTER_NAME,
+                DefaultJedisClientConfig.builder().timeoutMillis(1000).password("foobared").database(2).build()
+                , config, hostAndPortsSentinels, DefaultJedisClientConfig.builder().build());
+
+        try (JedisSentineled jedis = new JedisSentineled(sentineledConnectionProvider)) {
+
+            HostAndPort master1 = jedis.provider.getConnection().getHostAndPort();
+            Jedis sentinel = new Jedis(sentinel1);
+            sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+            try {
+                Thread.sleep(20000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            HostAndPort master2 = jedis.provider.getConnection().getHostAndPort();
+
+            assertNotEquals(master1, master2);
+        }
+    }
+
+    @Test
+    public void testSentinelMasterActiveDetectListenerForSentineledConnectionProvider() {
+        SentinelPoolConfig config = new SentinelPoolConfig();
+        config.setEnableActiveDetectListener(true);
+        config.setEnableDefaultSubscribeListener(false);
+
+        SentineledConnectionProvider sentineledConnectionProvider = new SentineledConnectionProvider(MASTER_NAME,
+                DefaultJedisClientConfig.builder().timeoutMillis(1000).password("foobared").database(2).build()
+                , config, hostAndPortsSentinels, DefaultJedisClientConfig.builder().build());
+
+        try (JedisSentineled jedis = new JedisSentineled(sentineledConnectionProvider)) {
+
+            HostAndPort master1 = jedis.provider.getConnection().getHostAndPort();
+            Jedis sentinel = new Jedis(sentinel1);
+            sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+            try {
+                Thread.sleep(20000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            HostAndPort master2 = jedis.provider.getConnection().getHostAndPort();
+
+            assertNotEquals(master1, master2);
+        }
+    }
+
+    @Test
+    public void testALLSentinelMasterListenerForSentineledConnectionProvider() {
+        SentinelPoolConfig config = new SentinelPoolConfig();
+        config.setEnableActiveDetectListener(true);
+        config.setEnableDefaultSubscribeListener(true);
+        config.setActiveDetectIntervalTimeMillis(5 * 1000);
+        config.setSubscribeRetryWaitTimeMillis(5 * 1000);
+
+        SentineledConnectionProvider sentineledConnectionProvider = new SentineledConnectionProvider(MASTER_NAME,
+                DefaultJedisClientConfig.builder().timeoutMillis(1000).password("foobared").database(2).build()
+                , config, hostAndPortsSentinels, DefaultJedisClientConfig.builder().build());
+
+        try (JedisSentineled jedis = new JedisSentineled(sentineledConnectionProvider)) {
+
+            HostAndPort master1 = jedis.provider.getConnection().getHostAndPort();
+            Jedis sentinel = new Jedis(sentinel1);
+            sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+            try {
+                Thread.sleep(20000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            HostAndPort master2 = jedis.provider.getConnection().getHostAndPort();
+
+            assertNotEquals(master1, master2);
+        }
+    }
+}

--- a/src/test/java/redis/clients/jedis/SentineledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/SentineledConnectionProviderTest.java
@@ -5,8 +5,10 @@ import java.util.Set;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 
+import org.junit.runners.MethodSorters;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.providers.SentineledConnectionProvider;
@@ -16,6 +18,7 @@ import static org.junit.Assert.*;
 /**
  * @see JedisSentinelPoolTest
  */
+@FixMethodOrder(MethodSorters.JVM)
 public class SentineledConnectionProviderTest {
 
   private static final String MASTER_NAME = "mymaster";
@@ -176,7 +179,7 @@ public class SentineledConnectionProviderTest {
       sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
 
       try {
-        Thread.sleep(10000);
+        Thread.sleep(20000);
       } catch (InterruptedException e) {
         e.printStackTrace();
       }
@@ -204,7 +207,7 @@ public class SentineledConnectionProviderTest {
       sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
 
       try {
-        Thread.sleep(10000);
+        Thread.sleep(20000);
       } catch (InterruptedException e) {
         e.printStackTrace();
       }
@@ -232,7 +235,7 @@ public class SentineledConnectionProviderTest {
       sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
 
       try {
-        Thread.sleep(10000);
+        Thread.sleep(20000);
       } catch (InterruptedException e) {
         e.printStackTrace();
       }

--- a/src/test/java/redis/clients/jedis/commands/jedis/SentinelCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SentinelCommandsTest.java
@@ -3,7 +3,9 @@ package redis.clients.jedis.commands.jedis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Map;
+
 import org.junit.Test;
 
 import redis.clients.jedis.HostAndPort;
@@ -51,8 +53,10 @@ public class SentinelCommandsTest {
   @Test
   public void replicas() {
     try (Jedis sentinel = new Jedis(sentinel2_1)) {
-      Map<String, String> details = sentinel.sentinelReplicas("mymaster").get(0);
-      assertEquals(Integer.toString(replica2.getPort()), details.get("port"));
+      List<Map<String, String>> replicas = sentinel.sentinelReplicas("mymaster");
+      for(Map<String, String> replica:replicas){
+        assertEquals("slave",replica.get("role-reported"));
+      }
     }
   }
 }


### PR DESCRIPTION
[sentinel mode， lost "+switch-master" message, should client add watchdog thread #3525](https://github.com/redis/jedis/discussions/3525)
please check this, JedisSentinelPool / SentineledConnectionProvider  provider monitor master-slave failover by subscribe the message from “+switch-master”。

this pr modify  master-slave failover monitor，Two listening mechanisms are provided, one is the default subscription mechanism and the other is the active detection mechanism; 
When due to network reasons, the client loses the subscription message and the main node connection of the jedis factory is still not switched, it will cause the connection to be unavailable.

1. SentinelMasterSubscribeListener the default listener
2. SentinelMasterActiveDetectListener the active detect listener

you can specify which listener to use;  or open both.  default is SubscribeListener, 
`

    SentinelPoolConfig config = new SentinelPoolConfig();
    config.setEnableActiveDetectListener(true);  // default off 
    config.setEnableDefaultSubscribeListener(true); // default on 
    config.setActiveDetectIntervalTimeMillis(5*1000); // default 5s 
    config.setSubscribeRetryWaitTimeMillis(5*1000); // default  5s 

    JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000,
            "foobared", 2);
`

