### PR TITLE
Remove broken JSON.ARRAPPEND method from CommandObjects

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -3623,14 +3623,6 @@ public class CommandObjects {
     return new CommandObject<>(commandArguments(JsonCommand.NUMINCRBY).key(key).add(path).add(value), BuilderFactory.DOUBLE);
   }
 
-  public final CommandObject<Long> jsonArrAppend(String key, String path, JSONObject... objects) {
-    CommandArguments args = commandArguments(JsonCommand.ARRAPPEND).key(key).add(path);
-    for (Object object : objects) {
-      args.add(object);
-    }
-    return new CommandObject<>(args, BuilderFactory.LONG);
-  }
-
   public final CommandObject<List<Long>> jsonArrAppend(String key, Path2 path, Object... objects) {
     CommandArguments args = commandArguments(JsonCommand.ARRAPPEND).key(key).add(path).addObjects(objects);
     return new CommandObject<>(args, BuilderFactory.LONG_LIST);


### PR DESCRIPTION
One of the jsonArrAppend methods in CommandObjects has broken serialization. Instead of deserializing the response into a List<Long>, it's only expecting Long. Luckily this method is not used, so better remove it.