### PR TITLE
Avoid NPE in MultiNodePipelineBase.java

### DIFF
--- a/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
+++ b/src/main/java/redis/clients/jedis/MultiNodePipelineBase.java
@@ -63,9 +63,6 @@ public abstract class MultiNodePipelineBase extends PipelineBase {
       queue = pipelinedResponses.get(nodeKey);
       connection = connections.get(nodeKey);
     } else {
-      pipelinedResponses.putIfAbsent(nodeKey, new LinkedList<>());
-      queue = pipelinedResponses.get(nodeKey);
-
       Connection newOne = getConnection(nodeKey);
       connections.putIfAbsent(nodeKey, newOne);
       connection = connections.get(nodeKey);
@@ -73,6 +70,9 @@ public abstract class MultiNodePipelineBase extends PipelineBase {
         log.debug("Duplicate connection to {}, closing it.", nodeKey);
         IOUtils.closeQuietly(newOne);
       }
+
+      pipelinedResponses.putIfAbsent(nodeKey, new LinkedList<>());
+      queue = pipelinedResponses.get(nodeKey);
     }
 
     connection.sendCommand(commandObject.getArguments());


### PR DESCRIPTION
should get connection first and then create new pipeline queue, otherwise it would cause NPE when timeout for getting connection and call sync() method

if there is timeout for getting connection, the pipeline queue would be create for node, but connections map has no connection for this node

once executing sync() method, it would throw NPE on connection.getMany() (line 112, connection is null)