### PR TITLE
Running doctests also on emb-examples

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags-ignore:
       - '*'
+    branches:
+      - 'emb-examples'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Given how these examples are generated, we intended to run and validate CI, ongoingly on emb-examples as well. As a result, this PR ensures that direct commits there, will also run them. After merging to master, a cherry-pick/merge to emb-examples is needed.