### PR TITLE
Add last entry id for XREADs and support XREADs reply as map

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1420,10 +1420,10 @@ public final class BuilderFactory {
             .collect(Collectors.toList());
       } else {
         List<Map.Entry<String, List<StreamEntry>>> result = new ArrayList<>(list.size());
-        for (Object streamObj : list) {
-          List<Object> stream = (List<Object>) streamObj;
-          String streamKey = STRING.build(stream.get(0));
-          List<StreamEntry> streamEntries = STREAM_ENTRY_LIST.build(stream.get(1));
+        for (Object anObj : list) {
+          List<Object> streamObj = (List<Object>) anObj;
+          String streamKey = STRING.build(streamObj.get(0));
+          List<StreamEntry> streamEntries = STREAM_ENTRY_LIST.build(streamObj.get(1));
           result.add(KeyValue.of(streamKey, streamEntries));
         }
         return result;
@@ -1433,6 +1433,35 @@ public final class BuilderFactory {
     @Override
     public String toString() {
       return "List<Entry<String, List<StreamEntry>>>";
+    }
+  };
+
+  public static final Builder<Map<String, List<StreamEntry>>> STREAM_READ_RESPONSE_MAP
+      = new Builder<Map<String, List<StreamEntry>>>() {
+    @Override
+    public Map<String, List<StreamEntry>> build(Object data) {
+      if (data == null) return null;
+      List list = (List) data;
+      if (list.isEmpty()) return Collections.emptyMap();
+
+      if (list.get(0) instanceof KeyValue) {
+        return ((List<KeyValue>) list).stream()
+            .collect(Collectors.toMap(kv -> STRING.build(kv.getKey()), kv -> STREAM_ENTRY_LIST.build(kv.getValue())));
+      } else {
+        Map<String, List<StreamEntry>> result = new HashMap<>(list.size());
+        for (Object anObj : list) {
+          List<Object> streamObj = (List<Object>) anObj;
+          String streamKey = STRING.build(streamObj.get(0));
+          List<StreamEntry> streamEntries = STREAM_ENTRY_LIST.build(streamObj.get(1));
+          result.put(streamKey, streamEntries);
+        }
+        return result;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "Map<String, List<StreamEntry>>";
     }
   };
 

--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1436,7 +1436,7 @@ public final class BuilderFactory {
     }
   };
 
-  public static final Builder<Map<String, List<StreamEntry>>> STREAM_READ_RESPONSE_MAP
+  public static final Builder<Map<String, List<StreamEntry>>> STREAM_READ_MAP_RESPONSE
       = new Builder<Map<String, List<StreamEntry>>>() {
     @Override
     public Map<String, List<StreamEntry>> build(Object data) {

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -2672,7 +2672,7 @@ public class CommandObjects {
     Set<Map.Entry<String, StreamEntryID>> entrySet = streams.entrySet();
     entrySet.forEach(entry -> args.key(entry.getKey()));
     entrySet.forEach(entry -> args.add(entry.getValue()));
-    return new CommandObject<>(args, BuilderFactory.STREAM_READ_RESPONSE_MAP);
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_MAP_RESPONSE);
   }
 
   public final CommandObject<List<Map.Entry<String, List<StreamEntry>>>> xreadGroup(
@@ -2696,7 +2696,7 @@ public class CommandObjects {
     Set<Map.Entry<String, StreamEntryID>> entrySet = streams.entrySet();
     entrySet.forEach(entry -> args.key(entry.getKey()));
     entrySet.forEach(entry -> args.add(entry.getValue()));
-    return new CommandObject<>(args, BuilderFactory.STREAM_READ_RESPONSE_MAP);
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_MAP_RESPONSE);
   }
 
   public final CommandObject<List<Object>> xread(XReadParams xReadParams, Map.Entry<byte[], byte[]>... streams) {

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -2666,6 +2666,15 @@ public class CommandObjects {
     return new CommandObject<>(args, BuilderFactory.STREAM_READ_RESPONSE);
   }
 
+  public final CommandObject<Map<String, List<StreamEntry>>> xreadAsMap(
+      XReadParams xReadParams, Map<String, StreamEntryID> streams) {
+    CommandArguments args = commandArguments(XREAD).addParams(xReadParams).add(STREAMS);
+    Set<Map.Entry<String, StreamEntryID>> entrySet = streams.entrySet();
+    entrySet.forEach(entry -> args.key(entry.getKey()));
+    entrySet.forEach(entry -> args.add(entry.getValue()));
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_RESPONSE_MAP);
+  }
+
   public final CommandObject<List<Map.Entry<String, List<StreamEntry>>>> xreadGroup(
       String groupName, String consumer, XReadGroupParams xReadGroupParams,
       Map<String, StreamEntryID> streams) {
@@ -2676,6 +2685,18 @@ public class CommandObjects {
     entrySet.forEach(entry -> args.key(entry.getKey()));
     entrySet.forEach(entry -> args.add(entry.getValue()));
     return new CommandObject<>(args, BuilderFactory.STREAM_READ_RESPONSE);
+  }
+
+  public final CommandObject<Map<String, List<StreamEntry>>> xreadGroupAsMap(
+      String groupName, String consumer, XReadGroupParams xReadGroupParams,
+      Map<String, StreamEntryID> streams) {
+    CommandArguments args = commandArguments(XREADGROUP)
+        .add(GROUP).add(groupName).add(consumer)
+        .addParams(xReadGroupParams).add(STREAMS);
+    Set<Map.Entry<String, StreamEntryID>> entrySet = streams.entrySet();
+    entrySet.forEach(entry -> args.key(entry.getKey()));
+    entrySet.forEach(entry -> args.add(entry.getValue()));
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_RESPONSE_MAP);
   }
 
   public final CommandObject<List<Object>> xread(XReadParams xReadParams, Map.Entry<byte[], byte[]>... streams) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -9395,6 +9395,12 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
+  public Map<String, List<StreamEntry>> xreadAsMap(final XReadParams xReadParams, final Map<String, StreamEntryID> streams) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.xreadAsMap(xReadParams, streams));
+  }
+
+  @Override
   public long xack(final String key, final String group, final StreamEntryID... ids) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.xack(key, group, ids));
