### PR TITLE
Support UnifiedJedis transactions without calling multi first

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -249,7 +249,7 @@ public class JedisCluster extends UnifiedJedis {
    * @throws UnsupportedOperationException
    */
   @Override
-  public Transaction multi() {
+  public Transaction transaction(boolean multi) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisSharding.java
+++ b/src/main/java/redis/clients/jedis/JedisSharding.java
@@ -63,7 +63,7 @@ public class JedisSharding extends UnifiedJedis {
    * @throws UnsupportedOperationException
    */
   @Override
-  public Transaction multi() {
+  public Transaction transaction(boolean multi) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -4844,12 +4844,20 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   public AbstractTransaction multi() {
+    return transaction(true);
+  }
+
+  public AbstractTransaction transaction() {
+    return transaction(false);
+  }
+
+  public AbstractTransaction transaction(boolean doMulti) {
     if (provider == null) {
-      throw new IllegalStateException("It is not allowed to create Pipeline from this " + getClass());
+      throw new IllegalStateException("It is not allowed to create Transaction from this " + getClass());
     } else if (provider instanceof MultiClusterPooledConnectionProvider) {
-      return new MultiClusterTransaction((MultiClusterPooledConnectionProvider) provider);
+      return new MultiClusterTransaction((MultiClusterPooledConnectionProvider) provider, doMulti);
     } else {
-      return new Transaction(provider.getConnection(), true, true);
+      return new Transaction(provider.getConnection(), doMulti, true);
     }
   }
 


### PR DESCRIPTION
Support `UnifiedJedis` create Transaction's that are not immediately entered into `multi` stage.
Resolves !3662