### PR TITLE
Use expiryOption in PipelineBase.expireAt

### DIFF
--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -2088,7 +2088,7 @@ public abstract class PipeliningBase
 
   @Override
   public Response<Long> expireAt(byte[] key, long unixTime, ExpiryOption expiryOption) {
-    return appendCommand(commandObjects.expireAt(key, unixTime));
+    return appendCommand(commandObjects.expireAt(key, unixTime, expiryOption));
   }
 
   @Override


### PR DESCRIPTION
One of the expireAt methods in PipelineBase is not using its ExpiryOption argument. Fix this by forwarding that argument too to the commandObjects.