### PR TITLE
Add active detection in sentinel mode,Reconstruct sentinel mode Listener

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -202,7 +202,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
   private void initMasterListeners(Set<HostAndPort> sentinels, String masterName,
       GenericObjectPoolConfig<Jedis> poolConfig) {
 
-    LOG.info("Init master node listener {}", masterName);
+    LOG.info("Starting Sentinel listeners for {}...", masterName);
     SentinelPoolConfig jedisSentinelPoolConfig = null;
     if (poolConfig instanceof SentinelPoolConfig) {
       jedisSentinelPoolConfig = ((SentinelPoolConfig) poolConfig);
@@ -232,7 +232,6 @@ public class JedisSentinelPool extends Pool<Jedis> {
         });
       }
     }
-
     masterListeners.forEach(SentinelMasterListener::start);
   }
 

--- a/src/main/java/redis/clients/jedis/JedisSentinelPool.java
+++ b/src/main/java/redis/clients/jedis/JedisSentinelPool.java
@@ -1,11 +1,9 @@
 package redis.clients.jedis;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -24,10 +22,10 @@ public class JedisSentinelPool extends Pool<Jedis> {
 
   private final JedisClientConfig sentinelClientConfig;
 
-  protected final Collection<MasterListener> masterListeners = new ArrayList<>();
+  protected final Collection<SentinelMasterListener> masterListeners = new ArrayList<>();
 
   private volatile HostAndPort currentHostMaster;
-  
+
   private final Object initPoolLock = new Object();
 
   public JedisSentinelPool(String masterName, Set<HostAndPort> sentinels,
@@ -181,6 +179,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
 
     HostAndPort master = initSentinels(sentinels, masterName);
     initMaster(master);
+    initMasterListeners(sentinels, masterName);
   }
 
   public JedisSentinelPool(String masterName, Set<HostAndPort> sentinels,
@@ -193,6 +192,48 @@ public class JedisSentinelPool extends Pool<Jedis> {
 
     HostAndPort master = initSentinels(sentinels, masterName);
     initMaster(master);
+    initMasterListeners(sentinels, masterName, poolConfig);
+  }
+
+  private void initMasterListeners(Set<HostAndPort> sentinels, String masterName) {
+    initMasterListeners(sentinels, masterName, null);
+  }
+
+  private void initMasterListeners(Set<HostAndPort> sentinels, String masterName,
+      GenericObjectPoolConfig<Jedis> poolConfig) {
+
+    LOG.info("Init master node listener {}", masterName);
+    SentinelPoolConfig jedisSentinelPoolConfig = null;
+    if (poolConfig instanceof SentinelPoolConfig) {
+      jedisSentinelPoolConfig = ((SentinelPoolConfig) poolConfig);
+    } else {
+      jedisSentinelPoolConfig = new SentinelPoolConfig();
+    }
+
+    for (HostAndPort sentinel : sentinels) {
+      if (jedisSentinelPoolConfig.isEnableActiveDetectListener()) {
+        masterListeners.add(
+          new SentinelMasterActiveDetectListener(currentHostMaster, sentinel, sentinelClientConfig,
+              masterName, jedisSentinelPoolConfig.getActiveDetectIntervalTimeMillis()) {
+            @Override
+            public void onChange(HostAndPort hostAndPort) {
+              initMaster(hostAndPort);
+            }
+          });
+      }
+
+      if (jedisSentinelPoolConfig.isEnableDefaultSubscribeListener()) {
+        masterListeners.add(new SentinelMasterSubscribeListener(masterName, sentinel,
+            sentinelClientConfig, jedisSentinelPoolConfig.getSubscribeRetryWaitTimeMillis()) {
+          @Override
+          public void onChange(HostAndPort hostAndPort) {
+            initMaster(hostAndPort);
+          }
+        });
+      }
+    }
+
+    masterListeners.forEach(SentinelMasterListener::start);
   }
 
   private static Set<HostAndPort> parseHostAndPorts(Set<String> strings) {
@@ -201,10 +242,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
 
   @Override
   public void destroy() {
-    for (MasterListener m : masterListeners) {
-      m.shutdown();
-    }
-
+    masterListeners.forEach(SentinelMasterListener::shutdown);
     super.destroy();
   }
 
@@ -271,16 +309,7 @@ public class JedisSentinelPool extends Pool<Jedis> {
       }
     }
 
-    LOG.info("Redis master running at {}, starting Sentinel listeners...", master);
-
-    for (HostAndPort sentinel : sentinels) {
-
-      MasterListener masterListener = new MasterListener(masterName, sentinel.getHost(), sentinel.getPort());
-      // whether MasterListener threads are alive or not, process can be stopped
-      masterListener.setDaemon(true);
-      masterListeners.add(masterListener);
-      masterListener.start();
-    }
+    LOG.info("Redis master running at {}", master);
 
     return master;
   }
@@ -320,115 +349,6 @@ public class JedisSentinelPool extends Pool<Jedis> {
       } catch (RuntimeException e) {
         returnBrokenResource(resource);
         LOG.debug("Resource is returned to the pool as broken", e);
-      }
-    }
-  }
-
-  protected class MasterListener extends Thread {
-
-    protected String masterName;
-    protected String host;
-    protected int port;
-    protected long subscribeRetryWaitTimeMillis = 5000;
-    protected volatile Jedis j;
-    protected AtomicBoolean running = new AtomicBoolean(false);
-
-    protected MasterListener() {
-    }
-
-    public MasterListener(String masterName, String host, int port) {
-      super(String.format("MasterListener-%s-[%s:%d]", masterName, host, port));
-      this.masterName = masterName;
-      this.host = host;
-      this.port = port;
-    }
-
-    public MasterListener(String masterName, String host, int port,
-        long subscribeRetryWaitTimeMillis) {
-      this(masterName, host, port);
-      this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
-    }
-
-    @Override
-    public void run() {
-
-      running.set(true);
-
-      while (running.get()) {
-
-        try {
-          // double check that it is not being shutdown
-          if (!running.get()) {
-            break;
-          }
-          
-          final HostAndPort hostPort = new HostAndPort(host, port);
-          j = new Jedis(hostPort, sentinelClientConfig);
-
-          // code for active refresh
-          List<String> masterAddr = j.sentinelGetMasterAddrByName(masterName);
-          if (masterAddr == null || masterAddr.size() != 2) {
-            LOG.warn("Can not get master addr, master name: {}. Sentinel: {}.", masterName,
-                hostPort);
-          } else {
-            initMaster(toHostAndPort(masterAddr));
-          }
-
-          j.subscribe(new JedisPubSub() {
-            @Override
-            public void onMessage(String channel, String message) {
-              LOG.debug("Sentinel {} published: {}.", hostPort, message);
-
-              String[] switchMasterMsg = message.split(" ");
-
-              if (switchMasterMsg.length > 3) {
-
-                if (masterName.equals(switchMasterMsg[0])) {
-                  initMaster(toHostAndPort(Arrays.asList(switchMasterMsg[3], switchMasterMsg[4])));
-                } else {
-                  LOG.debug(
-                    "Ignoring message on +switch-master for master name {}, our master name is {}",
-                    switchMasterMsg[0], masterName);
-                }
-
-              } else {
-                LOG.error("Invalid message received on Sentinel {} on channel +switch-master: {}",
-                    hostPort, message);
-              }
-            }
-          }, "+switch-master");
-
-        } catch (JedisException e) {
-
-          if (running.get()) {
-            LOG.error("Lost connection to Sentinel at {}:{}. Sleeping 5000ms and retrying.", host,
-              port, e);
-            try {
-              Thread.sleep(subscribeRetryWaitTimeMillis);
-            } catch (InterruptedException e1) {
-              LOG.error("Sleep interrupted: ", e1);
-            }
-          } else {
-            LOG.debug("Unsubscribing from Sentinel at {}:{}", host, port);
-          }
-        } finally {
-          if (j != null) {
-            j.close();
-          }
-        }
-      }
-    }
-
-    public void shutdown() {
-      try {
-        LOG.debug("Shutting down listener on {}:{}", host, port);
-        running.set(false);
-        // This isn't good, the Jedis object is not thread safe
-        if (j != null) {
-          j.close();
-        }
-      } catch (RuntimeException e) {
-        LOG.error("Caught exception while shutting down: ", e);
       }
     }
   }

