### PR TITLE
Add possibility to create text/tag fields with option WITHSUFFIXTRIE

### DIFF
--- a/src/main/java/redis/clients/jedis/search/Schema.java
+++ b/src/main/java/redis/clients/jedis/search/Schema.java
@@ -226,6 +226,7 @@ public class Schema {
     private final double weight;
     private final boolean nostem;
     private final String phonetic;
+    private final boolean withSuffixTrie;
 
     public TextField(String name) {
       this(name, 1.0);
@@ -252,17 +253,27 @@ public class Schema {
     }
 
     public TextField(String name, double weight, boolean sortable, boolean nostem, boolean noindex, String phonetic) {
+      this(name, weight, sortable, nostem, noindex, phonetic, false);
+    }
+
+    public TextField(String name, double weight, boolean sortable, boolean nostem, boolean noindex, String phonetic, boolean withSuffixTrie) {
       super(name, FieldType.TEXT, sortable, noindex);
       this.weight = weight;
       this.nostem = nostem;
       this.phonetic = phonetic;
+      this.withSuffixTrie = withSuffixTrie;
     }
 
     public TextField(FieldName name, double weight, boolean sortable, boolean nostem, boolean noindex, String phonetic) {
+      this(name, weight, sortable, nostem, noindex, phonetic, false);
+    }
+
+    public TextField(FieldName name, double weight, boolean sortable, boolean nostem, boolean noindex, String phonetic, boolean withSuffixTrie) {
       super(name, FieldType.TEXT, sortable, noindex);
       this.weight = weight;
       this.nostem = nostem;
       this.phonetic = phonetic;
+      this.withSuffixTrie = withSuffixTrie;
     }
 
     @Override
@@ -278,12 +289,15 @@ public class Schema {
         args.add("PHONETIC");
         args.add(this.phonetic);
       }
+      if (withSuffixTrie) {
+        args.add("WITHSUFFIXTRIE");
+      }
     }
 
     @Override
     public String toString() {
       return "TextField{name='" + fieldName + "', type=" + type + ", sortable=" + sortable + ", noindex=" + noIndex
-          + ", weight=" + weight + ", nostem=" + nostem + ", phonetic='" + phonetic + "'}";
+          + ", weight=" + weight + ", nostem=" + nostem + ", phonetic='" + phonetic + ", withSuffixTrie='" + withSuffixTrie + "'}";
     }
   }
 
