### PR TITLE
log a warning when `validateObject` determines the connection is no longer connected and/or the ping fails

### DIFF
--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -76,7 +76,7 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
       // check HostAndPort ??
       return jedis.isConnected() && jedis.ping();
     } catch (final Exception e) {
-      logger.error("Error while validating pooled Connection object.", e);
+      logger.warn("Error while validating pooled Connection object.", e);
       return false;
     }
   }


### PR DESCRIPTION
# changes
When `ConnectionFactory.validateObject` is called, the method logs an ERROR level log if the connection to Redis is disconnected and/or the ping fails. This method is called by `org.apache.commons.pool2.impl.GenericObjectPool.evict` when validating if a connection should be evicted. Because it is **expected** that the connection may no longer be valid, I suggest we log a WARN instead.

As a user of the library, we are getting paged due to our incident monitoring looking for any ERROR log-levels. I alternatively could modify our logging config to filter out this particular log, but I wouldn't want to filter out any future ERROR logs that could be added in the class or package.