--- a/src/main/java/redis/clients/jedis/SentinelMasterActiveDetectListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterActiveDetectListener.java
@@ -36,6 +36,7 @@ public abstract class SentinelMasterActiveDetectListener extends Thread
     this.jedisClientConfig = jedisClientConfig;
     this.masterName = masterName;
     this.activeDetectIntervalTimeMillis = activeDetectIntervalTimeMillis;
+    this.setDaemon(true);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/SentinelMasterActiveDetectListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterActiveDetectListener.java
@@ -1,0 +1,83 @@
+package redis.clients.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * active detect master node .in case of the subscribe message lost
+ * @see SentinelMasterSubscribeListener subscribe failover message from "+switch-master" channel
+ */
+public abstract class SentinelMasterActiveDetectListener extends Thread
+    implements SentinelMasterListener {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(SentinelMasterActiveDetectListener.class);
+
+  private List<String> currentHostMaster;
+  private HostAndPort sentinel;
+  private JedisClientConfig jedisClientConfig;
+  private String masterName;
+  private long activeDetectIntervalTimeMillis = 5 * 1000;
+
+  private AtomicBoolean running = new AtomicBoolean(false);
+  private volatile Jedis j;
+
+  public SentinelMasterActiveDetectListener(HostAndPort currentHostMaster, HostAndPort sentinel,
+      JedisClientConfig jedisClientConfig, String masterName, long activeDetectIntervalTimeMillis) {
+    super(String.format("SentinelMasterActiveDetectListener-%s-[%s:%d]", masterName,
+      sentinel.getHost(), sentinel.getPort()));
+    this.currentHostMaster = Arrays.asList(currentHostMaster.getHost(),
+      String.valueOf(currentHostMaster.getPort()));
+    this.sentinel = sentinel;
+    this.jedisClientConfig = jedisClientConfig;
+    this.masterName = masterName;
+    this.activeDetectIntervalTimeMillis = activeDetectIntervalTimeMillis;
+  }
+
+  @Override
+  public void shutdown() {
+    LOG.info("Shutting down active detect listener on {}", sentinel);
+    running.set(false);
+    if (j != null) {
+      j.close();
+    }
+  }
+
+  @Override
+  public void run() {
+    LOG.info("Start active detect listener on {},interval {} ms", sentinel,
+      activeDetectIntervalTimeMillis);
+    running.set(true);
+    j = new Jedis(sentinel, jedisClientConfig);
+    while (running.get()) {
+      try {
+        Thread.sleep(activeDetectIntervalTimeMillis);
+
+        if (j == null || j.isBroken() || !j.isConnected()) {
+          j = new Jedis(sentinel, jedisClientConfig);
+        }
+
+        List<String> masterAddr = j.sentinelGetMasterAddrByName(masterName);
+        if (masterAddr == null || masterAddr.size() != 2) {
+          LOG.warn("Can not get master addr, master name: {}. Sentinel: {}", masterName, sentinel);
+          continue;
+        }
+
+        if (!currentHostMaster.equals(masterAddr)) {
+          LOG.info("Found master node change from {} to{} ", currentHostMaster, masterAddr);
+          onChange(new HostAndPort(masterAddr.get(0), Integer.parseInt(masterAddr.get(1))));
+          this.currentHostMaster = masterAddr;
+        }
+      } catch (Exception e) {
+        // TO ensure the thread running, catch all exception
+        LOG.error("Active detect listener failed ", e);
+      }
+    }
+  }
+
+  public abstract void onChange(HostAndPort hostAndPort);
+}

