### PR TITLE
Add support for CLUSTER LINKS command

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -446,6 +446,23 @@ public final class BuilderFactory {
     }
   };
 
+  public static final Builder<List<Map<String, Object>>> ENCODED_MAP_LIST = new Builder<List<Map<String, Object>>>() {
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<Map<String, Object>> build(Object data) {
+      if (data == null) return null;
+      return ((List<List<Object>>) data).stream().map(one -> {
+        {
+          Map<String, Object> map = new HashMap<>();
+          for (int i = 0; i < one.size(); i += 2) {
+            map.put(STRING.build(one.get(i)), ENCODED_OBJECT.build(one.get(i + 1)));
+          }
+          return map;
+        }
+      }).collect(Collectors.toList());
+    }
+  };
+
   public static final Builder<Map<String, Long>> STRING_LONG_MAP = new Builder<Map<String, Long>>() {
     @Override
     @SuppressWarnings("unchecked")

--- a/src/main/java/redis/clients/jedis/ClusterCommandObjects.java
+++ b/src/main/java/redis/clients/jedis/ClusterCommandObjects.java
@@ -4,6 +4,8 @@ import static redis.clients.jedis.Protocol.Command.KEYS;
 import static redis.clients.jedis.Protocol.Command.SCAN;
 import static redis.clients.jedis.Protocol.Keyword.TYPE;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import redis.clients.jedis.commands.ProtocolCommand;
@@ -11,6 +13,7 @@ import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
 import redis.clients.jedis.util.JedisClusterHashTag;
 import redis.clients.jedis.util.KeyValue;
+import redis.clients.jedis.util.SafeEncoder;
 
 public class ClusterCommandObjects extends CommandObjects {
 
@@ -102,6 +105,13 @@ public class ClusterCommandObjects extends CommandObjects {
   @Override
   public CommandObject<KeyValue<Long, Long>> waitAOF(long numLocal, long numReplicas, long timeout) {
     throw new UnsupportedOperationException(CLUSTER_UNSUPPORTED_MESSAGE);
+  }
+
+  public CommandObject<List<Map<String, Object>>> clusterLinks() {
+    return new CommandObject<>(
+        new ClusterCommandArguments(Protocol.Command.CLUSTER).add(
+            SafeEncoder.encode(Protocol.ClusterKeyword.LINKS.getRaw())),
+        BuilderFactory.ENCODED_MAP_LIST);
   }
 
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -2,6 +2,8 @@ package redis.clients.jedis;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -264,5 +266,19 @@ public class JedisCluster extends UnifiedJedis {
   @Override
   public Transaction multi() {
     throw new UnsupportedOperationException();
+  }
+
+  public Map<HostAndPort, List<Map<String, Object>>> clusterLinks() {
+    Map<HostAndPort, List<Map<String, Object>>> nodeClusterLinksMap = new HashMap<>();
+    Map<String, ConnectionPool> clusterNodes = this.getClusterNodes();
+
+    for (Map.Entry<String, ConnectionPool> entry : clusterNodes.entrySet()) {
+      try (Connection connection = entry.getValue().getResource()) {
+        List<Map<String, Object>> clusterNodeLinks =
+            connection.executeCommand(((ClusterCommandObjects) commandObjects).clusterLinks());
+        nodeClusterLinksMap.put(HostAndPort.from(entry.getKey()), clusterNodeLinks);
+      }
+    }
+    return nodeClusterLinksMap;
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -2,8 +2,6 @@ package redis.clients.jedis;
 
 import java.time.Duration;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -268,17 +266,4 @@ public class JedisCluster extends UnifiedJedis {
     throw new UnsupportedOperationException();
   }
 
-  public Map<HostAndPort, List<Map<String, Object>>> clusterLinks() {
-    Map<HostAndPort, List<Map<String, Object>>> nodeClusterLinksMap = new HashMap<>();
-    Map<String, ConnectionPool> clusterNodes = this.getClusterNodes();
-
-    for (Map.Entry<String, ConnectionPool> entry : clusterNodes.entrySet()) {
-      try (Connection connection = entry.getValue().getResource()) {
-        List<Map<String, Object>> clusterNodeLinks =
-            connection.executeCommand(((ClusterCommandObjects) commandObjects).clusterLinks());
-        nodeClusterLinksMap.put(HostAndPort.from(entry.getKey()), clusterNodeLinks);
-      }
-    }
-    return nodeClusterLinksMap;
-  }
 }

--- a/src/test/java/redis/clients/jedis/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterTest.java
@@ -800,6 +800,59 @@ public class JedisClusterTest extends JedisClusterTestBase {
     }
   }
 
+  @Test
+  public void testClusterLinks() {
+    // 创建一个JedisCluster对象
+    Set<HostAndPort> jedisClusterNode = new HashSet<>();
+    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
+
+    try (JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, "cluster", DEFAULT_POOL_CONFIG)) {
+      Set<String> mapKeys = new HashSet<>(
+          Arrays.asList("direction", "node", "create-time", "events", "send-buffer-allocated",
+              "send-buffer-used"));
+
+      Map<HostAndPort, List<Map<String, Object>>> links = jc.clusterLinks();
+      assertNotNull(links);
+      assertTrue(links.size() >= 3);
+      for (Map.Entry<HostAndPort, List<Map<String, Object>>> linkEntry : links.entrySet()) {
+        List<Map<String, Object>> link = linkEntry.getValue();
+        assertTrue(link.size() >= 3);
+        assertEquals(6, link.get(0).size());
+        assertEquals(mapKeys, link.get(0).keySet());
+      }
+    }
+  }
+
+  @Test
+  public void testClusterLinksInPipeline() {
+    // 创建一个JedisCluster对象
+    Set<HostAndPort> jedisClusterNode = new HashSet<>();
+    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
+
+    try (JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
+        DEFAULT_REDIRECTIONS, "cluster", DEFAULT_POOL_CONFIG)) {
+      Set<String> mapKeys = new HashSet<>(
+          Arrays.asList("direction", "node", "create-time", "events", "send-buffer-allocated",
+              "send-buffer-used"));
+
+      ClusterPipeline pipelined = jc.pipelined();
+      Map<HostAndPort, Response<List<Map<String, Object>>>> nodeClusterLinksMap = pipelined.clusterLinks();
+      pipelined.sync();
+      for (Map.Entry<HostAndPort, Response<List<Map<String, Object>>>> entry : nodeClusterLinksMap.entrySet()) {
+        HostAndPort hostAndPort = entry.getKey();
+        Response<List<Map<String, Object>>> response = entry.getValue();
+        List<Map<String, Object>> links = response.get();
+        assertNotNull(links);
+        assertTrue(links.size() >= 3);
+        for (Map<String, Object> link : links) {
+          assertEquals(6, link.size());
+          assertEquals(mapKeys, link.keySet());
+        }
+      }
+    }
+  }
+
   private static String getNodeServingSlotRange(String infoOutput) {
     // f4f3dc4befda352a4e0beccf29f5e8828438705d 127.0.0.1:7380 master - 0
     // 1394372400827 0 connected 5461-10922

--- a/src/test/java/redis/clients/jedis/JedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterTest.java
@@ -801,30 +801,6 @@ public class JedisClusterTest extends JedisClusterTestBase {
   }
 
   @Test
-  public void testClusterLinks() {
-    // 创建一个JedisCluster对象
-    Set<HostAndPort> jedisClusterNode = new HashSet<>();
-    jedisClusterNode.add(new HostAndPort("127.0.0.1", 7379));
-
-    try (JedisCluster jc = new JedisCluster(jedisClusterNode, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT,
-        DEFAULT_REDIRECTIONS, "cluster", DEFAULT_POOL_CONFIG)) {
-      Set<String> mapKeys = new HashSet<>(
-          Arrays.asList("direction", "node", "create-time", "events", "send-buffer-allocated",
-              "send-buffer-used"));
-
-      Map<HostAndPort, List<Map<String, Object>>> links = jc.clusterLinks();
-      assertNotNull(links);
-      assertTrue(links.size() >= 3);
-      for (Map.Entry<HostAndPort, List<Map<String, Object>>> linkEntry : links.entrySet()) {
-        List<Map<String, Object>> link = linkEntry.getValue();
-        assertTrue(link.size() >= 3);
-        assertEquals(6, link.get(0).size());
-        assertEquals(mapKeys, link.get(0).keySet());
-      }
-    }
-  }
-
-  @Test
   public void testClusterLinksInPipeline() {
     // 创建一个JedisCluster对象
     Set<HostAndPort> jedisClusterNode = new HashSet<>();


### PR DESCRIPTION

## Resolves #3727 Add support for the cluster links command in Jedis 
- [x] Implement support for the clusterLinks command in JedisCluster. This feature iterates through all cluster nodes and retrieves the cluster link information from each node.

 

- [x] Implement support for the clusterLinks command in MultiNodePipeline. This feature iterates through all cluster nodes and retrieves the cluster link information from each node.