### PR TITLE
Introducing periodic topology mechanism for JedisCluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7379
-cluster-node-timeout 50
+cluster-node-timeout 15000
 pidfile /tmp/redis_cluster_node1.pid
 logfile /tmp/redis_cluster_node1.log
 save ""
@@ -223,7 +223,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7380
-cluster-node-timeout 50
+cluster-node-timeout 15000
 pidfile /tmp/redis_cluster_node2.pid
 logfile /tmp/redis_cluster_node2.log
 save ""
@@ -237,7 +237,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7381
-cluster-node-timeout 50
+cluster-node-timeout 15000
 pidfile /tmp/redis_cluster_node3.pid
 logfile /tmp/redis_cluster_node3.log
 save ""
@@ -251,7 +251,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7382
-cluster-node-timeout 50
+cluster-node-timeout 15000
 pidfile /tmp/redis_cluster_node4.pid
 logfile /tmp/redis_cluster_node4.log
 save ""
@@ -265,7 +265,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7383
-cluster-node-timeout 5000
+cluster-node-timeout 15000
 pidfile /tmp/redis_cluster_node5.pid
 logfile /tmp/redis_cluster_node5.log
 save ""

--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -25,9 +25,8 @@ public class ClusterPipeline extends MultiNodePipelineBase {
   }
 
   public ClusterPipeline(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
-      GenericObjectPoolConfig<Connection> poolConfig, boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
-    this(new ClusterConnectionProvider(clusterNodes, clientConfig, poolConfig,
-            topologyRefreshEnabled, topologyRefreshPeriod),
+      GenericObjectPoolConfig<Connection> poolConfig, Duration topologyRefreshPeriod) {
+    this(new ClusterConnectionProvider(clusterNodes, clientConfig, poolConfig, topologyRefreshPeriod),
         createClusterCommandObjects(clientConfig.getRedisProtocol()));
     this.closeable = this.provider;
   }

--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis;
 
+import java.time.Duration;
 import java.util.Set;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import redis.clients.jedis.providers.ClusterConnectionProvider;
@@ -19,6 +20,14 @@ public class ClusterPipeline extends MultiNodePipelineBase {
   public ClusterPipeline(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
       GenericObjectPoolConfig<Connection> poolConfig) {
     this(new ClusterConnectionProvider(clusterNodes, clientConfig, poolConfig),
+        createClusterCommandObjects(clientConfig.getRedisProtocol()));
+    this.closeable = this.provider;
+  }
+
+  public ClusterPipeline(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
+      GenericObjectPoolConfig<Connection> poolConfig, boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
+    this(new ClusterConnectionProvider(clusterNodes, clientConfig, poolConfig,
+            topologyRefreshEnabled, topologyRefreshPeriod),
         createClusterCommandObjects(clientConfig.getRedisProtocol()));
     this.closeable = this.provider;
   }

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -70,7 +70,7 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
         socket.setTcpNoDelay(true); // Socket buffer Whetherclosed, to ensure timely delivery of data
         socket.setSoLinger(true, 0); // Control calls close () method, the underlying socket is closed immediately
 
-        socket.connect(new InetSocketAddress(host.getHostAddress(), hostAndPort.getPort()), connectionTimeout);
+        socket.connect(new InetSocketAddress(host, hostAndPort.getPort()), connectionTimeout);
         return socket;
       } catch (Exception e) {
         jce.addSuppressed(e);

--- a/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisSocketFactory.java
@@ -70,6 +70,8 @@ public class DefaultJedisSocketFactory implements JedisSocketFactory {
         socket.setTcpNoDelay(true); // Socket buffer Whetherclosed, to ensure timely delivery of data
         socket.setSoLinger(true, 0); // Control calls close () method, the underlying socket is closed immediately
 
+        // Passing 'host' directly will avoid another call to InetAddress.getByName() inside the InetSocketAddress constructor.
+        // For machines with ipv4 and ipv6, but the startNode uses ipv4 to connect, the ipv6 connection may fail.
         socket.connect(new InetSocketAddress(host, hostAndPort.getPort()), connectionTimeout);
         return socket;
       } catch (Exception e) {

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -195,6 +195,13 @@ public class JedisCluster extends UnifiedJedis {
     super(clusterNodes, clientConfig, maxAttempts, maxTotalRetriesDuration);
   }
 
+  public JedisCluster(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
+      GenericObjectPoolConfig<Connection> poolConfig, int maxAttempts, Duration maxTotalRetriesDuration,
+      boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
+    super(clusterNodes, clientConfig, poolConfig, maxAttempts, maxTotalRetriesDuration, topologyRefreshEnabled,
+        topologyRefreshPeriod);
+  }
+
   public JedisCluster(ClusterConnectionProvider provider, int maxAttempts,
       Duration maxTotalRetriesDuration) {
     super(provider, maxAttempts, maxTotalRetriesDuration);

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -196,10 +196,10 @@ public class JedisCluster extends UnifiedJedis {
   }
 
   public JedisCluster(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
-      GenericObjectPoolConfig<Connection> poolConfig, boolean topologyRefreshEnabled,
-      Duration topologyRefreshPeriod, int maxAttempts, Duration maxTotalRetriesDuration) {
-    this(new ClusterConnectionProvider(clusterNodes, clientConfig, poolConfig, topologyRefreshEnabled,
-        topologyRefreshPeriod), maxAttempts, maxTotalRetriesDuration);
+      GenericObjectPoolConfig<Connection> poolConfig, Duration topologyRefreshPeriod, int maxAttempts,
+      Duration maxTotalRetriesDuration) {
+    this(new ClusterConnectionProvider(clusterNodes, clientConfig, poolConfig, topologyRefreshPeriod),
+        maxAttempts, maxTotalRetriesDuration);
   }
 
   public JedisCluster(ClusterConnectionProvider provider, int maxAttempts,

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -12,6 +12,8 @@ import redis.clients.jedis.util.JedisClusterCRC16;
 
 public class JedisCluster extends UnifiedJedis {
 
+  public static final String INIT_NO_ERROR_PROPERTY = "jedis.cluster.initNoError";
+
   /**
    * Default timeout in milliseconds.
    */

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -196,10 +196,10 @@ public class JedisCluster extends UnifiedJedis {
   }
 
   public JedisCluster(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
-      GenericObjectPoolConfig<Connection> poolConfig, int maxAttempts, Duration maxTotalRetriesDuration,
-      boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
-    super(clusterNodes, clientConfig, poolConfig, maxAttempts, maxTotalRetriesDuration, topologyRefreshEnabled,
-        topologyRefreshPeriod);
+      GenericObjectPoolConfig<Connection> poolConfig, boolean topologyRefreshEnabled,
+      Duration topologyRefreshPeriod, int maxAttempts, Duration maxTotalRetriesDuration) {
+    this(new ClusterConnectionProvider(clusterNodes, clientConfig, poolConfig, topologyRefreshEnabled,
+        topologyRefreshPeriod), maxAttempts, maxTotalRetriesDuration);
   }
 
   public JedisCluster(ClusterConnectionProvider provider, int maxAttempts,

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -44,12 +44,10 @@ public class JedisClusterInfoCache {
 
   private static final int MASTER_NODE_INDEX = 2;
 
-  private final Duration topologyRefreshPeriod;
-
   /**
    * The single thread executor for the topology refresh task.
    */
-  private final ScheduledExecutorService topologyRefreshExecutor;
+  private ScheduledExecutorService topologyRefreshExecutor = null;
 
   class TopologyRefreshTask implements Runnable {
     @Override
@@ -75,7 +73,6 @@ public class JedisClusterInfoCache {
     this.poolConfig = poolConfig;
     this.clientConfig = clientConfig;
     this.startNodes = startNodes;
-    this.topologyRefreshPeriod = topologyRefreshPeriod;
     if (topologyRefreshPeriod != null) {
       logger.info("Cluster topology refresh start, period: {}, startNodes: {}", topologyRefreshPeriod, startNodes);
       topologyRefreshExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -25,6 +25,8 @@ import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.SafeEncoder;
 
+import static redis.clients.jedis.JedisCluster.INIT_NO_ERROR_PROPERTY;
+
 public class JedisClusterInfoCache {
 
   private static final Logger logger = LoggerFactory.getLogger(JedisClusterInfoCache.class);
@@ -106,11 +108,13 @@ public class JedisClusterInfoCache {
 
   public void discoverClusterNodesAndSlots(Connection jedis) {
     List<Object> slotsInfo = executeClusterSlots(jedis);
-    if (slotsInfo.isEmpty()) {
-      throw new JedisClusterOperationException("Cluster slots list is empty.");
-    }
-    if (!checkClusterSlotSequence(slotsInfo)) {
-      throw new JedisClusterOperationException("Cluster slots have holes.");
+    if (System.getProperty(INIT_NO_ERROR_PROPERTY) == null) {
+      if (slotsInfo.isEmpty()) {
+        throw new JedisClusterOperationException("Cluster slots list is empty.");
+      }
+      if (!checkClusterSlotSequence(slotsInfo)) {
+        throw new JedisClusterOperationException("Cluster slots have holes.");
+      }
     }
     w.lock();
     try {
@@ -193,11 +197,13 @@ public class JedisClusterInfoCache {
 
   private void discoverClusterSlots(Connection jedis) {
     List<Object> slotsInfo = executeClusterSlots(jedis);
-    if (slotsInfo.isEmpty()) {
-      throw new JedisClusterOperationException("Cluster slots list is empty.");
-    }
-    if (!checkClusterSlotSequence(slotsInfo)) {
-      throw new JedisClusterOperationException("Cluster slots have holes.");
+    if (System.getProperty(INIT_NO_ERROR_PROPERTY) == null) {
+      if (slotsInfo.isEmpty()) {
+        throw new JedisClusterOperationException("Cluster slots list is empty.");
+      }
+      if (!checkClusterSlotSequence(slotsInfo)) {
+        throw new JedisClusterOperationException("Cluster slots have holes.");
+      }
     }
     w.lock();
     try {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -26,8 +26,8 @@ import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.SafeEncoder;
 
 public class JedisClusterInfoCache {
+
   private static final Logger logger = LoggerFactory.getLogger(JedisClusterInfoCache.class);
-  private static final Duration DEFAULT_TOPOLOGY_REFRESH_PERIOD = null;
 
   private final Map<String, ConnectionPool> nodes = new HashMap<>();
   private final ConnectionPool[] slots = new ConnectionPool[Protocol.CLUSTER_HASHSLOTS];
@@ -49,7 +49,7 @@ public class JedisClusterInfoCache {
   /**
    * The single thread executor for the topology refresh task.
    */
-  private ScheduledExecutorService topologyRefreshExecutor = null;
+  private final ScheduledExecutorService topologyRefreshExecutor;
 
   class TopologyRefreshTask implements Runnable {
     @Override
@@ -61,12 +61,12 @@ public class JedisClusterInfoCache {
   }
 
   public JedisClusterInfoCache(final JedisClientConfig clientConfig, final Set<HostAndPort> startNodes) {
-    this(clientConfig, null, startNodes, DEFAULT_TOPOLOGY_REFRESH_PERIOD);
+    this(clientConfig, null, startNodes);
   }
 
   public JedisClusterInfoCache(final JedisClientConfig clientConfig,
       final GenericObjectPoolConfig<Connection> poolConfig, final Set<HostAndPort> startNodes) {
-    this(clientConfig, poolConfig, startNodes, DEFAULT_TOPOLOGY_REFRESH_PERIOD);
+    this(clientConfig, poolConfig, startNodes, null);
   }
 
   public JedisClusterInfoCache(final JedisClientConfig clientConfig,
@@ -376,7 +376,7 @@ public class JedisClusterInfoCache {
 
   public void close() {
     reset();
-    if (topologyRefreshPeriod != null && topologyRefreshExecutor != null) {
+    if (topologyRefreshExecutor != null) {
       logger.info("Cluster topology refresh shutdown, startNodes: {}", startNodes);
       topologyRefreshExecutor.shutdownNow();
     }

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -164,6 +164,15 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
     if (proto != null) commandObjects.setProtocol(proto);
   }
 
+  public UnifiedJedis(Set<HostAndPort> jedisClusterNodes, JedisClientConfig clientConfig,
+      GenericObjectPoolConfig<Connection> poolConfig, int maxAttempts, Duration maxTotalRetriesDuration,
+      boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
+    this(new ClusterConnectionProvider(jedisClusterNodes, clientConfig, poolConfig, topologyRefreshEnabled,
+        topologyRefreshPeriod), maxAttempts, maxTotalRetriesDuration);
+    RedisProtocol proto = clientConfig.getRedisProtocol();
+    if (proto != null) commandObjects.setProtocol(proto);
+  }
+
   public UnifiedJedis(ClusterConnectionProvider provider, int maxAttempts, Duration maxTotalRetriesDuration) {
     this.provider = provider;
     this.executor = new ClusterCommandExecutor(provider, maxAttempts, maxTotalRetriesDuration);

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -164,15 +164,6 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
     if (proto != null) commandObjects.setProtocol(proto);
   }
 
-  public UnifiedJedis(Set<HostAndPort> jedisClusterNodes, JedisClientConfig clientConfig,
-      GenericObjectPoolConfig<Connection> poolConfig, int maxAttempts, Duration maxTotalRetriesDuration,
-      boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
-    this(new ClusterConnectionProvider(jedisClusterNodes, clientConfig, poolConfig, topologyRefreshEnabled,
-        topologyRefreshPeriod), maxAttempts, maxTotalRetriesDuration);
-    RedisProtocol proto = clientConfig.getRedisProtocol();
-    if (proto != null) commandObjects.setProtocol(proto);
-  }
-
   public UnifiedJedis(ClusterConnectionProvider provider, int maxAttempts, Duration maxTotalRetriesDuration) {
     this.provider = provider;
     this.executor = new ClusterCommandExecutor(provider, maxAttempts, maxTotalRetriesDuration);

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -18,9 +18,9 @@ import redis.clients.jedis.JedisClusterInfoCache;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
 import redis.clients.jedis.exceptions.JedisException;
 
-public class ClusterConnectionProvider implements ConnectionProvider {
+import static redis.clients.jedis.JedisCluster.INIT_NO_ERROR_PROPERTY;
 
-  private static final String INIT_NO_ERROR_PROPERTY = "jedis.cluster.initNoError";
+public class ClusterConnectionProvider implements ConnectionProvider {
 
   protected final JedisClusterInfoCache cache;
 

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -36,9 +36,8 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   }
 
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
-      GenericObjectPoolConfig<Connection> poolConfig, boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
-    this.cache = new JedisClusterInfoCache(clientConfig, poolConfig, clusterNodes, topologyRefreshEnabled,
-        topologyRefreshPeriod);
+      GenericObjectPoolConfig<Connection> poolConfig, Duration topologyRefreshPeriod) {
+    this.cache = new JedisClusterInfoCache(clientConfig, poolConfig, clusterNodes, topologyRefreshPeriod);
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.providers;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,6 +32,13 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
       GenericObjectPoolConfig<Connection> poolConfig) {
     this.cache = new JedisClusterInfoCache(clientConfig, poolConfig, clusterNodes);
+    initializeSlotsCache(clusterNodes, clientConfig);
+  }
+
+  public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
+      GenericObjectPoolConfig<Connection> poolConfig, boolean topologyRefreshEnabled, Duration topologyRefreshPeriod) {
+    this.cache = new JedisClusterInfoCache(clientConfig, poolConfig, clusterNodes, topologyRefreshEnabled,
+        topologyRefreshPeriod);
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 
@@ -66,7 +74,7 @@ public class ClusterConnectionProvider implements ConnectionProvider {
 
   @Override
   public void close() {
-    cache.reset();
+    cache.close();
   }
 
   public void renewSlotCache() {

--- a/src/test/java/redis/clients/jedis/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterTest.java
@@ -749,10 +749,9 @@ public class JedisClusterTest extends JedisClusterTestBase {
     jedisClusterNode.add(nodeInfo3);
 
     // we set topologyRefreshPeriod is 5s
-    boolean topologyRefreshEnabled = true;
     Duration topologyRefreshPeriod = Duration.ofSeconds(3);
     try (JedisCluster cluster = new JedisCluster(jedisClusterNode, DEFAULT_CLIENT_CONFIG, DEFAULT_POOL_CONFIG,
-        DEFAULT_REDIRECTIONS, Duration.ofSeconds(1000), topologyRefreshEnabled, topologyRefreshPeriod)) {
+        topologyRefreshPeriod, DEFAULT_REDIRECTIONS, Duration.ofSeconds(1000))) {
       assertEquals(3, cluster.getClusterNodes().size());
       cleanUp(); // cleanup and add node4
 

--- a/src/test/java/redis/clients/jedis/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterTest.java
@@ -741,6 +741,66 @@ public class JedisClusterTest extends JedisClusterTestBase {
     }
   }
 
+  @Test
+  public void clusterPeriodTopologyRefreshTest() throws Exception {
+    Set<HostAndPort> jedisClusterNode = new HashSet<>();
+    jedisClusterNode.add(nodeInfo1);
+    jedisClusterNode.add(nodeInfo2);
+    jedisClusterNode.add(nodeInfo3);
+
+    // we set topologyRefreshPeriod is 5s
+    boolean topologyRefreshEnabled = true;
+    Duration topologyRefreshPeriod = Duration.ofSeconds(3);
+    try (JedisCluster cluster = new JedisCluster(jedisClusterNode, DEFAULT_CLIENT_CONFIG, DEFAULT_POOL_CONFIG,
+        DEFAULT_REDIRECTIONS, Duration.ofSeconds(1000), topologyRefreshEnabled, topologyRefreshPeriod)) {
+      assertEquals(3, cluster.getClusterNodes().size());
+      cleanUp(); // cleanup and add node4
+
+      // at first, join node4 to cluster
+      node1.clusterMeet(LOCAL_IP, nodeInfo2.getPort());
+      node1.clusterMeet(LOCAL_IP, nodeInfo3.getPort());
+      node1.clusterMeet(LOCAL_IP, nodeInfo4.getPort());
+      // split available slots across the three nodes
+      int slotsPerNode = CLUSTER_HASHSLOTS / 4;
+      int[] node1Slots = new int[slotsPerNode];
+      int[] node2Slots = new int[slotsPerNode];
+      int[] node3Slots = new int[slotsPerNode];
+      int[] node4Slots = new int[slotsPerNode];
+      for (int i = 0, slot1 = 0, slot2 = 0, slot3 = 0, slot4 = 0; i < CLUSTER_HASHSLOTS; i++) {
+        if (i < slotsPerNode) {
+          node1Slots[slot1++] = i;
+        } else if (i >= slotsPerNode && i < slotsPerNode*2) {
+          node2Slots[slot2++] = i;
+        } else if (i >= slotsPerNode*2 && i < slotsPerNode*3) {
+          node3Slots[slot3++] = i;
+        } else {
+          node4Slots[slot4++] = i;
+        }
+      }
+
+      node1.clusterAddSlots(node1Slots);
+      node2.clusterAddSlots(node2Slots);
+      node3.clusterAddSlots(node3Slots);
+      node4.clusterAddSlots(node4Slots);
+      JedisClusterTestUtil.waitForClusterReady(node1, node2, node3, node4);
+
+      // Now we just wait topologyRefreshPeriod * 3 (executor will delay) for cluster topology refresh (3 -> 4)
+      Thread.sleep(topologyRefreshPeriod.toMillis() * 3);
+
+      assertEquals(4, cluster.getClusterNodes().size());
+      String nodeKey4 = LOCAL_IP + ":" + nodeInfo4.getPort();
+      assertTrue(cluster.getClusterNodes().keySet().contains(nodeKey4));
+
+      // make 4 nodes to 3 nodes
+      cleanUp();
+      setUp();
+
+      // Now we just wait topologyRefreshPeriod * 3 (executor will delay) for cluster topology refresh (4 -> 3)
+      Thread.sleep(topologyRefreshPeriod.toMillis() * 3);
+      assertEquals(3, cluster.getClusterNodes().size());
+    }
+  }
+
   private static String getNodeServingSlotRange(String infoOutput) {
     // f4f3dc4befda352a4e0beccf29f5e8828438705d 127.0.0.1:7380 master - 0
     // 1394372400827 0 connected 5461-10922

--- a/src/test/java/redis/clients/jedis/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterTest.java
@@ -741,17 +741,17 @@ public class JedisClusterTest extends JedisClusterTestBase {
     }
   }
 
-  @Test
+  @Test(timeout = 30_000)
   public void clusterPeriodTopologyRefreshTest() throws Exception {
     Set<HostAndPort> jedisClusterNode = new HashSet<>();
     jedisClusterNode.add(nodeInfo1);
     jedisClusterNode.add(nodeInfo2);
     jedisClusterNode.add(nodeInfo3);
 
-    // we set topologyRefreshPeriod is 5s
-    Duration topologyRefreshPeriod = Duration.ofSeconds(3);
+    // we set topologyRefreshPeriod is 1s
+    Duration topologyRefreshPeriod = Duration.ofSeconds(1);
     try (JedisCluster cluster = new JedisCluster(jedisClusterNode, DEFAULT_CLIENT_CONFIG, DEFAULT_POOL_CONFIG,
-        topologyRefreshPeriod, DEFAULT_REDIRECTIONS, Duration.ofSeconds(1000))) {
+        topologyRefreshPeriod, DEFAULT_REDIRECTIONS, Duration.ofSeconds(10))) {
       assertEquals(3, cluster.getClusterNodes().size());
       cleanUp(); // cleanup and add node4
 

--- a/src/test/java/redis/clients/jedis/JedisClusterTestBase.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterTestBase.java
@@ -77,10 +77,10 @@ public abstract class JedisClusterTestBase {
     node2.flushDB();
     node3.flushDB();
     node4.flushDB();
-    node1.clusterReset(ClusterResetType.SOFT);
-    node2.clusterReset(ClusterResetType.SOFT);
-    node3.clusterReset(ClusterResetType.SOFT);
-    node4.clusterReset(ClusterResetType.SOFT);
+    node1.clusterReset(ClusterResetType.HARD);
+    node2.clusterReset(ClusterResetType.HARD);
+    node3.clusterReset(ClusterResetType.HARD);
+    node4.clusterReset(ClusterResetType.HARD);
   }
 
   @After


### PR DESCRIPTION
solves #3595

EDIT: The main changes in this PR are as follows:

1. Add `topologyRefreshEnabled` and `topologyRefreshPeriod` to control the periodic topology refresh mechanism.
2. `topologyRefreshExecutor` is a single-threaded executor responsible for running `TopologyRefreshTask`.
3. Add `checkClusterSlotSequence` to check whether the cluster slots returned by the server are consecutive and there are no duplicates.
4. [Test] In JedisClusterTestBase, `CLUSTER RESET SOFT` was changed to `HARD`, because SOFT cannot clean up the Redis Cluster configuration and may cause a crash. Please refer to https://github.com/redis/redis/issues/12701
5. [Test] Adjust the cluster-node-timeout in the Makefile to 15s, consistent with the default configuration of Redis.
