### PR TITLE
Reduce the log level of validateObject to WARN

### DIFF
--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -76,7 +76,7 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
       // check HostAndPort ??
       return jedis.isConnected() && jedis.ping();
     } catch (final Exception e) {
-      logger.error("Error while validating pooled Connection object.", e);
+      logger.warn("Error while validating pooled Connection object.", e);
       return false;
     }
   }

--- a/src/main/java/redis/clients/jedis/JedisFactory.java
+++ b/src/main/java/redis/clients/jedis/JedisFactory.java
@@ -197,7 +197,7 @@ public class JedisFactory implements PooledObjectFactory<Jedis> {
           && jedis.getConnection().isConnected()
           && jedis.ping().equals("PONG");
     } catch (final Exception e) {
-      logger.error("Error while validating pooled Jedis object.", e);
+      logger.warn("Error while validating pooled Jedis object.", e);
       return false;
     }
   }


### PR DESCRIPTION
- Reduce the log level of `JedisFactory#validateObject` to `WARN`
- Reduce the log level of `ConnectionFactory#validateObject` to `WARN`

Resolves #3749 