### PR TITLE
Support transaction from UnifiedJedis without calling multi first

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -258,12 +258,12 @@ public class JedisCluster extends UnifiedJedis {
   }
 
   /**
-   * @param doMulti
+   * @param doMulti param
    * @return nothing
    * @throws UnsupportedOperationException
    */
   @Override
-  public Transaction transaction(boolean doMulti) {
+  public AbstractTransaction transaction(boolean doMulti) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -258,6 +258,7 @@ public class JedisCluster extends UnifiedJedis {
   }
 
   /**
+   * @param doMulti
    * @return nothing
    * @throws UnsupportedOperationException
    */

--- a/src/main/java/redis/clients/jedis/JedisCluster.java
+++ b/src/main/java/redis/clients/jedis/JedisCluster.java
@@ -262,7 +262,7 @@ public class JedisCluster extends UnifiedJedis {
    * @throws UnsupportedOperationException
    */
   @Override
-  public Transaction multi() {
+  public Transaction transaction(boolean doMulti) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisSharding.java
+++ b/src/main/java/redis/clients/jedis/JedisSharding.java
@@ -59,12 +59,12 @@ public class JedisSharding extends UnifiedJedis {
   }
 
   /**
-   * @param doMulti
+   * @param doMulti param
    * @return nothing
    * @throws UnsupportedOperationException
    */
   @Override
-  public Transaction transaction(boolean doMulti) {
+  public AbstractTransaction transaction(boolean doMulti) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisSharding.java
+++ b/src/main/java/redis/clients/jedis/JedisSharding.java
@@ -63,7 +63,7 @@ public class JedisSharding extends UnifiedJedis {
    * @throws UnsupportedOperationException
    */
   @Override
-  public Transaction multi() {
+  public Transaction transaction(boolean doMulti) {
     throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/redis/clients/jedis/JedisSharding.java
+++ b/src/main/java/redis/clients/jedis/JedisSharding.java
@@ -59,6 +59,7 @@ public class JedisSharding extends UnifiedJedis {
   }
 
   /**
+   * @param doMulti
    * @return nothing
    * @throws UnsupportedOperationException
    */

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -4878,10 +4878,17 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
     }
   }
 
+  /**
+   * @return transaction object
+   */
   public AbstractTransaction multi() {
     return transaction(true);
   }
 
+  /**
+   * @param doMulti {@code false} should be set to enable manual WATCH, UNWATCH and MULTI
+   * @return transaction object
+   */
   public AbstractTransaction transaction(boolean doMulti) {
     if (provider == null) {
       throw new IllegalStateException("It is not allowed to create Transaction from this " + getClass());

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -4879,12 +4879,16 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   public AbstractTransaction multi() {
+    return transaction(true);
+  }
+
+  public AbstractTransaction transaction(boolean doMulti) {
     if (provider == null) {
-      throw new IllegalStateException("It is not allowed to create Pipeline from this " + getClass());
+      throw new IllegalStateException("It is not allowed to create Transaction from this " + getClass());
     } else if (provider instanceof MultiClusterPooledConnectionProvider) {
-      return new MultiClusterTransaction((MultiClusterPooledConnectionProvider) provider, true, commandObjects);
+      return new MultiClusterTransaction((MultiClusterPooledConnectionProvider) provider, doMulti, commandObjects);
     } else {
-      return new Transaction(provider.getConnection(), true, true);
+      return new Transaction(provider.getConnection(), doMulti, true);
     }
   }
 

--- a/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.commands.unified.pooled;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -12,19 +13,15 @@ import org.junit.Test;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import redis.clients.jedis.JedisPooled;
-import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.AbstractPipeline;
+import redis.clients.jedis.AbstractTransaction;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.Response;
-import redis.clients.jedis.AbstractTransaction;
 import redis.clients.jedis.commands.unified.UnifiedJedisCommandsTestBase;
 import redis.clients.jedis.exceptions.JedisDataException;
 
 @RunWith(Parameterized.class)
 public class PooledMiscellaneousTest extends UnifiedJedisCommandsTestBase {
-
-  protected Pipeline pipeline;
-  protected AbstractTransaction transaction;
 
   public PooledMiscellaneousTest(RedisProtocol protocol) {
     super(protocol);
@@ -34,19 +31,11 @@ public class PooledMiscellaneousTest extends UnifiedJedisCommandsTestBase {
   public void setUp() {
     jedis = PooledCommandsTestHelper.getPooled(protocol);
     PooledCommandsTestHelper.clearData();
-    pipeline = ((JedisPooled) jedis).pipelined();
-    transaction = jedis.multi();
   }
 
   @After
   public void cleanUp() {
     jedis.close();
-  }
-
-  @After
-  public void tearDown() {
-    pipeline.close();
-    transaction.close();
   }
 
   @Test
@@ -64,15 +53,18 @@ public class PooledMiscellaneousTest extends UnifiedJedisCommandsTestBase {
 
     List<Response<?>> responses = new ArrayList<>(totalCount);
     List<Object> expected = new ArrayList<>(totalCount);
-    for (int i = 0; i < count; i++) {
-      responses.add(pipeline.get("foo" + i));
-      expected.add("bar" + i);
+
+    try (AbstractPipeline pipeline = jedis.pipelined()) {
+      for (int i = 0; i < count; i++) {
+        responses.add(pipeline.get("foo" + i));
+        expected.add("bar" + i);
+      }
+      for (int i = 0; i < count; i++) {
+        responses.add(pipeline.lrange("foobar" + i, 0, -1));
+        expected.add(Arrays.asList("foo" + i, "bar" + i));
+      }
+      pipeline.sync();
     }
-    for (int i = 0; i < count; i++) {
-      responses.add(pipeline.lrange("foobar" + i, 0, -1));
-      expected.add(Arrays.asList("foo" + i, "bar" + i));
-    }
-    pipeline.sync();
 
     for (int i = 0; i < totalCount; i++) {
       assertEquals(expected.get(i), responses.get(i).get());
@@ -92,20 +84,40 @@ public class PooledMiscellaneousTest extends UnifiedJedisCommandsTestBase {
     }
     totalCount += count;
 
+    List<Object> responses;
     List<Object> expected = new ArrayList<>(totalCount);
-    for (int i = 0; i < count; i++) {
-      transaction.get("foo" + i);
-      expected.add("bar" + i);
-    }
-    for (int i = 0; i < count; i++) {
-      transaction.lrange("foobar" + i, 0, -1);
-      expected.add(Arrays.asList("foo" + i, "bar" + i));
+
+    try (AbstractTransaction transaction = jedis.multi()) {
+      for (int i = 0; i < count; i++) {
+        transaction.get("foo" + i);
+        expected.add("bar" + i);
+      }
+      for (int i = 0; i < count; i++) {
+        transaction.lrange("foobar" + i, 0, -1);
+        expected.add(Arrays.asList("foo" + i, "bar" + i));
+      }
+      responses = transaction.exec();
     }
 
-    List<Object> responses = transaction.exec();
     for (int i = 0; i < totalCount; i++) {
       assertEquals(expected.get(i), responses.get(i));
     }
+  }
+
+  @Test
+  public void watch() {
+    List<Object> resp;
+    try (AbstractTransaction tx = jedis.transaction(false)) {
+      assertEquals("OK", tx.watch("mykey", "somekey"));
+      tx.multi();
+
+      jedis.set("mykey", "bar");
+
+      tx.set("mykey", "foo");
+      resp = tx.exec();
+    }
+    assertNull(resp);
+    assertEquals("bar", jedis.get("mykey"));
   }
 
   @Test


### PR DESCRIPTION
### Changes
* Support transaction from UnifiedJedis without calling multi first
* Return type of `multi()` method in JedisCluster and JedisSharding classes is changed to `AbstractTransaction` instead of `Transaction`
---
Resolves #3662 
Closes #3663 