@@ -291,6 +305,7 @@ public class Schema {
 
     private final String separator;
     private final boolean caseSensitive;
+    private final boolean withSuffixTrie;
 
     public TagField(String name) {
       this(name, null);
@@ -313,9 +328,14 @@ public class Schema {
     }
 
     public TagField(String name, String separator, boolean caseSensitive, boolean sortable) {
+      this(name, separator, caseSensitive, sortable, false);
+    }
+
+    public TagField(String name, String separator, boolean caseSensitive, boolean sortable, boolean withSuffixTrie) {
       super(name, FieldType.TAG, sortable);
       this.separator = separator;
       this.caseSensitive = caseSensitive;
+      this.withSuffixTrie = withSuffixTrie;
     }
 
     public TagField(FieldName name, String separator, boolean sortable) {
@@ -323,9 +343,14 @@ public class Schema {
     }
 
     public TagField(FieldName name, String separator, boolean caseSensitive, boolean sortable) {
+      this(name, separator, caseSensitive, sortable, false);
+    }
+
+    public TagField(FieldName name, String separator, boolean caseSensitive, boolean sortable, boolean withSuffixTrie) {
       super(name, FieldType.TAG, sortable, false);
       this.separator = separator;
       this.caseSensitive = caseSensitive;
+      this.withSuffixTrie = withSuffixTrie;
     }
 
     @Override
@@ -337,12 +362,15 @@ public class Schema {
       if (caseSensitive) {
         args.add("CASESENSITIVE");
       }
+      if (withSuffixTrie) {
+        args.add("WITHSUFFIXTRIE");
+      }
     }
 
     @Override
     public String toString() {
       return "TagField{name='" + fieldName + "', type=" + type + ", sortable=" + sortable + ", noindex=" + noIndex
-          + ", separator='" + separator + ", caseSensitive='" + caseSensitive + "'}";
+          + ", separator='" + separator + ", caseSensitive='" + caseSensitive + ", withSuffixTrie='" + withSuffixTrie + "'}";
     }
   }
 

--- a/src/test/java/redis/clients/jedis/modules/search/SearchTest.java
+++ b/src/test/java/redis/clients/jedis/modules/search/SearchTest.java
@@ -501,8 +501,8 @@ public class SearchTest extends RedisModuleCommandsTestBase {
   @Test
   public void testJsonWithAlias() {
     Schema sc = new Schema()
-            .addTextField("$.name", 1.0).as("name")
-            .addNumericField("$.num").as("num");
+        .addTextField("$.name", 1.0).as("name")
+        .addNumericField("$.num").as("num");
 
     IndexDefinition definition = new IndexDefinition(IndexDefinition.Type.JSON).setPrefixes("king:");
 
@@ -1270,4 +1270,63 @@ public class SearchTest extends RedisModuleCommandsTestBase {
     }
     assertEquals(7, total);
   }
+
+  @Test
+  public void testCreateIndexWithTextFieldWithSuffixTrie() {
+    Schema schema1 = new Schema()
+        .addField(new TextField("withSuffixTrie", 1.0, false, false, false, null, true));
+    Schema schema2 = new Schema()
+        .addField(new TextField("withSuffixTrie", 1.0, false, true, false, null, true));
+    Schema schema3 = new Schema()
+        .addField(new TextField("withSuffixTrie", 1.0, false, false, false, "dm:en", true));
+    Schema schema4 = new Schema()
+        .addField(new TextField("withSuffixTrie", 1.0, false, true, false, "dm:en", true));
+    Schema schema5 = new Schema()
+        .addField(new TextField("withSuffixTrie", 1.0, true, true, true, "dm:en", true));
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema1));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema2));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema3));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema4));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema5));
+    client.ftDropIndex(index);
+  }
+
+  @Test
+  public void testCreateIndexWithTagFieldWithSuffixTrie() {
+    Schema schema1 = new Schema()
+        .addField(new TagField("withSuffixTrie", null, false, false, true));
+    Schema schema2 = new Schema()
+        .addField(new TagField("withSuffixTrie", "|", false, false, true));
+    Schema schema3 = new Schema()
+        .addField(new TagField("withSuffixTrie", "|", true, false, true));
+    Schema schema4 = new Schema()
+        .addField(new TagField("withSuffixTrie", "|", false, true, true));
+    Schema schema5 = new Schema()
+        .addField(new TagField("withSuffixTrie", "|", true, true, true));
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema1));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema2));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema3));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema4));
+    client.ftDropIndex(index);
+
+    assertEquals("OK", client.ftCreate(index, IndexOptions.defaultOptions(), schema5));
+    client.ftDropIndex(index);
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/modules/search/SearchTest.java
+++ b/src/test/java/redis/clients/jedis/modules/search/SearchTest.java
@@ -501,8 +501,8 @@ public class SearchTest extends RedisModuleCommandsTestBase {
   @Test
   public void testJsonWithAlias() {
     Schema sc = new Schema()
-        .addTextField("$.name", 1.0).as("name")
-        .addNumericField("$.num").as("num");
+            .addTextField("$.name", 1.0).as("name")
+            .addNumericField("$.num").as("num");
 
     IndexDefinition definition = new IndexDefinition(IndexDefinition.Type.JSON).setPrefixes("king:");
 


### PR DESCRIPTION
This change allows to create Text and Tag fields in schema with option WITHSUFFIXTRIE.

The change will allow to extend annotations `@Indexed` and `@Searchable` with new option in the project: https://github.com/redis/redis-om-spring