### PR TITLE
Fix flaky tests in DocumentTest

### DIFF
--- a/src/test/java/redis/clients/jedis/modules/search/DocumentTest.java
+++ b/src/test/java/redis/clients/jedis/modules/search/DocumentTest.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.modules.search;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -40,9 +41,12 @@ public class DocumentTest {
     assertEquals(score, read.getScore(), 0d);
 
     // use english language to make sure the decimal separator is the same as the toString
-    String exp = String.format(Locale.ENGLISH, "id:%s, score: %.1f, properties:%s",
+    String exp1 = String.format(Locale.ENGLISH, "id:%s, score: %.1f, properties:%s",
         id, score, "[string=c, float=12.0]");
-    assertEquals(exp, read.toString());
+    String exp2 = String.format(Locale.ENGLISH, "id:%s, score: %.1f, properties:%s",
+        id, score, "[float=12.0, string=c]");
+    String actual = read.toString();
+    assertTrue(actual.equals(exp1)||actual.equals(exp2));
     assertEquals("c", read.getString("string"));
     assertEquals(Double.valueOf(12d), read.get("float"));
   }
@@ -57,8 +61,11 @@ public class DocumentTest {
     Document document = new Document(id, map, score);
 
     // use english language to make sure the decimal separator is the same as the toString
-    String expected = String.format(Locale.ENGLISH, "id:%s, score: %.1f, properties:%s",
+    String expected1 = String.format(Locale.ENGLISH, "id:%s, score: %.1f, properties:%s",
         id, score, "[string=c, float=12.0]");
-    assertEquals(expected, document.toString());
+    String expected2 = String.format(Locale.ENGLISH, "id:%s, score: %.1f, properties:%s",
+        id, score, "[float=12.0, string=c]");
+    String actual = document.toString();
+    assertTrue(actual.equals(expected1)||actual.equals(expected2));
   }
 }


### PR DESCRIPTION
## Description
There are 2 tests in the `DocumentTest.java` class which call the `DocumentTest.toString` method, this method converts a `Map` object to a string, which is not in any particular order, the tests may pass or fail even though the code under test may be working as expected.
https://github.com/219sansim/jedis/blob/c1cc657e8b3a984aab8779f84aa0ff55c2b29118/src/main/java/redis/clients/jedis/search/Document.java#L23
To resolve the bug, I changed the code to check for both possible orderings. 

Another possible fix could be to check if the string contains both the fields.

## Reproduction of error
Run maven tests with [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool
```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=redis.clients.jedis.modules.search.DocumentTest#toStringTest
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=redis.clients.jedis.modules.search.DocumentTest#serialize
```
**Error Output**
Showing error output of test `serialize`
```
[ERROR] Failures: 
[ERROR]   DocumentTest.serialize:45 expected:<...: 10.0, properties:[[string=c, float=12.0]]> but was:<...: 10.0, properties:[[float=12.0, string=c]]>
```
After making the changes, the tests pass with [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool 