--- a/src/main/java/redis/clients/jedis/SentinelMasterListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterListener.java
@@ -1,0 +1,14 @@
+package redis.clients.jedis;
+
+/**
+ * interface for monitor the master failover under sentinel mode We offer two implementation options
+ * @see SentinelMasterSubscribeListener Passive subscription
+ * @see SentinelMasterActiveDetectListener Active detection
+ */
+public interface SentinelMasterListener {
+  void start();
+
+  void shutdown();
+
+  void onChange(HostAndPort hostAndPort);
+}

--- a/src/main/java/redis/clients/jedis/SentinelMasterSubscribeListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterSubscribeListener.java
@@ -33,6 +33,7 @@ public abstract class SentinelMasterSubscribeListener extends Thread
     this.sentinel = sentinel;
     this.sentinelClientConfig = sentinelClientConfig;
     this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
+    this.setDaemon(true);
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/SentinelMasterSubscribeListener.java
+++ b/src/main/java/redis/clients/jedis/SentinelMasterSubscribeListener.java
@@ -1,0 +1,132 @@
+package redis.clients.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.exceptions.JedisException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * subscribe failover message from "+switch-master" channel , the default listener mode use this
+ * @see SentinelMasterActiveDetectListener active detect master node .in case of the subscribe
+ *      message lost
+ */
+public abstract class SentinelMasterSubscribeListener extends Thread
+    implements SentinelMasterListener {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SentinelMasterSubscribeListener.class);
+
+  private String masterName;
+  private HostAndPort sentinel;
+  private JedisClientConfig sentinelClientConfig;
+  private long subscribeRetryWaitTimeMillis = 5000;
+  private volatile Jedis j;
+  private AtomicBoolean running = new AtomicBoolean(false);
+
+  public SentinelMasterSubscribeListener(String masterName, HostAndPort sentinel,
+      JedisClientConfig sentinelClientConfig, long subscribeRetryWaitTimeMillis) {
+    super(String.format("SentinelMaterSubscribeListener-%s-[%s:%d]", masterName, sentinel.getHost(),
+      sentinel.getPort()));
+    this.masterName = masterName;
+    this.sentinel = sentinel;
+    this.sentinelClientConfig = sentinelClientConfig;
+    this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
+  }
+
+  @Override
+  public void run() {
+
+    LOG.info("start on:{}", sentinel);
+
+    running.set(true);
+
+    while (running.get()) {
+
+      try {
+        // double check that it is not being shutdown
+        if (!running.get()) {
+          break;
+        }
+
+        j = new Jedis(sentinel, sentinelClientConfig);
+
+        // code for active refresh
+        List<String> masterAddr = j.sentinelGetMasterAddrByName(masterName);
+        if (masterAddr == null || masterAddr.size() != 2) {
+          LOG.warn("Can not get master addr, master name: {}. Sentinel: {}.", masterName, sentinel);
+        } else {
+          onChange(toHostAndPort(masterAddr));
+        }
+
+        j.subscribe(new JedisPubSub() {
+          @Override
+          public void onMessage(String channel, String message) {
+            LOG.debug("Sentinel {} published: {}.", sentinel, message);
+
+            String[] switchMasterMsg = message.split(" ");
+
+            if (switchMasterMsg.length > 3) {
+
+              if (masterName.equals(switchMasterMsg[0])) {
+                LOG.info("Receive switch-master message:{} from {}.", message, channel);
+                onChange(toHostAndPort(Arrays.asList(switchMasterMsg[3], switchMasterMsg[4])));
+              } else {
+                LOG.debug(
+                  "Ignoring message on +switch-master for master name {}, our master name is {}",
+                  switchMasterMsg[0], masterName);
+              }
+
+            } else {
+              LOG.error("Invalid message received on Sentinel {} on channel +switch-master: {}",
+                sentinel, message);
+            }
+          }
+        }, "+switch-master");
+
+      } catch (JedisException e) {
+
+        if (running.get()) {
+          LOG.error("Lost connection to Sentinel at {}. Sleeping {}ms and retrying.", sentinel,
+            subscribeRetryWaitTimeMillis, e);
+          try {
+            Thread.sleep(subscribeRetryWaitTimeMillis);
+          } catch (InterruptedException e1) {
+            LOG.error("Sleep interrupted: ", e1);
+          }
+        } else {
+          LOG.debug("Unsubscribing from Sentinel at {}", sentinel);
+        }
+      } finally {
+        if (j != null) {
+          j.close();
+        }
+      }
+    }
+  }
+
+  @Override
+  public void shutdown() {
+    try {
+      LOG.debug("Shutting down subscribe listener on {}", sentinel);
+      running.set(false);
+      // This isn't good, the Jedis object is not thread safe
+      if (j != null) {
+        j.close();
+      }
+    } catch (RuntimeException e) {
+      LOG.error("Caught exception while shutting down: ", e);
+    }
+  }
+
+  @Override
+  public abstract void onChange(HostAndPort hostAndPort);
+
+  private HostAndPort toHostAndPort(List<String> getMasterAddrByNameResult) {
+    String host = getMasterAddrByNameResult.get(0);
+    int port = Integer.parseInt(getMasterAddrByNameResult.get(1));
+
+    return new HostAndPort(host, port);
+  }
+}

