### PR TITLE
Remove commented out code

### DIFF
--- a/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
+++ b/src/main/java/redis/clients/jedis/BinaryJedisPubSub.java
@@ -6,4 +6,5 @@ public abstract class BinaryJedisPubSub extends JedisPubSubBase<byte[]> {
   protected final byte[] encode(byte[] raw) {
     return raw;
   }
+
 }

--- a/src/main/java/redis/clients/jedis/JedisPubSubBase.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSubBase.java
@@ -174,7 +174,5 @@ public abstract class JedisPubSubBase<T> {
       }
     } while (isSubscribed());
 
-//    /* Invalidate instance since this thread is no longer listening */
-//    this.client = null;
   }
 }


### PR DESCRIPTION
There is a commented code meant to initially invalidate `client` connection when the Connection is no longer listening.
However, it is currently being bypassed, and does not actually reference anything in the JVM.


This patch aims to remove it - therefore, and as such does not introduces breaking change to the actual module.
