### PR TITLE
Fix transaction failure tests using mock

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
@@ -2,7 +2,6 @@ package redis.clients.jedis.commands.jedis;
 
 import static org.junit.Assert.*;
 
-import static org.mockito.ArgumentMatchers.any;
 import static redis.clients.jedis.Protocol.Command.INCR;
 import static redis.clients.jedis.Protocol.Command.GET;
 import static redis.clients.jedis.Protocol.Command.SET;
@@ -15,6 +14,7 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -159,7 +159,9 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
     trans.set("b", "b");
 
     try (MockedStatic<Protocol> protocol = Mockito.mockStatic(Protocol.class)) {
-      protocol.when(() -> Protocol.read(any())).thenThrow(JedisConnectionException.class);
+      //protocol.when(() -> Protocol.read(any())).thenThrow(JedisConnectionException.class);
+      protocol.when(() -> Protocol.read(ArgumentMatchers.any(), ArgumentMatchers.isNull()))
+          .thenThrow(JedisConnectionException.class);
 
       trans.discard();
       fail("Should get mocked JedisConnectionException.");
@@ -179,7 +181,9 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
     trans.set("b", "b");
 
     try (MockedStatic<Protocol> protocol = Mockito.mockStatic(Protocol.class)) {
-      protocol.when(() -> Protocol.read(any())).thenThrow(JedisConnectionException.class);
+      //protocol.when(() -> Protocol.read(any())).thenThrow(JedisConnectionException.class);
+      protocol.when(() -> Protocol.read(ArgumentMatchers.any(), ArgumentMatchers.isNull()))
+          .thenThrow(JedisConnectionException.class);
 
       trans.exec();
       fail("Should get mocked JedisConnectionException.");


### PR DESCRIPTION
Now we have to mock Protocol#read(RedisInputStream, ClientSideCache) instead of Protocol#read(RedisInputStream).