@@ -9450,11 +9456,17 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
-  public List<Map.Entry<String, List<StreamEntry>>> xreadGroup(final String groupName,
-      final String consumer, final XReadGroupParams xReadGroupParams,
-      final Map<String, StreamEntryID> streams) {
+  public List<Map.Entry<String, List<StreamEntry>>> xreadGroup(final String groupName, final String consumer,
+      final XReadGroupParams xReadGroupParams, final Map<String, StreamEntryID> streams) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.xreadGroup(groupName, consumer, xReadGroupParams, streams));
+  }
+
+  @Override
+  public Map<String, List<StreamEntry>> xreadGroupAsMap(final String groupName, final String consumer,
+      final XReadGroupParams xReadGroupParams, final Map<String, StreamEntryID> streams) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.xreadGroupAsMap(groupName, consumer, xReadGroupParams, streams));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -1537,8 +1537,18 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<Map<String, List<StreamEntry>>> xreadAsMap(XReadParams xReadParams, Map<String, StreamEntryID> streams) {
+    return appendCommand(commandObjects.xreadAsMap(xReadParams, streams));
+  }
+
+  @Override
   public Response<List<Map.Entry<String, List<StreamEntry>>>> xreadGroup(String groupName, String consumer, XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams) {
     return appendCommand(commandObjects.xreadGroup(groupName, consumer, xReadGroupParams, streams));
+  }
+
+  @Override
+  public Response<Map<String, List<StreamEntry>>> xreadGroupAsMap(String groupName, String consumer, XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams) {
+    return appendCommand(commandObjects.xreadGroupAsMap(groupName, consumer, xReadGroupParams, streams));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/StreamEntryID.java
+++ b/src/main/java/redis/clients/jedis/StreamEntryID.java
@@ -108,7 +108,8 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   };
 
   /**
-   * @deprecated Use {@link StreamEntryID#XGROUP_LAST_ID} or {@link StreamEntryID#XREAD_NEW_ENTRY}.
+   * @deprecated Use {@link StreamEntryID#XGROUP_LAST_ENTRY} for XREADGROUP command or
+   * {@link StreamEntryID#XREAD_NEW_ENTRY} for XREAD command.
    */
   @Deprecated
   public static final StreamEntryID LAST_ENTRY = XGROUP_LAST_ENTRY;

