### PR TITLE
Fix typo in SetPipelineCommands method name

### DIFF
--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -786,7 +786,7 @@ public abstract class PipeliningBase
   }
 
   @Override
-  public Response<Long> sdiffStore(String dstKey, String... keys) {
+  public Response<Long> sdiffstore(String dstKey, String... keys) {
     return appendCommand(commandObjects.sdiffstore(dstKey, keys));
   }
 

--- a/src/main/java/redis/clients/jedis/commands/SetPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/SetPipelineCommands.java
@@ -37,7 +37,14 @@ public interface SetPipelineCommands {
 
   Response<Set<String>> sdiff(String... keys);
 
-  Response<Long> sdiffStore(String dstKey, String... keys);
+  Response<Long> sdiffstore(String dstKey, String... keys);
+
+  /**
+   * @deprecated Use {@code redis.clients.jedis.commands.SetPipelineCommands#sdiffstore(java.lang.String, java.lang.String...)}
+   */
+  default Response<Long> sdiffStore(String dstKey, String... keys) {
+    return sdiffstore(dstKey, keys);
+  }
 
   Response<Set<String>> sinter(String... keys);
 

--- a/src/main/java/redis/clients/jedis/commands/SetPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/SetPipelineCommands.java
@@ -40,8 +40,9 @@ public interface SetPipelineCommands {
   Response<Long> sdiffstore(String dstKey, String... keys);
 
   /**
-   * @deprecated Use {@code redis.clients.jedis.commands.SetPipelineCommands#sdiffstore(java.lang.String, java.lang.String...)}
+   * @deprecated Use {@link SetPipelineCommands#sdiffstore(java.lang.String, java.lang.String...)}.
    */
+  @Deprecated
   default Response<Long> sdiffStore(String dstKey, String... keys) {
     return sdiffstore(dstKey, keys);
   }

--- a/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
@@ -527,7 +527,8 @@ public class ClusterPipeliningTest {
     Response<Long> r1 = p.sadd("my{set}", "hello", "hello", "world", "foo", "bar");
     p.sadd("mynew{set}", "hello", "hello", "world");
     Response<Set<String>> r2 = p.sdiff("my{set}", "mynew{set}");
-    Response<Long> r3 = p.sdiffStore("diffset{set}", "my{set}", "mynew{set}");
+    Response<Long> r3deprecated = p.sdiffStore("diffset{set}deprecated", "my{set}", "mynew{set}");
+    Response<Long> r3 = p.sdiffstore("diffset{set}", "my{set}", "mynew{set}");
     Response<Set<String>> r4 = p.smembers("diffset{set}");
     Response<Set<String>> r5 = p.sinter("my{set}", "mynew{set}");
     Response<Long> r6 = p.sinterstore("interset{set}", "my{set}", "mynew{set}");
@@ -547,6 +548,7 @@ public class ClusterPipeliningTest {
     p.sync();
     assertEquals(Long.valueOf(4), r1.get());
     assertEquals(diff, r2.get());
+    assertEquals(Long.valueOf(diff.size()), r3deprecated.get());
     assertEquals(Long.valueOf(diff.size()), r3.get());
     assertEquals(diff, r4.get());
     assertEquals(inter, r5.get());


### PR DESCRIPTION
One method in the SetPipelineCommands interface does not respect the general naming pattern. Add a new method that respects naming, and deprecate the other one.