### PR TITLE
Fix NPE in empty XPENDING summary

### DIFF
--- a/src/main/java/redis/clients/jedis/BuilderFactory.java
+++ b/src/main/java/redis/clients/jedis/BuilderFactory.java
@@ -1813,6 +1813,11 @@ public final class BuilderFactory {
 
       List<Object> objectList = (List<Object>) data;
       long total = BuilderFactory.LONG.build(objectList.get(0));
+
+      if (total == 0) {
+        return new StreamPendingSummary(total, null, null, null);
+      }
+
       String minId = SafeEncoder.encode((byte[]) objectList.get(1));
       String maxId = SafeEncoder.encode((byte[]) objectList.get(2));
       List<List<Object>> consumerObjList = (List<List<Object>>) objectList.get(3);


### PR DESCRIPTION
When there are no pending messages in a stream, the summary response to XPENDING contains nulls, except the first position which is 0 (the total number of pending message). Return early from the builder, in this case, to avoid NPE.