### PR TITLE
Helper methods to use a Jedis object within a JedisPool

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisPool.java
+++ b/src/main/java/redis/clients/jedis/JedisPool.java
@@ -1,6 +1,8 @@
 package redis.clients.jedis;
 
 import java.net.URI;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
@@ -392,4 +394,17 @@ public class JedisPool extends Pool<Jedis> {
       }
     }
   }
+
+  public void withJedisDo(Consumer<Jedis> consumer) {
+    try (Jedis jedis = getResource()) {
+      consumer.accept(jedis);
+    }
+  }
+
+  public <K> K withJedisGet(Function<Jedis, K> function) {
+    try (Jedis jedis = getResource()) {
+      return function.apply(jedis);
+    }
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPoolTest.java
@@ -2,12 +2,14 @@ package redis.clients.jedis;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.PooledObjectFactory;
@@ -453,4 +455,30 @@ public class JedisPoolTest {
       }
     }
   }
+
+  @Test
+  public void testWithJedisDo() {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort())) {
+      pool.withJedisDo(jedis -> {
+        jedis.auth("foobared");
+        assertEquals(jedis.getClient().getHostAndPort().getHost(), hnp.getHost());
+        assertEquals(jedis.getClient().getHostAndPort().getPort(), hnp.getPort());
+        assertNotNull(jedis.time());
+      });
+    }
+  }
+
+  @Test
+  public void testWithJedisGet() {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort())) {
+      List<String> result = pool.withJedisGet(jedis -> {
+        jedis.auth("foobared");
+        assertEquals(jedis.getClient().getHostAndPort().getHost(), hnp.getHost());
+        assertEquals(jedis.getClient().getHostAndPort().getPort(), hnp.getPort());
+        return jedis.time();
+      });
+      assertNotNull(result);
+    }
+  }
+
 }


### PR DESCRIPTION
Add two helper methods to JedisPool
- one that uses a lamda to operate with a jedis connection from the pool and doesn't return anything
- other similar but it returns something