--- a/src/main/java/redis/clients/jedis/SentinelPoolConfig.java
+++ b/src/main/java/redis/clients/jedis/SentinelPoolConfig.java
@@ -1,0 +1,44 @@
+package redis.clients.jedis;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+public class SentinelPoolConfig extends GenericObjectPoolConfig {
+
+  private boolean enableActiveDetectListener = false;
+  private long activeDetectIntervalTimeMillis = 5 * 1000;
+
+  private boolean enableDefaultSubscribeListener = true;
+  private long subscribeRetryWaitTimeMillis = 5 * 1000;
+
+  public boolean isEnableActiveDetectListener() {
+    return enableActiveDetectListener;
+  }
+
+  public void setEnableActiveDetectListener(boolean enableActiveDetectListener) {
+    this.enableActiveDetectListener = enableActiveDetectListener;
+  }
+
+  public long getActiveDetectIntervalTimeMillis() {
+    return activeDetectIntervalTimeMillis;
+  }
+
+  public void setActiveDetectIntervalTimeMillis(long activeDetectIntervalTimeMillis) {
+    this.activeDetectIntervalTimeMillis = activeDetectIntervalTimeMillis;
+  }
+
+  public boolean isEnableDefaultSubscribeListener() {
+    return enableDefaultSubscribeListener;
+  }
+
+  public void setEnableDefaultSubscribeListener(boolean enableDefaultSubscribeListener) {
+    this.enableDefaultSubscribeListener = enableDefaultSubscribeListener;
+  }
+
+  public long getSubscribeRetryWaitTimeMillis() {
+    return subscribeRetryWaitTimeMillis;
+  }
+
+  public void setSubscribeRetryWaitTimeMillis(long subscribeRetryWaitTimeMillis) {
+    this.subscribeRetryWaitTimeMillis = subscribeRetryWaitTimeMillis;
+  }
+}

