### PR TITLE
Renew slot cache if ClusterPipeline.sync results in MOVED response

### DIFF
--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -3,6 +3,7 @@ package redis.clients.jedis;
 import java.time.Duration;
 import java.util.Set;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import redis.clients.jedis.exceptions.JedisMovedDataException;
 import redis.clients.jedis.providers.ClusterConnectionProvider;
 import redis.clients.jedis.util.IOUtils;
 
@@ -52,6 +53,16 @@ public class ClusterPipeline extends MultiNodePipelineBase {
       super.close();
     } finally {
       IOUtils.closeQuietly(closeable);
+    }
+  }
+
+  @Override
+  public void sync() {
+    try {
+      super.sync();
+    } catch (JedisMovedDataException e) {
+      provider.renewSlotCache();
+      throw e;
     }
   }
 


### PR DESCRIPTION
The intent of this change is to fix a couple issues `MultiNodePipelineBase`:
- Exceptions thrown from `Connection.getMany` are swallowed.
- `JedisMovedDataException` does not trigger a call to `JedisClusterInfoCache.renewClusterSlots` (and there may be no other opportunity to call `JedisClusterInfoCache.renewClusterSlots` if the application did not specify a `topologyRefreshPeriod` when constructing `JedisCluster`).

With this implementation only the first exception thrown from `Connection.getMany` is rethrown; however this matches the behavior of `Pipeline`.