### PR TITLE
Run integration workflow for 5.2.0 branch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,13 +10,11 @@ on:
       - '**/*.rst'
     branches:
       - master
-      - '[0-9].x'
-      - '[0-9].[0-9].x'
+      - '[0-9].*'
   pull_request:
     branches:
       - master
-      - '[0-9].x'
-      - '[0-9].[0-9].x'
+      - '[0-9].*'
   schedule:
     - cron: '0 1 * * *' # nightly build
   workflow_dispatch:


### PR DESCRIPTION
Currently integration workflow runs for versioned like `4.x` (generic major version branch), `5.0.x` (generic minor version branch). But we also need it for `5.2.0` like specific minor version branches.

For this purpose, I have used a common pattern instead of adding a new pattern.