--- a/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/SentineledConnectionProvider.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.slf4j.Logger;
@@ -16,10 +15,12 @@ import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisClientConfig;
-import redis.clients.jedis.JedisPubSub;
+import redis.clients.jedis.SentinelMasterActiveDetectListener;
+import redis.clients.jedis.SentinelMasterListener;
+import redis.clients.jedis.SentinelMasterSubscribeListener;
+import redis.clients.jedis.SentinelPoolConfig;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
-import redis.clients.jedis.util.IOUtils;
 
 public class SentineledConnectionProvider implements ConnectionProvider {
 
@@ -37,7 +38,7 @@ public class SentineledConnectionProvider implements ConnectionProvider {
 
   private final GenericObjectPoolConfig<Connection> masterPoolConfig;
 
-  protected final Collection<SentinelListener> sentinelListeners = new ArrayList<>();
+  protected final Collection<SentinelMasterListener> sentinelListeners = new ArrayList<>();
 
   private final JedisClientConfig sentinelClientConfig;
 
@@ -71,6 +72,44 @@ public class SentineledConnectionProvider implements ConnectionProvider {
 
     HostAndPort master = initSentinels(sentinels);
     initMaster(master);
+    initMasterListeners(sentinels,masterName,poolConfig);
+  }
+
+  private void initMasterListeners(Set<HostAndPort> sentinels, String masterName,
+      GenericObjectPoolConfig poolConfig) {
+
+    LOG.info("Init master node listener {}", masterName);
+    SentinelPoolConfig jedisSentinelPoolConfig = null;
+    if (poolConfig instanceof SentinelPoolConfig) {
+      jedisSentinelPoolConfig = ((SentinelPoolConfig) poolConfig);
+    } else {
+      jedisSentinelPoolConfig = new SentinelPoolConfig();
+    }
+
+    for (HostAndPort sentinel : sentinels) {
+      if (jedisSentinelPoolConfig.isEnableActiveDetectListener()) {
+        sentinelListeners.add(
+          new SentinelMasterActiveDetectListener(currentMaster, sentinel, sentinelClientConfig,
+              masterName, jedisSentinelPoolConfig.getActiveDetectIntervalTimeMillis()) {
+            @Override
+            public void onChange(HostAndPort hostAndPort) {
+              initMaster(hostAndPort);
+            }
+          });
+      }
+
+      if (jedisSentinelPoolConfig.isEnableDefaultSubscribeListener()) {
+        sentinelListeners.add(new SentinelMasterSubscribeListener(masterName, sentinel,
+            sentinelClientConfig, jedisSentinelPoolConfig.getSubscribeRetryWaitTimeMillis()) {
+          @Override
+          public void onChange(HostAndPort hostAndPort) {
+            initMaster(hostAndPort);
+          }
+        });
+      }
+    }
+
+    sentinelListeners.forEach(SentinelMasterListener::start);
   }
 
   @Override
@@ -85,7 +124,7 @@ public class SentineledConnectionProvider implements ConnectionProvider {
 
   @Override
   public void close() {
-    sentinelListeners.forEach(SentinelListener::shutdown);
+    sentinelListeners.forEach(SentinelMasterListener::shutdown);
 
     pool.close();
   }
@@ -161,16 +200,7 @@ public class SentineledConnectionProvider implements ConnectionProvider {
       }
     }
 
-    LOG.info("Redis master running at {}. Starting sentinel listeners...", master);
-
-    for (HostAndPort sentinel : sentinels) {
-
-      SentinelListener listener = new SentinelListener(sentinel);
-      // whether SentinelListener threads are alive or not, process can be stopped
-      listener.setDaemon(true);
-      sentinelListeners.add(listener);
-      listener.start();
-    }
+    LOG.info("Redis master running at {}. ", master);
 
     return master;
   }
@@ -184,97 +214,5 @@ public class SentineledConnectionProvider implements ConnectionProvider {
 
   private static HostAndPort toHostAndPort(String hostStr, String portStr) {
     return new HostAndPort(hostStr, Integer.parseInt(portStr));
-  }
-
-  protected class SentinelListener extends Thread {
-
-    protected final HostAndPort node;
-    protected volatile Jedis sentinelJedis;
-    protected AtomicBoolean running = new AtomicBoolean(false);
-
-    public SentinelListener(HostAndPort node) {
-      super(String.format("%s-SentinelListener-[%s]", masterName, node.toString()));
-      this.node = node;
-    }
-
-    @Override
-    public void run() {
-
-      running.set(true);
-
-      while (running.get()) {
-
-        try {
-          // double check that it is not being shutdown
-          if (!running.get()) {
-            break;
-          }
-
-          sentinelJedis = new Jedis(node, sentinelClientConfig);
-
-          // code for active refresh
-          List<String> masterAddr = sentinelJedis.sentinelGetMasterAddrByName(masterName);
-          if (masterAddr == null || masterAddr.size() != 2) {
-            LOG.warn("Can not get master {} address. Sentinel: {}.", masterName, node);
-          } else {
-            initMaster(toHostAndPort(masterAddr));
-          }
-
-          sentinelJedis.subscribe(new JedisPubSub() {
-            @Override
-            public void onMessage(String channel, String message) {
-              LOG.debug("Sentinel {} published: {}.", node, message);
-
-              String[] switchMasterMsg = message.split(" ");
-
-              if (switchMasterMsg.length > 3) {
-
-                if (masterName.equals(switchMasterMsg[0])) {
-                  initMaster(toHostAndPort(switchMasterMsg[3], switchMasterMsg[4]));
-                } else {
-                  LOG.debug(
-                    "Ignoring message on +switch-master for master {}. Our master is {}.",
-                    switchMasterMsg[0], masterName);
-                }
-
-              } else {
-                LOG.error("Invalid message received on sentinel {} on channel +switch-master: {}.",
-                    node, message);
-              }
-            }
-          }, "+switch-master");
-
-        } catch (JedisException e) {
-
-          if (running.get()) {
-            LOG.error("Lost connection to sentinel {}. Sleeping {}ms and retrying.", node,
-                subscribeRetryWaitTimeMillis, e);
-            try {
-              Thread.sleep(subscribeRetryWaitTimeMillis);
-            } catch (InterruptedException se) {
-              LOG.error("Sleep interrupted.", se);
-            }
-          } else {
-            LOG.debug("Unsubscribing from sentinel {}.", node);
-          }
-        } finally {
-          IOUtils.closeQuietly(sentinelJedis);
-        }
-      }
-    }
-
-    // must not throw exception
-    public void shutdown() {
-      try {
-        LOG.debug("Shutting down listener on {}.", node);
-        running.set(false);
-        // This isn't good, the Jedis object is not thread safe
-        if (sentinelJedis != null) {
-          sentinelJedis.close();
-        }
-      } catch (RuntimeException e) {
-        LOG.error("Error while shutting down.", e);
-      }
-    }
   }
 }

--- a/src/test/java/redis/clients/jedis/SentinelMasterListenerTest.java
+++ b/src/test/java/redis/clients/jedis/SentinelMasterListenerTest.java
@@ -1,0 +1,201 @@
+package redis.clients.jedis;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import redis.clients.jedis.providers.SentineledConnectionProvider;
+
+import static org.junit.Assert.*;
+
+/**
+ * In order to simulate the scenario of active/standby switching. this test case will effect all the
+ * sentinel test case, you can run this test case separately
+ */
+@Ignore
+public class SentinelMasterListenerTest {
+  private static final String MASTER_NAME = "mymaster";
+
+  public static final HostAndPort sentinel1 = HostAndPorts.getSentinelServers().get(0);
+  public static final HostAndPort sentinel2 = HostAndPorts.getSentinelServers().get(1);
+
+  public final Set<String> sentinels = new HashSet<>();
+
+  public final Set<HostAndPort> hostAndPortsSentinels = new HashSet<>();
+
+  private static final long WAIT_FAILOVER_TIMES_MILLS = 10000;
+
+  @Before
+  public void setUp() throws Exception {
+    sentinels.clear();
+    hostAndPortsSentinels.clear();
+
+    sentinels.add(sentinel1.toString());
+    sentinels.add(sentinel2.toString());
+
+    hostAndPortsSentinels.add(sentinel1);
+    hostAndPortsSentinels.add(sentinel2);
+  }
+
+  @Test
+  public void testSentinelMasterSubscribeListener() {
+    // case 1: default : subscribe on ,active off
+    SentinelPoolConfig config = new SentinelPoolConfig();
+
+    JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000, "foobared",
+        2);
+    HostAndPort hostPort1 = pool.getResource().connection.getHostAndPort();
+
+    Jedis sentinel = new Jedis(sentinel1);
+    sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+    try {
+      Thread.sleep(WAIT_FAILOVER_TIMES_MILLS); // sleep. let the failover finish
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    HostAndPort hostPort2 = pool.getResource().connection.getHostAndPort();
+
+    pool.destroy();
+    assertNotEquals(hostPort1, hostPort2);
+  }
+
+  @Test
+  public void testSentinelMasterActiveDetectListener() {
+    // case 2: subscribe off ,active on
+    SentinelPoolConfig config = new SentinelPoolConfig();
+    config.setEnableActiveDetectListener(true);
+    config.setEnableDefaultSubscribeListener(false);
+
+    JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000, "foobared",
+        2);
+    HostAndPort hostPort1 = pool.getResource().connection.getHostAndPort();
+
+    Jedis sentinel = new Jedis(sentinel1);
+    sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+    try {
+      Thread.sleep(WAIT_FAILOVER_TIMES_MILLS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    HostAndPort hostPort2 = pool.getResource().connection.getHostAndPort();
+
+    pool.destroy();
+    assertNotEquals(hostPort1, hostPort2);
+  }
+
+  @Test
+  public void testALLSentinelMasterListener() {
+    // case 2: subscribe on ,active on
+    SentinelPoolConfig config = new SentinelPoolConfig();
+    config.setEnableActiveDetectListener(true);
+    config.setEnableDefaultSubscribeListener(true);
+    config.setActiveDetectIntervalTimeMillis(5 * 1000);
+    config.setSubscribeRetryWaitTimeMillis(5 * 1000);
+
+    JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000, "foobared",
+        2);
+    HostAndPort hostPort1 = pool.getResource().connection.getHostAndPort();
+
+    Jedis sentinel = new Jedis(sentinel1);
+    sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+    try {
+      Thread.sleep(WAIT_FAILOVER_TIMES_MILLS);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    HostAndPort hostPort2 = pool.getResource().connection.getHostAndPort();
+
+    pool.destroy();
+    assertNotEquals(hostPort1, hostPort2);
+  }
+
+  @Test
+  public void testSentinelMasterSubscribeListenerForSentineledConnectionProvider() {
+    SentinelPoolConfig config = new SentinelPoolConfig();
+
+    SentineledConnectionProvider sentineledConnectionProvider = new SentineledConnectionProvider(
+        MASTER_NAME, DefaultJedisClientConfig.builder().timeoutMillis(1000).password("foobared")
+            .database(2).build(),
+        config, hostAndPortsSentinels, DefaultJedisClientConfig.builder().build());
+
+    try (JedisSentineled jedis = new JedisSentineled(sentineledConnectionProvider)) {
+
+      HostAndPort master1 = jedis.provider.getConnection().getHostAndPort();
+      Jedis sentinel = new Jedis(sentinel1);
+      sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+      try {
+        Thread.sleep(WAIT_FAILOVER_TIMES_MILLS);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+
+      HostAndPort master2 = jedis.provider.getConnection().getHostAndPort();
+
+      assertNotEquals(master1, master2);
+    }
+  }
+
+  @Test
+  public void testSentinelMasterActiveDetectListenerForSentineledConnectionProvider() {
+    SentinelPoolConfig config = new SentinelPoolConfig();
+    config.setEnableActiveDetectListener(true);
+    config.setEnableDefaultSubscribeListener(false);
+
+    SentineledConnectionProvider sentineledConnectionProvider = new SentineledConnectionProvider(
+        MASTER_NAME, DefaultJedisClientConfig.builder().timeoutMillis(1000).password("foobared")
+            .database(2).build(),
+        config, hostAndPortsSentinels, DefaultJedisClientConfig.builder().build());
+
+    try (JedisSentineled jedis = new JedisSentineled(sentineledConnectionProvider)) {
+
+      HostAndPort master1 = jedis.provider.getConnection().getHostAndPort();
+      Jedis sentinel = new Jedis(sentinel1);
+      sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+      try {
+        Thread.sleep(WAIT_FAILOVER_TIMES_MILLS);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+
+      HostAndPort master2 = jedis.provider.getConnection().getHostAndPort();
+
+      assertNotEquals(master1, master2);
+    }
+  }
+
+  @Test
+  public void testALLSentinelMasterListenerForSentineledConnectionProvider() {
+    SentinelPoolConfig config = new SentinelPoolConfig();
+    config.setEnableActiveDetectListener(true);
+    config.setEnableDefaultSubscribeListener(true);
+    config.setActiveDetectIntervalTimeMillis(5 * 1000);
+    config.setSubscribeRetryWaitTimeMillis(5 * 1000);
+
+    SentineledConnectionProvider sentineledConnectionProvider = new SentineledConnectionProvider(
+        MASTER_NAME, DefaultJedisClientConfig.builder().timeoutMillis(1000).password("foobared")
+            .database(2).build(),
+        config, hostAndPortsSentinels, DefaultJedisClientConfig.builder().build());
+
+    try (JedisSentineled jedis = new JedisSentineled(sentineledConnectionProvider)) {
+
+      HostAndPort master1 = jedis.provider.getConnection().getHostAndPort();
+      Jedis sentinel = new Jedis(sentinel1);
+      sentinel.sendCommand(Protocol.Command.SENTINEL, "failover", MASTER_NAME);
+      try {
+        Thread.sleep(WAIT_FAILOVER_TIMES_MILLS);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+
+      HostAndPort master2 = jedis.provider.getConnection().getHostAndPort();
+
+      assertNotEquals(master1, master2);
+    }
+  }
+}


### PR DESCRIPTION
[sentinel mode， lost "+switch-master" message, should client add watchdog thread #3525](https://github.com/redis/jedis/discussions/3525)
please check this, JedisSentinelPool / SentineledConnectionProvider  provider monitor master-slave failover by subscribe the message from “+switch-master”。

this pr modify  master-slave failover monitor，Two listening mechanisms are provided, one is the default subscription mechanism and the other is the active detection mechanism; 
When due to network reasons, the client loses the subscription message and the main node connection of the jedis factory is still not switched, it will cause the connection to be unavailable.

1. SentinelMasterSubscribeListener the default listener
2. SentinelMasterActiveDetectListener the active detect listener

you can specify which listener to use;  or open both.  default is SubscribeListener, 
`

    SentinelPoolConfig config = new SentinelPoolConfig();
    config.setEnableActiveDetectListener(true);   // default off 
    config.setEnableDefaultSubscribeListener(true); // default on 
    config.setActiveDetectIntervalTimeMillis(5*1000); // default 5s 
    config.setSubscribeRetryWaitTimeMillis(5*1000); // default  5s 

    JedisSentinelPool pool = new JedisSentinelPool(MASTER_NAME, sentinels, config, 1000,
            "foobared", 2);
`