--- a/src/main/java/redis/clients/jedis/StreamEntryID.java
+++ b/src/main/java/redis/clients/jedis/StreamEntryID.java
@@ -80,9 +80,7 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   /**
    * Should be used only with XADD
    *
-   * <code>
-   * XADD mystream * field1 value1
-   * </code>
+   * {@code XADD mystream * field1 value1}
    */
   public static final StreamEntryID NEW_ENTRY = new StreamEntryID() {
 
@@ -97,11 +95,30 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   /**
    * Should be used only with XGROUP CREATE
    *
-   * <code>
-   * XGROUP CREATE mystream consumer-group-name $
-   * </code>
+   * {@code XGROUP CREATE mystream consumer-group-name $}
    */
-  public static final StreamEntryID LAST_ENTRY = new StreamEntryID() {
+  public static final StreamEntryID XGROUP_LAST_ENTRY = new StreamEntryID() {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String toString() {
+      return "$";
+    }
+  };
+
+  /**
+   * @deprecated Use {@link StreamEntryID#XGROUP_LAST_ID} or {@link StreamEntryID#XREAD_NEW_ENTRY}.
+   */
+  @Deprecated
+  public static final StreamEntryID LAST_ENTRY = XGROUP_LAST_ENTRY;
+
+  /**
+   * Should be used only with XREAD
+   *
+   * {@code XREAD BLOCK 5000 COUNT 100 STREAMS mystream $}
+   */
+  public static final StreamEntryID XREAD_NEW_ENTRY = new StreamEntryID() {
 
     private static final long serialVersionUID = 1L;
 
@@ -129,6 +146,7 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   /**
    * Can be used in XRANGE, XREVRANGE and XPENDING commands.
    */
+  // TODO: FIRST_ID ?
   public static final StreamEntryID MINIMUM_ID = new StreamEntryID() {
 
     private static final long serialVersionUID = 1L;
@@ -142,7 +160,25 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   /**
    * Can be used in XRANGE, XREVRANGE and XPENDING commands.
    */
+  // TODO: LAST_ID ?
+  // TODO: unify with XREAD_LAST_ENTRY ??
   public static final StreamEntryID MAXIMUM_ID = new StreamEntryID() {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public String toString() {
+      return "+";
+    }
+  };
+
+  /**
+   * Should be used only with XREAD
+   *
+   * {@code XREAD STREAMS mystream +}
+   */
+  // TODO: unify with MAXIMUM_ID ??
+  public static final StreamEntryID XREAD_LAST_ENTRY = new StreamEntryID() {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/redis/clients/jedis/StreamEntryID.java
+++ b/src/main/java/redis/clients/jedis/StreamEntryID.java
@@ -108,7 +108,7 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   };
 
   /**
-   * @deprecated Use {@link StreamEntryID#XGROUP_LAST_ENTRY} for XREADGROUP command or
+   * @deprecated Use {@link StreamEntryID#XGROUP_LAST_ENTRY} for XGROUP CREATE command or
    * {@link StreamEntryID#XREAD_NEW_ENTRY} for XREAD command.
    */
   @Deprecated
@@ -132,9 +132,9 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   /**
    * Should be used only with XREADGROUP
    * <p>
-   * {@code XREADGROUP $GroupName $ConsumerName BLOCK 2000 COUNT 10 STREAMS mystream >}
+   * {@code XREADGROUP GROUP mygroup myconsumer STREAMS mystream >}
    */
-  public static final StreamEntryID UNRECEIVED_ENTRY = new StreamEntryID() {
+  public static final StreamEntryID XREADGROUP_UNDELIVERED_ENTRY = new StreamEntryID() {
 
     private static final long serialVersionUID = 1L;
 
@@ -145,9 +145,14 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   };
 
   /**
+   * @deprecated Use {@link StreamEntryID#XREADGROUP_UNDELIVERED_ENTRY}.
+   */
+  @Deprecated
+  public static final StreamEntryID UNRECEIVED_ENTRY = XREADGROUP_UNDELIVERED_ENTRY;
+
+  /**
    * Can be used in XRANGE, XREVRANGE and XPENDING commands.
    */
-  // TODO: FIRST_ID ?
   public static final StreamEntryID MINIMUM_ID = new StreamEntryID() {
 
     private static final long serialVersionUID = 1L;
@@ -161,8 +166,6 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
   /**
    * Can be used in XRANGE, XREVRANGE and XPENDING commands.
    */
-  // TODO: LAST_ID ?
-  // TODO: unify with XREAD_LAST_ENTRY ??
   public static final StreamEntryID MAXIMUM_ID = new StreamEntryID() {
 
     private static final long serialVersionUID = 1L;
@@ -178,7 +181,6 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
    *
    * {@code XREAD STREAMS mystream +}
    */
-  // TODO: unify with MAXIMUM_ID ??
   public static final StreamEntryID XREAD_LAST_ENTRY = new StreamEntryID() {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -3067,9 +3067,20 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public Map<String, List<StreamEntry>> xreadAsMap(XReadParams xReadParams, Map<String, StreamEntryID> streams) {
+    return executeCommand(commandObjects.xreadAsMap(xReadParams, streams));
+  }
+
+  @Override
   public List<Map.Entry<String, List<StreamEntry>>> xreadGroup(String groupName, String consumer,
       XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams) {
     return executeCommand(commandObjects.xreadGroup(groupName, consumer, xReadGroupParams, streams));
+  }
+
+  @Override
+  public Map<String, List<StreamEntry>> xreadGroupAsMap(String groupName, String consumer,
+      XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams) {
+    return executeCommand(commandObjects.xreadGroupAsMap(groupName, consumer, xReadGroupParams, streams));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/commands/StreamCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StreamCommands.java
@@ -250,7 +250,19 @@ public interface StreamCommands {
   /**
    * XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] ID [ID ...]
    */
+  Map<String, List<StreamEntry>> xreadAsMap(XReadParams xReadParams,
+      Map<String, StreamEntryID> streams);
+
+  /**
+   * XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] [NOACK] STREAMS key [key ...] id [id ...]
+   */
   List<Map.Entry<String, List<StreamEntry>>> xreadGroup(String groupName, String consumer,
+      XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams);
+
+  /**
+   * XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] [NOACK] STREAMS key [key ...] id [id ...]
+   */
+  Map<String, List<StreamEntry>> xreadGroupAsMap(String groupName, String consumer,
       XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams);
 
 }

--- a/src/main/java/redis/clients/jedis/commands/StreamPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StreamPipelineCommands.java
@@ -243,7 +243,19 @@ public interface StreamPipelineCommands {
   /**
    * XREAD [COUNT count] [BLOCK milliseconds] STREAMS key [key ...] ID [ID ...]
    */
+  Response<Map<String, List<StreamEntry>>> xreadAsMap(XReadParams xReadParams,
+      Map<String, StreamEntryID> streams);
+
+  /**
+   * XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] [NOACK] STREAMS key [key ...] id [id ...]
+   */
   Response<List<Map.Entry<String, List<StreamEntry>>>> xreadGroup(String groupName, String consumer,
+      XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams);
+
+  /**
+   * XREADGROUP GROUP group consumer [COUNT count] [BLOCK milliseconds] [NOACK] STREAMS key [key ...] id [id ...]
+   */
+  Response<Map<String, List<StreamEntry>>> xreadGroupAsMap(String groupName, String consumer,
       XReadGroupParams xReadGroupParams, Map<String, StreamEntryID> streams);
 
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/StreamsCommandsTest.java
@@ -488,7 +488,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     map.put("f1", "v1");
     jedis.xadd("xreadGroup-stream1", (StreamEntryID) null, map);
     jedis.xgroupCreate("xreadGroup-stream1", "xreadGroup-group", null, false);
-    Map<String, StreamEntryID> streamQeury1 = singletonMap("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury1 = singletonMap("xreadGroup-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     List<Entry<String, List<StreamEntry>>> range = jedis.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(1).noAck(), streamQeury1);
     assertEquals(1, range.size());
@@ -499,7 +499,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     jedis.xgroupCreate("xreadGroup-stream2", "xreadGroup-group", null, false);
 
     // Read only a single Stream
-    Map<String, StreamEntryID> streamQeury11 = singletonMap("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury11 = singletonMap("xreadGroup-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     List<Entry<String, List<StreamEntry>>> streams1 = jedis.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(1).block(1).noAck(), streamQeury11);
     assertEquals(1, streams1.size());
@@ -515,7 +515,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Read only fresh messages
     StreamEntryID id4 = jedis.xadd("xreadGroup-stream1", (StreamEntryID) null, map);
-    Map<String, StreamEntryID> streamQeuryFresh = singletonMap("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeuryFresh = singletonMap("xreadGroup-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     List<Entry<String, List<StreamEntry>>> streams3 = jedis.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(4).block(100).noAck(), streamQeuryFresh);
     assertEquals(1, streams3.size());
@@ -536,7 +536,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     jedis.xadd("xreadGroup-discard-stream1", xAddParams, map2);
 
     jedis.xgroupCreate("xreadGroup-discard-stream1", "xreadGroup-group", null, false);
-    Map<String, StreamEntryID> streamQuery1 = singletonMap("xreadGroup-discard-stream1", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQuery1 = singletonMap("xreadGroup-discard-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     List<Entry<String, List<StreamEntry>>> range = jedis.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
             XReadGroupParams.xReadGroupParams().count(1), streamQuery1);
     assertEquals(1, range.size());
@@ -569,8 +569,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     jedis.xgroupCreate("xack-stream", "xack-group", null, false);
 
-    Map<String, StreamEntryID> streamQeury1 = singletonMap(
-        "xack-stream", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury1 = singletonMap("xack-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
 
     // Empty Stream
     List<Entry<String, List<StreamEntry>>> range = jedis.xreadGroup("xack-group", "xack-consumer",
@@ -589,8 +588,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     assertEquals("OK", jedis.xgroupCreate("xpendeing-stream", "xpendeing-group", null, false));
 
-    Map<String, StreamEntryID> streamQeury1 = singletonMap(
-            "xpendeing-stream", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury1 = singletonMap("xpendeing-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
 
     // Read the event from Stream put it on pending
     List<Entry<String, List<StreamEntry>>> range = jedis.xreadGroup("xpendeing-group",
@@ -630,8 +628,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     jedis.xgroupCreate("xpendeing-stream", "xpendeing-group", null, false);
 
     // read 1 message from the group with each consumer
-    Map<String, StreamEntryID> streamQeury = singletonMap(
-        "xpendeing-stream", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury = singletonMap("xpendeing-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     jedis.xreadGroup("xpendeing-group", "consumer1", XReadGroupParams.xReadGroupParams().count(1), streamQeury);
     jedis.xreadGroup("xpendeing-group", "consumer2", XReadGroupParams.xReadGroupParams().count(1), streamQeury);
 
@@ -662,7 +659,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Read the event from Stream put it on pending
     jedis.xreadGroup("xpendeing-group", "xpendeing-consumer", XReadGroupParams.xReadGroupParams().count(1).block(1),
-            singletonMap("xpendeing-stream", StreamEntryID.UNRECEIVED_ENTRY));
+            singletonMap("xpendeing-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     List<StreamPendingEntry> pendingRange = jedis.xpending("xpendeing-stream", "xpendeing-group",
@@ -693,7 +690,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Read the event from Stream put it on pending
     jedis.xreadGroup("xpendeing-group", "xpendeing-consumer", XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpendeing-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpendeing-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     List<StreamPendingEntry> pendingRange = jedis.xpending("xpendeing-stream", "xpendeing-group",
@@ -722,7 +719,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Read the event from Stream put it on pending
     jedis.xreadGroup("xpending-group", "xpending-consumer", XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     List<StreamPendingEntry> pendingRange = jedis.xpending("xpending-stream", "xpending-group",
@@ -752,7 +749,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Read the event from Stream put it on pending
     jedis.xreadGroup("xpending-group", "xpending-consumer", XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     List<StreamPendingEntry> pendingRange = jedis.xpending("xpending-stream", "xpending-group",
@@ -784,7 +781,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Read the event from Stream put it on pending
     jedis.xreadGroup("xpending-group", "xpending-consumer", XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     List<StreamPendingEntry> pendingRange = jedis.xpending("xpending-stream", "xpending-group",
@@ -814,7 +811,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
 
     // Read the event from Stream put it on pending
     jedis.xreadGroup("xpending-group", "xpending-consumer", XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     List<StreamPendingEntry> pendingRange = jedis.xpending("xpending-stream", "xpending-group",
@@ -976,7 +973,7 @@ public class StreamsCommandsTest extends JedisCommandsTestBase {
     StreamEntryID id2 = jedis.xadd("streamfull2", (StreamEntryID) null, map);
     jedis.xgroupCreate("streamfull2", "xreadGroup-group", null, false);
 
-    Map<String, StreamEntryID> streamQeury1 = singletonMap("streamfull2", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury1 = singletonMap("streamfull2", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     List<Entry<String, List<StreamEntry>>> range = jedis.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(1), streamQeury1);
     assertEquals(1, range.size());

--- a/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
@@ -648,7 +648,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     jedis.xgroupCreate("xreadGroup-stream1", "xreadGroup-group", null, false);
 
-    Map<String, StreamEntryID> streamQuery1 = singletonMap("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQuery1 = singletonMap("xreadGroup-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
 
     Response<List<Entry<String, List<StreamEntry>>>> streams1 =
         pipe.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
@@ -679,8 +679,8 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     // Read from two Streams
     Map<String, StreamEntryID> streamQuery2 = new LinkedHashMap<>();
-    streamQuery2.put("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
-    streamQuery2.put("xreadGroup-stream2", StreamEntryID.UNRECEIVED_ENTRY);
+    streamQuery2.put("xreadGroup-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
+    streamQuery2.put("xreadGroup-stream2", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
 
     Response<List<Entry<String, List<StreamEntry>>>> streams3 = pipe.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(1).noAck(), streamQuery2);
@@ -709,7 +709,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     Map<String, String> map4 = singletonMap("f4", "v4");
     StreamEntryID id4 = jedis.xadd("xreadGroup-stream1", (StreamEntryID) null, map4);
 
-    Map<String, StreamEntryID> streamQueryFresh = singletonMap("xreadGroup-stream1", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQueryFresh = singletonMap("xreadGroup-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     Response<List<Entry<String, List<StreamEntry>>>> streams4 = pipe.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(4).block(100).noAck(), streamQueryFresh);
 
@@ -737,7 +737,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     pipe.xgroupCreate("xreadGroup-discard-stream1", "xreadGroup-group", null, false);
 
-    Map<String, StreamEntryID> streamQuery1 = singletonMap("xreadGroup-discard-stream1", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQuery1 = singletonMap("xreadGroup-discard-stream1", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
 
     Response<List<Entry<String, List<StreamEntry>>>> streams1 =
         pipe.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
@@ -781,7 +781,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     pipe.xgroupCreate("xack-stream", "xack-group", null, false);
 
-    Map<String, StreamEntryID> streamQuery1 = singletonMap("xack-stream", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQuery1 = singletonMap("xack-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
 
     // Empty Stream
     Response<List<Entry<String, List<StreamEntry>>>> streams1 =
@@ -809,7 +809,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     assertEquals("OK", jedis.xgroupCreate("xpending-stream", "xpending-group", null, false));
 
-    Map<String, StreamEntryID> streamQeury1 = singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury1 = singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
 
     // Read the event from Stream put it on pending
     Response<List<Entry<String, List<StreamEntry>>>> range = pipe.xreadGroup("xpending-group",
@@ -861,7 +861,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     pipe.xgroupCreate("xpending-stream", "xpending-group", null, false);
 
     // read 1 message from the group with each consumer
-    Map<String, StreamEntryID> streamQeury = singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury = singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     pipe.xreadGroup("xpending-group", "consumer1", XReadGroupParams.xReadGroupParams().count(1), streamQeury);
     pipe.xreadGroup("xpending-group", "consumer2", XReadGroupParams.xReadGroupParams().count(1), streamQeury);
 
@@ -896,7 +896,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     // Read the event from Stream put it on pending
     pipe.xreadGroup("xpending-group", "xpending-consumer",
         XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     Response<List<StreamPendingEntry>> pending =
@@ -938,7 +938,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     // Read the event from Stream put it on pending
     pipe.xreadGroup("xpending-group", "xpending-consumer",
         XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     Response<List<StreamPendingEntry>> pending =
@@ -976,7 +976,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     // Read the event from Stream put it on pending
     pipe.xreadGroup("xpending-group", "xpending-consumer",
         XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     Response<List<StreamPendingEntry>> pending = pipe.xpending("xpending-stream", "xpending-group",
@@ -1016,7 +1016,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     // Read the event from Stream put it on pending
     pipe.xreadGroup("xpending-group", "xpending-consumer",
         XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     Response<List<StreamPendingEntry>> pending = pipe.xpending("xpending-stream", "xpending-group",
@@ -1059,7 +1059,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     // Read the event from Stream put it on pending
     pipe.xreadGroup("xpending-group", "xpending-consumer", XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     Response<List<StreamPendingEntry>> pending = pipe.xpending("xpending-stream", "xpending-group",
@@ -1095,7 +1095,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     // Read the event from Stream put it on pending
     pipe.xreadGroup("xpending-group", "xpending-consumer",
         XReadGroupParams.xReadGroupParams().count(1).block(1),
-        singletonMap("xpending-stream", StreamEntryID.UNRECEIVED_ENTRY));
+        singletonMap("xpending-stream", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY));
 
     // Get the pending event
     Response<List<StreamPendingEntry>> pending = pipe.xpending("xpending-stream", "xpending-group",
@@ -1281,7 +1281,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     StreamEntryID id2 = jedis.xadd("streamfull2", (StreamEntryID) null, map);
     jedis.xgroupCreate("streamfull2", "xreadGroup-group", null, false);
 
-    Map<String, StreamEntryID> streamQeury1 = singletonMap("streamfull2", StreamEntryID.UNRECEIVED_ENTRY);
+    Map<String, StreamEntryID> streamQeury1 = singletonMap("streamfull2", StreamEntryID.XREADGROUP_UNDELIVERED_ENTRY);
     Response<List<Entry<String, List<StreamEntry>>>> pending = pipe.xreadGroup("xreadGroup-group", "xreadGroup-consumer",
         XReadGroupParams.xReadGroupParams().count(1), streamQeury1);
 

--- a/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pipeline/StreamsPipelineCommandsTest.java
@@ -397,10 +397,10 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
   @Test
   public void xreadWithParams() {
 
-    final String key1 = "xread-stream1";
-    final String key2 = "xread-stream2";
+    final String stream1 = "xread-stream1";
+    final String stream2 = "xread-stream2";
 
-    Map<String, StreamEntryID> streamQuery1 = singletonMap(key1, new StreamEntryID());
+    Map<String, StreamEntryID> streamQuery1 = singletonMap(stream1, new StreamEntryID());
 
     // Before creating Stream
     pipe.xread(XReadParams.xReadParams().block(1), streamQuery1);
@@ -412,25 +412,25 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     ));
 
     Map<String, String> map1 = singletonMap("f1", "v1");
-    StreamEntryID id1 = jedis.xadd(key1, (StreamEntryID) null, map1);
+    StreamEntryID id1 = jedis.xadd(stream1, (StreamEntryID) null, map1);
 
     Map<String, String> map2 = singletonMap("f2", "v2");
-    StreamEntryID id2 = jedis.xadd(key2, (StreamEntryID) null, map2);
+    StreamEntryID id2 = jedis.xadd(stream2, (StreamEntryID) null, map2);
 
     // Read only a single Stream
     Response<List<Entry<String, List<StreamEntry>>>> streams1 =
         pipe.xread(XReadParams.xReadParams().count(1).block(1), streamQuery1);
 
     Response<List<Entry<String, List<StreamEntry>>>> streams2 =
-        pipe.xread(XReadParams.xReadParams().block(1), singletonMap(key1, id1));
+        pipe.xread(XReadParams.xReadParams().block(1), singletonMap(stream1, id1));
 
     Response<List<Entry<String, List<StreamEntry>>>> streams3 =
-        pipe.xread(XReadParams.xReadParams(), singletonMap(key1, id1));
+        pipe.xread(XReadParams.xReadParams(), singletonMap(stream1, id1));
 
     pipe.sync();
 
     assertThat(streams1.get().stream().map(Entry::getKey).collect(Collectors.toList()),
-        contains(key1));
+        contains(stream1));
 
     assertThat(streams1.get().stream().map(Entry::getValue).flatMap(List::stream)
         .map(StreamEntry::getID).collect(Collectors.toList()), contains(id1));
@@ -444,8 +444,8 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
 
     // Read from two Streams
     Map<String, StreamEntryID> streamQuery2 = new LinkedHashMap<>();
-    streamQuery2.put(key1, new StreamEntryID());
-    streamQuery2.put(key2, new StreamEntryID());
+    streamQuery2.put(stream1, new StreamEntryID());
+    streamQuery2.put(stream2, new StreamEntryID());
 
     Response<List<Entry<String, List<StreamEntry>>>> streams4 =
         pipe.xread(XReadParams.xReadParams().count(2).block(1), streamQuery2);
@@ -453,7 +453,7 @@ public class StreamsPipelineCommandsTest extends PipelineCommandsTestBase {
     pipe.sync();
 
     assertThat(streams4.get().stream().map(Entry::getKey).collect(Collectors.toList()),
-        contains(key1, key2));
+        contains(stream1, stream2));
 
     assertThat(streams4.get().stream().map(Entry::getValue).flatMap(List::stream)
         .map(StreamEntry::getID).collect(Collectors.toList()), contains(id1, id2));

--- a/src/test/java/redis/clients/jedis/params/XPendingParamsTest.java
+++ b/src/test/java/redis/clients/jedis/params/XPendingParamsTest.java
@@ -24,7 +24,7 @@ public class XPendingParamsTest {
     @Test
     public void checkEqualsVariousParams() {
         XPendingParams firstParam = getDefaultValue();
-        firstParam.start(StreamEntryID.LAST_ENTRY);
+        firstParam.start(StreamEntryID.XGROUP_LAST_ENTRY);
         XPendingParams secondParam = getDefaultValue();
         secondParam.start(StreamEntryID.NEW_ENTRY);
         assertFalse(firstParam.equals(secondParam));
@@ -33,7 +33,7 @@ public class XPendingParamsTest {
     @Test
     public void checkHashCodeVariousParams() {
         XPendingParams firstParam = getDefaultValue();
-        firstParam.start(StreamEntryID.LAST_ENTRY);
+        firstParam.start(StreamEntryID.XGROUP_LAST_ENTRY);
         XPendingParams secondParam = getDefaultValue();
         secondParam.start(StreamEntryID.NEW_ENTRY);
         assertNotEquals(firstParam.hashCode(), secondParam.hashCode());


### PR DESCRIPTION
- Added a last entry id for XREAD and XREADGROUP commands (Resolves #3732)
- Support map replies for XREAD and XREADGROUP commands (currently have list of key-value pairs)

---

Task breakdown (ToDo):
- [x] new StreamEntryID for less confusion
- [x] new XREAD and XREADGROUP support as map
- [x] command tests
- [ ] pipeline tests