### PR TITLE
Introduce EndpointConfig and load endpoint settings from the endpoints.json file

### DIFF
--- a/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
@@ -177,7 +177,8 @@ public class ACLJedisPoolTest {
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool(endpoint.getCustomizedURI(true, "/2"));
+    try (JedisPool pool = new JedisPool(
+        endpoint.getURIBuilder().defaultCredentials().path("/2").build());
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
@@ -191,13 +192,14 @@ public class ACLJedisPoolTest {
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool(endpoint.getCustomizedURI(true, "/2"));
+    try (JedisPool pool = new JedisPool(
+        endpoint.getURIBuilder().defaultCredentials().path("/2").build());
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
 
     try (JedisPool pool = new JedisPool(
-        endpointWithDefaultUser.getCustomizedURI(true, "/2"));
+        endpointWithDefaultUser.getURIBuilder().defaultCredentials().path("/2").build());
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
@@ -258,10 +260,10 @@ public class ACLJedisPoolTest {
   public void testCloseConnectionOnMakeObject() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(), 2000,
-            endpoint.getUsername(), "wrongpassword");
-         Jedis jedis = new Jedis(endpointWithDefaultUser.getCustomizedURI(
-                 "", endpointWithDefaultUser.getPassword(), ""))) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint.getHost(),
+        endpoint.getPort(), 2000, endpoint.getUsername(), "wrongpassword");
+        Jedis jedis = new Jedis(endpointWithDefaultUser.getURIBuilder()
+            .credentials("", endpointWithDefaultUser.getPassword()).build())) {
       int currentClientCount = getClientCount(jedis.clientList());
       try {
         pool.getResource();

--- a/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
@@ -29,7 +29,7 @@ public class ACLJedisPoolTest {
   public static void prepare() throws Exception {
     // Use to check if the ACL test should be ran. ACL are available only in 6.0 and later
     org.junit.Assume.assumeTrue("Not running ACL test on this version of Redis",
-        RedisVersionUtil.checkRedisMajorVersionNumber(6));
+        RedisVersionUtil.checkRedisMajorVersionNumber(6, endpoint));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.BeforeClass;
@@ -21,7 +20,7 @@ import redis.clients.jedis.util.RedisVersionUtil;
  * This test is only executed when the server/cluster is Redis 6. or more.
  */
 public class ACLJedisPoolTest {
-  private static final HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
 
   @BeforeClass
   public static void prepare() throws Exception {
@@ -32,8 +31,8 @@ public class ACLJedisPoolTest {
 
   @Test
   public void checkConnections() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), "acljedis",
-        "fizzbuzz");
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(),
+        endpoint.getUsername(), endpoint.getPassword());
     try (Jedis jedis = pool.getResource()) {
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
@@ -44,7 +43,8 @@ public class ACLJedisPoolTest {
 
   @Test
   public void checkCloseableConnections() throws Exception {
-    JedisPool pool = new JedisPool(hnp.getHost(), hnp.getPort(), "acljedis", "fizzbuzz");
+    JedisPool pool = new JedisPool(endpoint.getHost(), endpoint.getPort(), endpoint.getUsername(),
+        endpoint.getPassword());
     try (Jedis jedis = pool.getResource()) {
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
@@ -58,9 +58,9 @@ public class ACLJedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(),
-        Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, 0 /* infinite */, "acljedis",
-        "fizzbuzz", Protocol.DEFAULT_DATABASE, "closable-reusable-pool", false, null, null, null)) {
+    try (JedisPool pool = new JedisPool(config, endpoint.getHost(), endpoint.getPort(),
+        Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, 0 /* infinite */, endpoint.getUsername(),
+        endpoint.getPassword(), Protocol.DEFAULT_DATABASE, "closable-reusable-pool", false, null, null, null)) {
 
       Jedis jedis = pool.getResource();
       jedis.set("hello", "jedis");
@@ -78,8 +78,8 @@ public class ACLJedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPool pool = new JedisPool(config, hnp, DefaultJedisClientConfig.builder()
-        .user("acljedis").password("fizzbuzz").clientName("closable-reusable-pool")
+    try (JedisPool pool = new JedisPool(config, endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().clientName("closable-reusable-pool")
         .build())) {
 
       Jedis jedis = pool.getResource();
@@ -96,9 +96,9 @@ public class ACLJedisPoolTest {
 
   @Test
   public void checkPoolRepairedWhenJedisIsBroken() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(),
-        Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, 0 /* infinite */, "acljedis",
-        "fizzbuzz", Protocol.DEFAULT_DATABASE, "repairable-pool");
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(),
+        Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT, 0 /* infinite */, endpoint.getUsername(),
+        endpoint.getPassword(), Protocol.DEFAULT_DATABASE, "repairable-pool");
     try (Jedis jedis = pool.getResource()) {
       jedis.set("foo", "0");
       jedis.disconnect();
@@ -116,12 +116,12 @@ public class ACLJedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
+    try (JedisPool pool = new JedisPool(config, endpoint.getHost(), endpoint.getPort());
         Jedis jedis = pool.getResource()) {
-      jedis.auth("acljedis", "fizzbuzz");
+      jedis.auth(endpoint.getUsername(), endpoint.getPassword());
 
       try (Jedis jedis2 = pool.getResource()) {
-        jedis2.auth("acljedis", "fizzbuzz");
+        jedis2.auth(endpoint.getUsername(), endpoint.getPassword());
       }
     }
   }
@@ -130,8 +130,8 @@ public class ACLJedisPoolTest {
   public void securePool() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis",
-        "fizzbuzz");
+    JedisPool pool = new JedisPool(config, endpoint.getHost(), endpoint.getPort(), 2000, endpoint.getUsername(),
+        endpoint.getPassword());
     try (Jedis jedis = pool.getResource()) {
       jedis.set("foo", "bar");
     }
@@ -143,8 +143,8 @@ public class ACLJedisPoolTest {
   public void securePoolNonSSL() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "acljedis",
-        "fizzbuzz", false);
+    JedisPool pool = new JedisPool(config, endpoint.getHost(), endpoint.getPort(), 2000, endpoint.getUsername(),
+        endpoint.getPassword(), false);
     try (Jedis jedis = pool.getResource()) {
       jedis.set("foo", "bar");
     }
@@ -154,27 +154,27 @@ public class ACLJedisPoolTest {
 
   @Test
   public void nonDefaultDatabase() {
-    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "acljedis", "fizzbuzz"); Jedis jedis0 = pool0.getResource()) {
+    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(), 2000,
+        endpoint.getUsername(), endpoint.getPassword()); Jedis jedis0 = pool0.getResource()) {
       jedis0.set("foo", "bar");
       assertEquals("bar", jedis0.get("foo"));
     }
 
-    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "acljedis", "fizzbuzz", 1); Jedis jedis1 = pool1.getResource()) {
+    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(), 2000,
+        endpoint.getUsername(), endpoint.getPassword(), 1); Jedis jedis1 = pool1.getResource()) {
       assertNull(jedis1.get("foo"));
     }
   }
 
   @Test
   public void startWithUrlString() {
-    try (Jedis j = new Jedis("localhost", 6379)) {
-      j.auth("acljedis", "fizzbuzz");
+    try (Jedis j = new Jedis(endpoint.getHost(), endpoint.getPort())) {
+      j.auth(endpoint.getUsername(), endpoint.getPassword());
       j.select(2);
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool("redis://acljedis:fizzbuzz@localhost:6379/2");
+    try (JedisPool pool = new JedisPool(endpoint.getCustomizedURI(true, "/2"));
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
@@ -182,18 +182,19 @@ public class ACLJedisPoolTest {
 
   @Test
   public void startWithUrl() throws URISyntaxException {
-    try (Jedis j = new Jedis("localhost", 6379)) {
-      j.auth("acljedis", "fizzbuzz");
+    try (Jedis j = new Jedis(endpoint.getHost(), endpoint.getPort())) {
+      j.auth(endpoint.getUsername(), endpoint.getPassword());
       j.select(2);
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"));
+    try (JedisPool pool = new JedisPool(endpoint.getCustomizedURI(true, "/2"));
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
 
-    try (JedisPool pool = new JedisPool(new URI("redis://default:foobared@localhost:6379/2"));
+    try (JedisPool pool = new JedisPool(
+        endpoint.getCustomizedURI("default", endpoint.getPassword(), "/2"));
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
@@ -201,19 +202,19 @@ public class ACLJedisPoolTest {
 
   @Test(expected = InvalidURIException.class)
   public void shouldThrowInvalidURIExceptionForInvalidURI() throws URISyntaxException {
-    new JedisPool(new URI("localhost:6379")).close();
+    new JedisPool(endpoint.getURI()).close();
   }
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() throws URISyntaxException {
-    new JedisPool("redis://localhost:6379").close();
-    new JedisPool(new URI("redis://localhost:6379")).close();
+    new JedisPool(endpoint.getURI().toString()).close();
+    new JedisPool(endpoint.getURI()).close();
   }
 
   @Test
   public void selectDatabaseOnActivation() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "acljedis", "fizzbuzz")) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(), 2000,
+        endpoint.getUsername(), endpoint.getPassword())) {
 
       Jedis jedis0 = pool.getResource();
       assertEquals(0, jedis0.getDB());
@@ -233,8 +234,8 @@ public class ACLJedisPoolTest {
 
   @Test
   public void customClientName() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "acljedis", "fizzbuzz", 0, "my_shiny_client_name"); Jedis jedis = pool.getResource()) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(), 2000,
+        endpoint.getUsername(), endpoint.getPassword(), 0, "my_shiny_client_name"); Jedis jedis = pool.getResource()) {
 
       assertEquals("my_shiny_client_name", jedis.clientGetname());
     }
@@ -242,8 +243,8 @@ public class ACLJedisPoolTest {
 
   @Test
   public void customClientNameNoSSL() {
-    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "acljedis", "fizzbuzz", 0, "my_shiny_client_name_no_ssl", false);
+    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(), 2000,
+        endpoint.getUsername(), endpoint.getPassword(), 0, "my_shiny_client_name_no_ssl", false);
         Jedis jedis = pool0.getResource()) {
 
       assertEquals("my_shiny_client_name_no_ssl", jedis.clientGetname());
@@ -254,8 +255,9 @@ public class ACLJedisPoolTest {
   public void testCloseConnectionOnMakeObject() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "acljedis", "foobared"); Jedis jedis = new Jedis("redis://:foobared@localhost:6379/")) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint.getHost(), endpoint.getPort(), 2000,
+        endpoint.getUsername(), endpoint.getPassword()); Jedis jedis = new Jedis(endpoint.getCustomizedURI(
+        "", endpoint.getPassword(), ""))) {
       int currentClientCount = getClientCount(jedis.clientList());
       try {
         pool.getResource();

--- a/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisPoolTest.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.util.RedisVersionUtil;
  * This test is only executed when the server/cluster is Redis 6. or more.
  */
 public class ACLJedisPoolTest {
-  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
+  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0-acl");
 
   @BeforeClass
   public static void prepare() throws Exception {

--- a/src/test/java/redis/clients/jedis/ACLJedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisSentinelPoolTest.java
@@ -24,7 +24,6 @@ public class ACLJedisSentinelPoolTest {
 
   private static final String MASTER_NAME = "aclmaster";
 
-  //protected static HostAndPort master = HostAndPortUtil.getRedisServers().get(8);
   protected static HostAndPort sentinel1 = HostAndPorts.getSentinelServers().get(4);
 
   protected Set<HostAndPort> sentinels = new HashSet<>();

--- a/src/test/java/redis/clients/jedis/ACLJedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisSentinelPoolTest.java
@@ -30,8 +30,9 @@ public class ACLJedisSentinelPoolTest {
 
   @BeforeClass
   public static void prepare() throws Exception {
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone2-primary");
     org.junit.Assume.assumeTrue("Not running ACL test on this version of Redis",
-        RedisVersionUtil.checkRedisMajorVersionNumber(6));
+        RedisVersionUtil.checkRedisMajorVersionNumber(6, endpoint));
   }
 
   @Before

--- a/src/test/java/redis/clients/jedis/ACLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisTest.java
@@ -19,6 +19,8 @@ import redis.clients.jedis.util.RedisVersionUtil;
 @RunWith(Parameterized.class)
 public class ACLJedisTest extends JedisCommandsTestBase {
 
+  protected static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0-acl");
+
   /**
    * Use to check if the ACL test should be ran. ACL are available only in 6.0 and later
    * @throws Exception

--- a/src/test/java/redis/clients/jedis/ACLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisTest.java
@@ -83,7 +83,8 @@ public class ACLJedisTest extends JedisCommandsTestBase {
       assertEquals("OK", j.select(2));
       j.set("foo", "bar");
     }
-    try (Jedis j2 = new Jedis(endpoint.getCustomizedURI(true, "/2").toString())) {
+    try (Jedis j2 = new Jedis(
+        endpoint.getURIBuilder().defaultCredentials().path("/2").build().toString())) {
       assertEquals("PONG", j2.ping());
       assertEquals("bar", j2.get("foo"));
     }
@@ -96,11 +97,11 @@ public class ACLJedisTest extends JedisCommandsTestBase {
       assertEquals("OK", j.select(2));
       j.set("foo", "bar");
     }
-    try (Jedis j1 = new Jedis(endpoint.getCustomizedURI(true, "/2"))) {
+    try (Jedis j1 = new Jedis(endpoint.getURIBuilder().defaultCredentials().path("/2").build())) {
       assertEquals("PONG", j1.ping());
       assertEquals("bar", j1.get("foo"));
     }
-    try (Jedis j2 = new Jedis(endpoint.getCustomizedURI(true, "/2"))) {
+    try (Jedis j2 = new Jedis(endpoint.getURIBuilder().defaultCredentials().path("/2").build())) {
       assertEquals("PONG", j2.ping());
       assertEquals("bar", j2.get("foo"));
     }

--- a/src/test/java/redis/clients/jedis/ACLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisTest.java
@@ -28,7 +28,7 @@ public class ACLJedisTest extends JedisCommandsTestBase {
   @BeforeClass
   public static void prepare() throws Exception {
     org.junit.Assume.assumeTrue("Not running ACL test on this version of Redis",
-        RedisVersionUtil.checkRedisMajorVersionNumber(6));
+        RedisVersionUtil.checkRedisMajorVersionNumber(6, endpoint));
   }
 
   public ACLJedisTest(RedisProtocol redisProtocol) {

--- a/src/test/java/redis/clients/jedis/ACLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/ACLJedisTest.java
@@ -2,7 +2,6 @@ package redis.clients.jedis;
 
 import static org.junit.Assert.assertEquals;
 
-import java.net.URI;
 import java.net.URISyntaxException;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,39 +36,38 @@ public class ACLJedisTest extends JedisCommandsTestBase {
   @Test
   public void useWithoutConnecting() {
     try (Jedis j = new Jedis()) {
-      assertEquals("OK", j.auth("acljedis", "fizzbuzz"));
+      assertEquals("OK", j.auth(endpoint.getUsername(), endpoint.getPassword()));
       j.dbSize();
     }
   }
 
   @Test
   public void connectWithConfig() {
-    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().build())) {
-      jedis.auth("acljedis", "fizzbuzz");
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), DefaultJedisClientConfig.builder().build())) {
+      jedis.auth(endpoint.getUsername(), endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
-    try (Jedis jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().user("acljedis")
-        .password("fizzbuzz").build())) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder().build())) {
       assertEquals("PONG", jedis.ping());
     }
   }
 
   @Test
   public void connectWithConfigInterface() {
-    try (Jedis jedis = new Jedis(hnp, new JedisClientConfig() {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), new JedisClientConfig() {
     })) {
-      jedis.auth("acljedis", "fizzbuzz");
+      jedis.auth(endpoint.getUsername(), endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
-    try (Jedis jedis = new Jedis(hnp, new JedisClientConfig() {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(), new JedisClientConfig() {
       @Override
       public String getUser() {
-        return "acljedis";
+        return endpoint.getUsername();
       }
 
       @Override
       public String getPassword() {
-        return "fizzbuzz";
+        return endpoint.getPassword();
       }
     })) {
       assertEquals("PONG", jedis.ping());
@@ -78,12 +76,12 @@ public class ACLJedisTest extends JedisCommandsTestBase {
 
   @Test
   public void startWithUrl() {
-    try (Jedis j = new Jedis("localhost", 6379)) {
-      assertEquals("OK", j.auth("acljedis", "fizzbuzz"));
+    try (Jedis j = new Jedis(endpoint.getHostAndPort())) {
+      assertEquals("OK", j.auth(endpoint.getUsername(), endpoint.getPassword()));
       assertEquals("OK", j.select(2));
       j.set("foo", "bar");
     }
-    try (Jedis j2 = new Jedis("redis://acljedis:fizzbuzz@localhost:6379/2")) {
+    try (Jedis j2 = new Jedis(endpoint.getCustomizedURI(true, "/2").toString())) {
       assertEquals("PONG", j2.ping());
       assertEquals("bar", j2.get("foo"));
     }
@@ -91,16 +89,16 @@ public class ACLJedisTest extends JedisCommandsTestBase {
 
   @Test
   public void startWithUri() throws URISyntaxException {
-    try (Jedis j = new Jedis("localhost", 6379)) {
-      assertEquals("OK", j.auth("acljedis", "fizzbuzz"));
+    try (Jedis j = new Jedis(endpoint.getHostAndPort())) {
+      assertEquals("OK", j.auth(endpoint.getUsername(), endpoint.getPassword()));
       assertEquals("OK", j.select(2));
       j.set("foo", "bar");
     }
-    try (Jedis j1 = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"))) {
+    try (Jedis j1 = new Jedis(endpoint.getCustomizedURI(true, "/2"))) {
       assertEquals("PONG", j1.ping());
       assertEquals("bar", j1.get("foo"));
     }
-    try (Jedis j2 = new Jedis(new URI("redis://acljedis:fizzbuzz@localhost:6379/2"))) {
+    try (Jedis j2 = new Jedis(endpoint.getCustomizedURI(true, "/2"))) {
       assertEquals("PONG", j2.ping());
       assertEquals("bar", j2.get("foo"));
     }

--- a/src/test/java/redis/clients/jedis/EndpointConfig.java
+++ b/src/test/java/redis/clients/jedis/EndpointConfig.java
@@ -18,14 +18,14 @@ public class EndpointConfig {
     private List<URI> endpoints;
 
 
-    public EndpointConfig(HostAndPort hnp, String username, String password) {
-        this.tls = false;
+    public EndpointConfig(HostAndPort hnp, String username, String password, boolean tls) {
+        this.tls = tls;
         this.username = username;
         this.password = password;
         this.bdbId = 0;
         this.rawEndpoints = null;
         this.endpoints = Collections.singletonList(
-                URI.create("redis://" + hnp.getHost() + ":" + hnp.getPort())
+                URI.create(getURISchema() + hnp.getHost() + ":" + hnp.getPort())
         );
     }
 
@@ -59,7 +59,7 @@ public class EndpointConfig {
 
     public URI getCustomizedURI(String u, String p, String path) {
         String userInfo = !(u.isEmpty() && p.isEmpty()) ? u + ":" + p + "@" : "";
-        return URI.create((tls ? "rediss" : "redis") + "://" + userInfo + getHost() + ":" + getPort() + path);
+        return URI.create(getURISchema() + userInfo + getHost() + ":" + getPort() + path);
     }
 
     public Connection getConnection() {
@@ -80,6 +80,10 @@ public class EndpointConfig {
 
     public DefaultJedisClientConfig.Builder getClientConfigBuilder() {
         return DefaultJedisClientConfig.builder().user(username).password(password).ssl(tls);
+    }
+
+    private String getURISchema() {
+        return (tls ? "rediss" : "redis") + "://";
     }
 
     public static HashMap<String, EndpointConfig> loadFromJSON(String filePath) throws Exception {

--- a/src/test/java/redis/clients/jedis/EndpointConfig.java
+++ b/src/test/java/redis/clients/jedis/EndpointConfig.java
@@ -1,0 +1,93 @@
+package redis.clients.jedis;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import redis.clients.jedis.util.JedisURIHelper;
+
+import java.io.FileReader;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+
+public class EndpointConfig {
+
+  private boolean tls;
+  private String username;
+  private String password;
+  private int bdbId;
+  private Object rawEndpoints;
+
+  private List<URI> endpoints;
+
+  public EndpointConfig(boolean tls, String username, String password, int bdbId, Object rawEndpoints) {
+    this.tls = tls;
+    this.username = username;
+    this.password = password;
+    this.bdbId = bdbId;
+    this.rawEndpoints = rawEndpoints;
+  }
+
+  public HostAndPort getHostAndPort() {
+    return JedisURIHelper.getHostAndPort(endpoints.get(0));
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getHost() {
+    return getHostAndPort().getHost();
+  }
+
+  public int getPort() {
+    return getHostAndPort().getPort();
+  }
+
+  public URI getURI() {
+    return endpoints.get(0);
+  }
+
+  public URI getCustomizedURI(boolean withCredentials, String path)
+  {
+    return getCustomizedURI(withCredentials ? username : "", withCredentials ? password : "", path);
+  }
+
+  public URI getCustomizedURI(String u, String p, String path)
+  {
+    String userInfo = !(u.isEmpty() && p.isEmpty()) ? u + ":" + p + "@" : "";
+    return URI.create((tls ? "rediss" : "redis") + "://" + userInfo + getHost() + ":" + getPort() + path);
+  }
+
+  public Connection getConnection() {
+    return new Connection(getHostAndPort(), getClientConfigBuilder().build());
+  }
+
+  public Connection getConnection(int timeoutMillis) {
+    return new Connection(getHostAndPort(), getClientConfigBuilder().timeoutMillis(timeoutMillis).build());
+  }
+
+  public Jedis getJedis() {
+    return new Jedis(getHostAndPort(), getClientConfigBuilder().build());
+  }
+
+  public Jedis getJedis(int timeoutMillis) {
+    return new Jedis(getHostAndPort(), getClientConfigBuilder().timeoutMillis(timeoutMillis).build());
+  }
+
+  public DefaultJedisClientConfig.Builder getClientConfigBuilder() {
+    return DefaultJedisClientConfig.builder().user(username).password(password);
+  }
+
+  public static HashMap<String, EndpointConfig> loadFromJSON(String filePath) throws Exception {
+    Gson gson = new Gson();
+    HashMap<String, EndpointConfig> configs;
+    try (FileReader reader = new FileReader(filePath)) {
+      configs = gson.fromJson(reader, new TypeToken<HashMap<String, EndpointConfig>>() {
+      }.getType());
+    }
+    return configs;
+  }
+}

--- a/src/test/java/redis/clients/jedis/EndpointConfig.java
+++ b/src/test/java/redis/clients/jedis/EndpointConfig.java
@@ -34,7 +34,7 @@ public class EndpointConfig {
     }
 
     public String getUsername() {
-        return username;
+        return username == null? "default" : username;
     }
 
     public String getHost() {
@@ -68,8 +68,8 @@ public class EndpointConfig {
         }
 
         public EndpointURIBuilder defaultCredentials() {
-            this.username = EndpointConfig.this.username;
-            this.password = EndpointConfig.this.password;
+            this.username = EndpointConfig.this.username == null ? "" : getUsername();
+            this.password = EndpointConfig.this.getPassword();
             return this;
         }
 
@@ -91,7 +91,7 @@ public class EndpointConfig {
 
         public URI build() {
             String userInfo = !(this.username.isEmpty() && this.password.isEmpty()) ?
-                this.username + ":" + this.password + "@" :
+                this.username + ':' + this.password + '@' :
                 "";
             return URI.create(
                 getURISchema(this.tls) + userInfo + getHost() + ":" + getPort() + this.path);
@@ -103,7 +103,14 @@ public class EndpointConfig {
     }
 
     public DefaultJedisClientConfig.Builder getClientConfigBuilder() {
-        return DefaultJedisClientConfig.builder().user(username).password(password).ssl(tls);
+      DefaultJedisClientConfig.Builder builder = DefaultJedisClientConfig.builder()
+          .password(password).ssl(tls);
+
+        if (username != null) {
+          return builder.user(username);
+        }
+
+        return builder;
     }
 
     protected String getURISchema(boolean tls) {

--- a/src/test/java/redis/clients/jedis/EndpointConfig.java
+++ b/src/test/java/redis/clients/jedis/EndpointConfig.java
@@ -1,93 +1,94 @@
 package redis.clients.jedis;
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import redis.clients.jedis.util.JedisURIHelper;
 
 import java.io.FileReader;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 public class EndpointConfig {
 
-  private boolean tls;
-  private String username;
-  private String password;
-  private int bdbId;
-  private Object rawEndpoints;
+    private boolean tls;
+    private String username;
+    private String password;
+    private int bdbId;
+    private Object rawEndpoints;
+    private List<URI> endpoints;
 
-  private List<URI> endpoints;
 
-  public EndpointConfig(boolean tls, String username, String password, int bdbId, Object rawEndpoints) {
-    this.tls = tls;
-    this.username = username;
-    this.password = password;
-    this.bdbId = bdbId;
-    this.rawEndpoints = rawEndpoints;
-  }
-
-  public HostAndPort getHostAndPort() {
-    return JedisURIHelper.getHostAndPort(endpoints.get(0));
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public String getHost() {
-    return getHostAndPort().getHost();
-  }
-
-  public int getPort() {
-    return getHostAndPort().getPort();
-  }
-
-  public URI getURI() {
-    return endpoints.get(0);
-  }
-
-  public URI getCustomizedURI(boolean withCredentials, String path)
-  {
-    return getCustomizedURI(withCredentials ? username : "", withCredentials ? password : "", path);
-  }
-
-  public URI getCustomizedURI(String u, String p, String path)
-  {
-    String userInfo = !(u.isEmpty() && p.isEmpty()) ? u + ":" + p + "@" : "";
-    return URI.create((tls ? "rediss" : "redis") + "://" + userInfo + getHost() + ":" + getPort() + path);
-  }
-
-  public Connection getConnection() {
-    return new Connection(getHostAndPort(), getClientConfigBuilder().build());
-  }
-
-  public Connection getConnection(int timeoutMillis) {
-    return new Connection(getHostAndPort(), getClientConfigBuilder().timeoutMillis(timeoutMillis).build());
-  }
-
-  public Jedis getJedis() {
-    return new Jedis(getHostAndPort(), getClientConfigBuilder().build());
-  }
-
-  public Jedis getJedis(int timeoutMillis) {
-    return new Jedis(getHostAndPort(), getClientConfigBuilder().timeoutMillis(timeoutMillis).build());
-  }
-
-  public DefaultJedisClientConfig.Builder getClientConfigBuilder() {
-    return DefaultJedisClientConfig.builder().user(username).password(password);
-  }
-
-  public static HashMap<String, EndpointConfig> loadFromJSON(String filePath) throws Exception {
-    Gson gson = new Gson();
-    HashMap<String, EndpointConfig> configs;
-    try (FileReader reader = new FileReader(filePath)) {
-      configs = gson.fromJson(reader, new TypeToken<HashMap<String, EndpointConfig>>() {
-      }.getType());
+    public EndpointConfig(HostAndPort hnp, String username, String password) {
+        this.tls = false;
+        this.username = username;
+        this.password = password;
+        this.bdbId = 0;
+        this.rawEndpoints = null;
+        this.endpoints = Collections.singletonList(
+                URI.create("redis://" + hnp.getHost() + ":" + hnp.getPort())
+        );
     }
-    return configs;
-  }
+
+    public HostAndPort getHostAndPort() {
+        return JedisURIHelper.getHostAndPort(endpoints.get(0));
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getHost() {
+        return getHostAndPort().getHost();
+    }
+
+    public int getPort() {
+        return getHostAndPort().getPort();
+    }
+
+    public URI getURI() {
+        return endpoints.get(0);
+    }
+
+    public URI getCustomizedURI(boolean withCredentials, String path) {
+        return getCustomizedURI(withCredentials ? username : "", withCredentials ? password : "", path);
+    }
+
+    public URI getCustomizedURI(String u, String p, String path) {
+        String userInfo = !(u.isEmpty() && p.isEmpty()) ? u + ":" + p + "@" : "";
+        return URI.create((tls ? "rediss" : "redis") + "://" + userInfo + getHost() + ":" + getPort() + path);
+    }
+
+    public Connection getConnection() {
+        return new Connection(getHostAndPort(), getClientConfigBuilder().build());
+    }
+
+    public Connection getConnection(int timeoutMillis) {
+        return new Connection(getHostAndPort(), getClientConfigBuilder().timeoutMillis(timeoutMillis).build());
+    }
+
+    public Jedis getJedis() {
+        return new Jedis(getHostAndPort(), getClientConfigBuilder().build());
+    }
+
+    public Jedis getJedis(int timeoutMillis) {
+        return new Jedis(getHostAndPort(), getClientConfigBuilder().timeoutMillis(timeoutMillis).build());
+    }
+
+    public DefaultJedisClientConfig.Builder getClientConfigBuilder() {
+        return DefaultJedisClientConfig.builder().user(username).password(password).ssl(tls);
+    }
+
+    public static HashMap<String, EndpointConfig> loadFromJSON(String filePath) throws Exception {
+        Gson gson = new Gson();
+        HashMap<String, EndpointConfig> configs;
+        try (FileReader reader = new FileReader(filePath)) {
+            configs = gson.fromJson(reader, new TypeToken<HashMap<String, EndpointConfig>>() {
+            }.getType());
+        }
+        return configs;
+    }
 }

--- a/src/test/java/redis/clients/jedis/HostAndPorts.java
+++ b/src/test/java/redis/clients/jedis/HostAndPorts.java
@@ -1,9 +1,12 @@
 package redis.clients.jedis;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 public final class HostAndPorts {
+
+  private static HashMap<String, EndpointConfig> endpointConfigs;
 
   private static List<HostAndPort> redisHostAndPortList = new ArrayList<>();
   private static List<HostAndPort> sentinelHostAndPortList = new ArrayList<>();
@@ -11,17 +14,15 @@ public final class HostAndPorts {
   private static List<HostAndPort> stableClusterHostAndPortList = new ArrayList<>();
 
   static {
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 1));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 2));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 3));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 4));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 5));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 6));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 7));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 8));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 9));
-    redisHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_PORT + 10));
+    try {
+      endpointConfigs = EndpointConfig.loadFromJSON("src/test/resources/endpoints.json");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    // TODO: This is a temporary solution to avoid breaking existing tests.
+    //       We should update the tests to make them compatible
+    //       with RE Discovery Service and OSS Cluster API.
 
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT));
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 1));
@@ -41,31 +42,8 @@ public final class HostAndPorts {
     stableClusterHostAndPortList.add(new HostAndPort("localhost", 7481));
   }
 
-  public static List<HostAndPort> parseHosts(String envHosts,
-      List<HostAndPort> existingHostsAndPorts) {
-
-    if (null != envHosts && 0 < envHosts.length()) {
-
-      String[] hostDefs = envHosts.split(",");
-
-      if (null != hostDefs && 2 <= hostDefs.length) {
-
-        List<HostAndPort> envHostsAndPorts = new ArrayList<>(hostDefs.length);
-
-        for (String hostDef : hostDefs) {
-
-          envHostsAndPorts.add(HostAndPort.from(hostDef));
-        }
-
-        return envHostsAndPorts;
-      }
-    }
-
-    return existingHostsAndPorts;
-  }
-
-  public static List<HostAndPort> getRedisServers() {
-    return redisHostAndPortList;
+  public static EndpointConfig getRedisEndpoint(String endpointName) {
+    return endpointConfigs.get(endpointName);
   }
 
   public static List<HostAndPort> getSentinelServers() {

--- a/src/test/java/redis/clients/jedis/HostAndPorts.java
+++ b/src/test/java/redis/clients/jedis/HostAndPorts.java
@@ -20,10 +20,6 @@ public final class HostAndPorts {
       throw new RuntimeException(e);
     }
 
-    // TODO: This is a temporary solution to avoid breaking existing tests.
-    //       We should update the tests to make them compatible
-    //       with RE Discovery Service and OSS Cluster API.
-
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT));
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 1));
     sentinelHostAndPortList.add(new HostAndPort("localhost", Protocol.DEFAULT_SENTINEL_PORT + 2));

--- a/src/test/java/redis/clients/jedis/HostAndPorts.java
+++ b/src/test/java/redis/clients/jedis/HostAndPorts.java
@@ -8,14 +8,14 @@ public final class HostAndPorts {
 
   private static HashMap<String, EndpointConfig> endpointConfigs;
 
-  private static List<HostAndPort> redisHostAndPortList = new ArrayList<>();
   private static List<HostAndPort> sentinelHostAndPortList = new ArrayList<>();
   private static List<HostAndPort> clusterHostAndPortList = new ArrayList<>();
   private static List<HostAndPort> stableClusterHostAndPortList = new ArrayList<>();
 
   static {
+    String endpointsPath = System.getenv().getOrDefault("REDIS_ENDPOINTS_CONFIG_PATH", "src/test/resources/endpoints.json");
     try {
-      endpointConfigs = EndpointConfig.loadFromJSON("src/test/resources/endpoints.json");
+      endpointConfigs = EndpointConfig.loadFromJSON(endpointsPath);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/redis/clients/jedis/HostAndPorts.java
+++ b/src/test/java/redis/clients/jedis/HostAndPorts.java
@@ -43,6 +43,10 @@ public final class HostAndPorts {
   }
 
   public static EndpointConfig getRedisEndpoint(String endpointName) {
+    if (!endpointConfigs.containsKey(endpointName)) {
+      throw new IllegalArgumentException("Unknown Redis endpoint: " + endpointName);
+    }
+
     return endpointConfigs.get(endpointName);
   }
 

--- a/src/test/java/redis/clients/jedis/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPoolTest.java
@@ -22,13 +22,15 @@ import redis.clients.jedis.exceptions.JedisException;
 
 public class JedisPoolTest {
 
-  private static final HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static final EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone0");
+
+  private static final EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("standalone1");
 
   @Test
   public void checkConnections() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000);
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
@@ -38,7 +40,7 @@ public class JedisPoolTest {
 
   @Test
   public void checkResourceWithConfig() {
-    try (JedisPool pool = new JedisPool(HostAndPorts.getRedisServers().get(7),
+    try (JedisPool pool = new JedisPool(HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy").getHostAndPort(),
         DefaultJedisClientConfig.builder().socketTimeoutMillis(5000).build())) {
 
       try (Jedis jedis = pool.getResource()) {
@@ -51,9 +53,9 @@ public class JedisPoolTest {
 
   @Test
   public void checkCloseableConnections() throws Exception {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000);
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000);
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
@@ -65,7 +67,7 @@ public class JedisPoolTest {
   public void checkConnectionWithDefaultHostAndPort() {
     JedisPool pool = new JedisPool(new JedisPoolConfig());
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
@@ -78,7 +80,7 @@ public class JedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared", 0,
+    try (JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort(), 2000, endpoint1.getPassword(), 0,
         "closable-reusable-pool", false, null, null, null)) {
 
       Jedis jedis = pool.getResource();
@@ -94,15 +96,15 @@ public class JedisPoolTest {
 
   @Test
   public void checkPoolRepairedWhenJedisIsBroken() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort());
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort());
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
       jedis.set("foo", "0");
       jedis.disconnect();
     }
 
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
       jedis.incr("foo");
     }
     pool.close();
@@ -114,12 +116,12 @@ public class JedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort());
+    try (JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort());
         Jedis jedis = pool.getResource()) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
 
       try (Jedis jedis2 = pool.getResource()) {
-        jedis2.auth("foobared");
+        jedis2.auth(endpoint1.getPassword());
       }
     }
   }
@@ -128,7 +130,7 @@ public class JedisPoolTest {
   public void securePool() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared");
+    JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort(), 2000, endpoint1.getPassword());
     try (Jedis jedis = pool.getResource()) {
       jedis.set("foo", "bar");
     }
@@ -138,27 +140,27 @@ public class JedisPoolTest {
 
   @Test
   public void nonDefaultDatabase() {
-    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared"); Jedis jedis0 = pool0.getResource()) {
+    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
+        endpoint1.getPassword()); Jedis jedis0 = pool0.getResource()) {
       jedis0.set("foo", "bar");
       assertEquals("bar", jedis0.get("foo"));
     }
 
-    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared", 1); Jedis jedis1 = pool1.getResource()) {
+    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
+        endpoint1.getPassword(), 1); Jedis jedis1 = pool1.getResource()) {
       assertNull(jedis1.get("foo"));
     }
   }
 
   @Test
   public void startWithUrlString() {
-    try (Jedis j = new Jedis("localhost", 6380)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(endpoint2.getHostAndPort())) {
+      j.auth(endpoint2.getPassword());
       j.select(2);
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool("redis://:foobared@localhost:6380/2");
+    try (JedisPool pool = new JedisPool(endpoint2.getCustomizedURI("", endpoint2.getPassword(), "/2"));
         Jedis jedis = pool.getResource()) {
       assertEquals("PONG", jedis.ping());
       assertEquals("bar", jedis.get("foo"));
@@ -167,13 +169,13 @@ public class JedisPoolTest {
 
   @Test
   public void startWithUrl() throws URISyntaxException {
-    try (Jedis j = new Jedis("localhost", 6380)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(endpoint2.getHostAndPort())) {
+      j.auth(endpoint2.getPassword());
       j.select(2);
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool(new URI("redis://:foobared@localhost:6380/2"));
+    try (JedisPool pool = new JedisPool(endpoint2.getCustomizedURI("", endpoint2.getPassword(), "/2"));
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
@@ -186,14 +188,14 @@ public class JedisPoolTest {
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() throws URISyntaxException {
-    new JedisPool("redis://localhost:6380").close();
-    new JedisPool(new URI("redis://localhost:6380")).close();
+    new JedisPool(endpoint2.getURI().toString()).close();
+    new JedisPool(endpoint2.getURI()).close();
   }
 
   @Test
   public void selectDatabaseOnActivation() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared")) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
+        endpoint1.getPassword())) {
 
       Jedis jedis0 = pool.getResource();
       assertEquals(0, jedis0.getDB());
@@ -213,8 +215,8 @@ public class JedisPoolTest {
 
   @Test
   public void customClientName() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared", 0, "my_shiny_client_name"); Jedis jedis = pool.getResource()) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
+        endpoint1.getPassword(), 0, "my_shiny_client_name"); Jedis jedis = pool.getResource()) {
 
       assertEquals("my_shiny_client_name", jedis.clientGetname());
     }
@@ -222,8 +224,8 @@ public class JedisPoolTest {
 
   @Test
   public void invalidClientName() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared", 0, "invalid client name"); Jedis jedis = pool.getResource()) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
+        endpoint1.getPassword(), 0, "invalid client name"); Jedis jedis = pool.getResource()) {
     } catch (Exception e) {
       if (!e.getMessage().startsWith("client info cannot contain space")) {
         Assert.fail("invalid client name test fail");
@@ -287,7 +289,7 @@ public class JedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, hnp.getHost(), hnp.getPort(), 2000, "foobared");
+    JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort(), 2000, endpoint1.getPassword());
 
     Jedis jedis = pool.getResource();
     try {
@@ -312,8 +314,8 @@ public class JedisPoolTest {
 
   @Test
   public void getNumActiveWhenPoolIsClosed() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "foobared", 0, "my_shiny_client_name");
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
+        endpoint1.getPassword(), 0, "my_shiny_client_name");
 
     try (Jedis j = pool.getResource()) {
       j.ping();
@@ -325,16 +327,16 @@ public class JedisPoolTest {
 
   @Test
   public void getNumActiveReturnsTheCorrectNumber() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
       Jedis jedis = pool.getResource();
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
 
       assertEquals(1, pool.getNumActive());
 
       Jedis jedis2 = pool.getResource();
-      jedis.auth("foobared");
+      jedis.auth(endpoint1.getPassword());
       jedis.set("foo", "bar");
 
       assertEquals(2, pool.getNumActive());
@@ -350,7 +352,7 @@ public class JedisPoolTest {
 
   @Test
   public void testAddObject() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
       pool.addObjects(1);
       assertEquals(1, pool.getNumIdle());
     }
@@ -358,9 +360,9 @@ public class JedisPoolTest {
 
   @Test
   public void closeResourceTwice() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
       Jedis j = pool.getResource();
-      j.auth("foobared");
+      j.auth(endpoint1.getPassword());
       j.ping();
       j.close();
       j.close();
@@ -369,7 +371,7 @@ public class JedisPoolTest {
 
   @Test
   public void closeBrokenResourceTwice() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
       Jedis j = pool.getResource();
       try {
         // make connection broken
@@ -388,8 +390,8 @@ public class JedisPoolTest {
   public void testCloseConnectionOnMakeObject() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), hnp.getHost(), hnp.getPort(), 2000,
-        "wrong pass"); Jedis jedis = new Jedis("redis://:foobared@localhost:6379/")) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
+        "wrong pass"); Jedis jedis = new Jedis(endpoint1.getCustomizedURI(true, ""))) {
       int currentClientCount = getClientCount(jedis.clientList());
       try {
         pool.getResource();
@@ -407,8 +409,8 @@ public class JedisPoolTest {
   @Test
   public void testResetInvalidCredentials() {
     DefaultRedisCredentialsProvider credentialsProvider
-        = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, "foobared"));
-    JedisFactory factory = new JedisFactory(hnp, DefaultJedisClientConfig.builder()
+        = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, endpoint1.getPassword()));
+    JedisFactory factory = new JedisFactory(endpoint1.getHostAndPort(), DefaultJedisClientConfig.builder()
         .credentialsProvider(credentialsProvider).clientName("my_shiny_client_name").build());
 
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), factory)) {
@@ -437,7 +439,7 @@ public class JedisPoolTest {
   public void testResetValidCredentials() {
     DefaultRedisCredentialsProvider credentialsProvider
         = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, "bad password"));
-    JedisFactory factory = new JedisFactory(hnp, DefaultJedisClientConfig.builder()
+    JedisFactory factory = new JedisFactory(endpoint1.getHostAndPort(), DefaultJedisClientConfig.builder()
         .credentialsProvider(credentialsProvider).clientName("my_shiny_client_name").build());
 
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), factory)) {
@@ -446,7 +448,7 @@ public class JedisPoolTest {
       } catch (JedisException e) { }
       assertEquals(0, pool.getNumActive());
 
-      credentialsProvider.setCredentials(new DefaultRedisCredentials(null, "foobared"));
+      credentialsProvider.setCredentials(new DefaultRedisCredentials(null, endpoint1.getPassword()));
       try (Jedis obj2 = pool.getResource()) {
         obj2.set("foo", "bar");
         assertEquals("bar", obj2.get("foo"));

--- a/src/test/java/redis/clients/jedis/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPoolTest.java
@@ -22,15 +22,15 @@ import redis.clients.jedis.exceptions.JedisException;
 
 public class JedisPoolTest {
 
-  private static final EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone0");
+  private static final EndpointConfig endpointStandalone0 = HostAndPorts.getRedisEndpoint("standalone0");
 
-  private static final EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("standalone1");
+  private static final EndpointConfig endpointStandalone1 = HostAndPorts.getRedisEndpoint("standalone1");
 
   @Test
   public void checkConnections() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000);
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000);
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
@@ -53,9 +53,9 @@ public class JedisPoolTest {
 
   @Test
   public void checkCloseableConnections() throws Exception {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000);
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000);
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
@@ -67,7 +67,7 @@ public class JedisPoolTest {
   public void checkConnectionWithDefaultHostAndPort() {
     JedisPool pool = new JedisPool(new JedisPoolConfig());
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
     }
@@ -80,7 +80,7 @@ public class JedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort(), 2000, endpoint1.getPassword(), 0,
+    try (JedisPool pool = new JedisPool(config, endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000, endpointStandalone0.getPassword(), 0,
         "closable-reusable-pool", false, null, null, null)) {
 
       Jedis jedis = pool.getResource();
@@ -96,15 +96,15 @@ public class JedisPoolTest {
 
   @Test
   public void checkPoolRepairedWhenJedisIsBroken() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort());
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort());
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
       jedis.set("foo", "0");
       jedis.disconnect();
     }
 
     try (Jedis jedis = pool.getResource()) {
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
       jedis.incr("foo");
     }
     pool.close();
@@ -116,12 +116,12 @@ public class JedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort());
+    try (JedisPool pool = new JedisPool(config, endpointStandalone0.getHost(), endpointStandalone0.getPort());
         Jedis jedis = pool.getResource()) {
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
 
       try (Jedis jedis2 = pool.getResource()) {
-        jedis2.auth(endpoint1.getPassword());
+        jedis2.auth(endpointStandalone0.getPassword());
       }
     }
   }
@@ -130,7 +130,7 @@ public class JedisPoolTest {
   public void securePool() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort(), 2000, endpoint1.getPassword());
+    JedisPool pool = new JedisPool(config, endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000, endpointStandalone0.getPassword());
     try (Jedis jedis = pool.getResource()) {
       jedis.set("foo", "bar");
     }
@@ -140,27 +140,28 @@ public class JedisPoolTest {
 
   @Test
   public void nonDefaultDatabase() {
-    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
-        endpoint1.getPassword()); Jedis jedis0 = pool0.getResource()) {
+    try (JedisPool pool0 = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000,
+        endpointStandalone0.getPassword()); Jedis jedis0 = pool0.getResource()) {
       jedis0.set("foo", "bar");
       assertEquals("bar", jedis0.get("foo"));
     }
 
-    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
-        endpoint1.getPassword(), 1); Jedis jedis1 = pool1.getResource()) {
+    try (JedisPool pool1 = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000,
+        endpointStandalone0.getPassword(), 1); Jedis jedis1 = pool1.getResource()) {
       assertNull(jedis1.get("foo"));
     }
   }
 
   @Test
   public void startWithUrlString() {
-    try (Jedis j = new Jedis(endpoint2.getHostAndPort())) {
-      j.auth(endpoint2.getPassword());
+    try (Jedis j = new Jedis(endpointStandalone1.getHostAndPort())) {
+      j.auth(endpointStandalone1.getPassword());
       j.select(2);
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool(endpoint2.getCustomizedURI("", endpoint2.getPassword(), "/2"));
+    try (JedisPool pool = new JedisPool(
+        endpointStandalone1.getURIBuilder().credentials("", endpointStandalone1.getPassword()).path("/2").build());
         Jedis jedis = pool.getResource()) {
       assertEquals("PONG", jedis.ping());
       assertEquals("bar", jedis.get("foo"));
@@ -169,13 +170,14 @@ public class JedisPoolTest {
 
   @Test
   public void startWithUrl() throws URISyntaxException {
-    try (Jedis j = new Jedis(endpoint2.getHostAndPort())) {
-      j.auth(endpoint2.getPassword());
+    try (Jedis j = new Jedis(endpointStandalone1.getHostAndPort())) {
+      j.auth(endpointStandalone1.getPassword());
       j.select(2);
       j.set("foo", "bar");
     }
 
-    try (JedisPool pool = new JedisPool(endpoint2.getCustomizedURI("", endpoint2.getPassword(), "/2"));
+    try (JedisPool pool = new JedisPool(
+        endpointStandalone1.getURIBuilder().credentials("", endpointStandalone1.getPassword()).path("/2").build());
         Jedis jedis = pool.getResource()) {
       assertEquals("bar", jedis.get("foo"));
     }
@@ -188,14 +190,14 @@ public class JedisPoolTest {
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() throws URISyntaxException {
-    new JedisPool(endpoint2.getURI().toString()).close();
-    new JedisPool(endpoint2.getURI()).close();
+    new JedisPool(endpointStandalone1.getURI().toString()).close();
+    new JedisPool(endpointStandalone1.getURI()).close();
   }
 
   @Test
   public void selectDatabaseOnActivation() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
-        endpoint1.getPassword())) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000,
+        endpointStandalone0.getPassword())) {
 
       Jedis jedis0 = pool.getResource();
       assertEquals(0, jedis0.getDB());
@@ -215,8 +217,8 @@ public class JedisPoolTest {
 
   @Test
   public void customClientName() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
-        endpoint1.getPassword(), 0, "my_shiny_client_name"); Jedis jedis = pool.getResource()) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000,
+        endpointStandalone0.getPassword(), 0, "my_shiny_client_name"); Jedis jedis = pool.getResource()) {
 
       assertEquals("my_shiny_client_name", jedis.clientGetname());
     }
@@ -224,8 +226,8 @@ public class JedisPoolTest {
 
   @Test
   public void invalidClientName() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
-        endpoint1.getPassword(), 0, "invalid client name"); Jedis jedis = pool.getResource()) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000,
+        endpointStandalone0.getPassword(), 0, "invalid client name"); Jedis jedis = pool.getResource()) {
     } catch (Exception e) {
       if (!e.getMessage().startsWith("client info cannot contain space")) {
         Assert.fail("invalid client name test fail");
@@ -289,7 +291,7 @@ public class JedisPoolTest {
     GenericObjectPoolConfig<Jedis> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    JedisPool pool = new JedisPool(config, endpoint1.getHost(), endpoint1.getPort(), 2000, endpoint1.getPassword());
+    JedisPool pool = new JedisPool(config, endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000, endpointStandalone0.getPassword());
 
     Jedis jedis = pool.getResource();
     try {
@@ -314,8 +316,8 @@ public class JedisPoolTest {
 
   @Test
   public void getNumActiveWhenPoolIsClosed() {
-    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
-        endpoint1.getPassword(), 0, "my_shiny_client_name");
+    JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000,
+        endpointStandalone0.getPassword(), 0, "my_shiny_client_name");
 
     try (Jedis j = pool.getResource()) {
       j.ping();
@@ -327,16 +329,16 @@ public class JedisPoolTest {
 
   @Test
   public void getNumActiveReturnsTheCorrectNumber() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000)) {
       Jedis jedis = pool.getResource();
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
       jedis.set("foo", "bar");
       assertEquals("bar", jedis.get("foo"));
 
       assertEquals(1, pool.getNumActive());
 
       Jedis jedis2 = pool.getResource();
-      jedis.auth(endpoint1.getPassword());
+      jedis.auth(endpointStandalone0.getPassword());
       jedis.set("foo", "bar");
 
       assertEquals(2, pool.getNumActive());
@@ -352,7 +354,7 @@ public class JedisPoolTest {
 
   @Test
   public void testAddObject() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000)) {
       pool.addObjects(1);
       assertEquals(1, pool.getNumIdle());
     }
@@ -360,9 +362,9 @@ public class JedisPoolTest {
 
   @Test
   public void closeResourceTwice() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000)) {
       Jedis j = pool.getResource();
-      j.auth(endpoint1.getPassword());
+      j.auth(endpointStandalone0.getPassword());
       j.ping();
       j.close();
       j.close();
@@ -371,7 +373,7 @@ public class JedisPoolTest {
 
   @Test
   public void closeBrokenResourceTwice() {
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(), endpointStandalone0.getPort(), 2000)) {
       Jedis j = pool.getResource();
       try {
         // make connection broken
@@ -390,8 +392,9 @@ public class JedisPoolTest {
   public void testCloseConnectionOnMakeObject() {
     JedisPoolConfig config = new JedisPoolConfig();
     config.setTestOnBorrow(true);
-    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000,
-        "wrong pass"); Jedis jedis = new Jedis(endpoint1.getCustomizedURI(true, ""))) {
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(), endpointStandalone0.getHost(),
+        endpointStandalone0.getPort(), 2000, "wrong pass");
+        Jedis jedis = new Jedis(endpointStandalone0.getURIBuilder().defaultCredentials().build())) {
       int currentClientCount = getClientCount(jedis.clientList());
       try {
         pool.getResource();
@@ -409,8 +412,8 @@ public class JedisPoolTest {
   @Test
   public void testResetInvalidCredentials() {
     DefaultRedisCredentialsProvider credentialsProvider
-        = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, endpoint1.getPassword()));
-    JedisFactory factory = new JedisFactory(endpoint1.getHostAndPort(), DefaultJedisClientConfig.builder()
+        = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, endpointStandalone0.getPassword()));
+    JedisFactory factory = new JedisFactory(endpointStandalone0.getHostAndPort(), DefaultJedisClientConfig.builder()
         .credentialsProvider(credentialsProvider).clientName("my_shiny_client_name").build());
 
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), factory)) {
@@ -439,7 +442,7 @@ public class JedisPoolTest {
   public void testResetValidCredentials() {
     DefaultRedisCredentialsProvider credentialsProvider
         = new DefaultRedisCredentialsProvider(new DefaultRedisCredentials(null, "bad password"));
-    JedisFactory factory = new JedisFactory(endpoint1.getHostAndPort(), DefaultJedisClientConfig.builder()
+    JedisFactory factory = new JedisFactory(endpointStandalone0.getHostAndPort(), DefaultJedisClientConfig.builder()
         .credentialsProvider(credentialsProvider).clientName("my_shiny_client_name").build());
 
     try (JedisPool pool = new JedisPool(new JedisPoolConfig(), factory)) {
@@ -448,7 +451,7 @@ public class JedisPoolTest {
       } catch (JedisException e) { }
       assertEquals(0, pool.getNumActive());
 
-      credentialsProvider.setCredentials(new DefaultRedisCredentials(null, endpoint1.getPassword()));
+      credentialsProvider.setCredentials(new DefaultRedisCredentials(null, endpointStandalone0.getPassword()));
       try (Jedis obj2 = pool.getResource()) {
         obj2.set("foo", "bar");
         assertEquals("bar", obj2.get("foo"));

--- a/src/test/java/redis/clients/jedis/JedisPooledTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPooledTest.java
@@ -21,12 +21,15 @@ import redis.clients.jedis.exceptions.JedisException;
 
 public class JedisPooledTest {
 
-  private static final EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy");
-  private static final EndpointConfig endpointStandalone1 = HostAndPorts.getRedisEndpoint("standalone1"); // password protected
+  private static final EndpointConfig endpointStandalone7 = HostAndPorts.getRedisEndpoint(
+      "standalone7-with-lfu-policy");
+  private static final EndpointConfig endpointStandalone1 = HostAndPorts.getRedisEndpoint(
+      "standalone1"); // password protected
 
   @Test
   public void checkCloseableConnections() {
-    JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000);
+    JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(), endpointStandalone7.getHost(),
+        endpointStandalone7.getPort(), 2000);
     pool.set("foo", "bar");
     assertEquals("bar", pool.get("foo"));
     pool.close();
@@ -35,7 +38,7 @@ public class JedisPooledTest {
 
   @Test
   public void checkResourceWithConfig() {
-    try (JedisPooled pool = new JedisPooled(endpoint1.getHostAndPort(),
+    try (JedisPooled pool = new JedisPooled(endpointStandalone7.getHostAndPort(),
         DefaultJedisClientConfig.builder().socketTimeoutMillis(5000).build())) {
 
       try (Connection jedis = pool.getPool().getResource()) {
@@ -50,7 +53,7 @@ public class JedisPooledTest {
     GenericObjectPoolConfig<Connection> config = new GenericObjectPoolConfig<>();
     config.setMaxTotal(1);
     config.setBlockWhenExhausted(false);
-    try (JedisPooled pool = new JedisPooled(endpoint1.getHostAndPort(), config);
+    try (JedisPooled pool = new JedisPooled(endpointStandalone7.getHostAndPort(), config);
         Connection jedis = pool.getPool().getResource()) {
 
       try (Connection jedis2 = pool.getPool().getResource()) {
@@ -100,7 +103,7 @@ public class JedisPooledTest {
 
   @Test
   public void customClientName() {
-    try (JedisPooled pool = new JedisPooled(endpoint1.getHostAndPort(), DefaultJedisClientConfig.builder()
+    try (JedisPooled pool = new JedisPooled(endpointStandalone7.getHostAndPort(), DefaultJedisClientConfig.builder()
         .clientName("my_shiny_client_name").build());
         Connection jedis = pool.getPool().getResource()) {
       assertEquals("my_shiny_client_name", new Jedis(jedis).clientGetname());
@@ -109,7 +112,7 @@ public class JedisPooledTest {
 
   @Test
   public void invalidClientName() {
-    try (JedisPooled pool = new JedisPooled(endpoint1.getHostAndPort(), DefaultJedisClientConfig.builder()
+    try (JedisPooled pool = new JedisPooled(endpointStandalone7.getHostAndPort(), DefaultJedisClientConfig.builder()
         .clientName("invalid client name").build());
          Connection jedis = pool.getPool().getResource()) {
     } catch (Exception e) {
@@ -121,7 +124,7 @@ public class JedisPooledTest {
 
   @Test
   public void getNumActiveWhenPoolIsClosed() {
-    JedisPooled pool = new JedisPooled(endpoint1.getHostAndPort());
+    JedisPooled pool = new JedisPooled(endpointStandalone7.getHostAndPort());
 
     try (Connection j = pool.getPool().getResource()) {
       j.ping();
@@ -133,7 +136,8 @@ public class JedisPooledTest {
 
   @Test
   public void getNumActiveReturnsTheCorrectNumber() {
-    try (JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
+    try (JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(),
+        endpointStandalone7.getHost(), endpointStandalone7.getPort(), 2000)) {
 
       Connection jedis = pool.getPool().getResource();
       assertEquals(1, pool.getPool().getNumActive());
@@ -151,7 +155,8 @@ public class JedisPooledTest {
 
   @Test
   public void closeResourceTwice() {
-    try (JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
+    try (JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(),
+        endpointStandalone7.getHost(), endpointStandalone7.getPort(), 2000)) {
       Connection j = pool.getPool().getResource();
       j.ping();
       j.close();
@@ -161,7 +166,8 @@ public class JedisPooledTest {
 
   @Test
   public void closeBrokenResourceTwice() {
-    try (JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(), endpoint1.getHost(), endpoint1.getPort(), 2000)) {
+    try (JedisPooled pool = new JedisPooled(new ConnectionPoolConfig(),
+        endpointStandalone7.getHost(), endpointStandalone7.getPort(), 2000)) {
       Connection j = pool.getPool().getResource();
       try {
         // make connection broken

--- a/src/test/java/redis/clients/jedis/JedisSentinelPoolTest.java
+++ b/src/test/java/redis/clients/jedis/JedisSentinelPoolTest.java
@@ -18,9 +18,6 @@ public class JedisSentinelPoolTest {
 
   private static final String MASTER_NAME = "mymaster";
 
-  //protected static HostAndPort master = HostAndPorts.getRedisServers().get(2);
-  //protected static HostAndPort slave1 = HostAndPorts.getRedisServers().get(3);
-
   protected static final HostAndPort sentinel1 = HostAndPorts.getSentinelServers().get(1);
   protected static final HostAndPort sentinel2 = HostAndPorts.getSentinelServers().get(3);
 

--- a/src/test/java/redis/clients/jedis/JedisSentinelTest.java
+++ b/src/test/java/redis/clients/jedis/JedisSentinelTest.java
@@ -24,12 +24,10 @@ public class JedisSentinelTest {
   private static final String FAILOVER_MASTER_NAME = "mymasterfailover";
   private static final String MASTER_IP = "127.0.0.1";
 
-  protected static HostAndPort master = HostAndPorts.getRedisServers().get(0);
-  protected static HostAndPort slave = HostAndPorts.getRedisServers().get(4);
+  protected static EndpointConfig master = HostAndPorts.getRedisEndpoint("standalone0");
   protected static HostAndPort sentinel = HostAndPorts.getSentinelServers().get(0);
 
   protected static HostAndPort sentinelForFailover = HostAndPorts.getSentinelServers().get(2);
-  protected static HostAndPort masterForFailover = HostAndPorts.getRedisServers().get(5);
 
   @Before
   public void setup() throws InterruptedException {

--- a/src/test/java/redis/clients/jedis/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/JedisTest.java
@@ -36,7 +36,7 @@ public class JedisTest extends JedisCommandsTestBase {
   @Test
   public void useWithoutConnecting() {
     try (Jedis j = new Jedis()) {
-      j.auth("foobared");
+      j.auth(endpoint.getPassword());
       j.dbSize();
     }
   }
@@ -240,15 +240,17 @@ public class JedisTest extends JedisCommandsTestBase {
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() {
-    try (Jedis j1 = new Jedis("redis://localhost:6380")) {
-      j1.auth("foobared");
+    EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone1");
+
+    try (Jedis j1 = new Jedis(endpoint1.getURI().toString())) {
+      j1.auth(endpoint1.getPassword());
 //      assertEquals("localhost", j1.getClient().getHost());
 //      assertEquals(6380, j1.getClient().getPort());
       assertEquals(0, j1.getDB());
     }
 
-    try (Jedis j2 = new Jedis("redis://localhost:6380/")) {
-      j2.auth("foobared");
+    try (Jedis j2 = new Jedis(endpoint1.getURI().toString())) {
+      j2.auth(endpoint1.getPassword());
 //      assertEquals("localhost", j2.getClient().getHost());
 //      assertEquals(6380, j2.getClient().getPort());
       assertEquals(0, j2.getDB());
@@ -288,7 +290,7 @@ public class JedisTest extends JedisCommandsTestBase {
   @Test
   public void checkCloseableAfterCommand() {
     Jedis bj = new Jedis();
-    bj.auth("foobared");
+    bj.auth(endpoint.getPassword());
     bj.close();
   }
 

--- a/src/test/java/redis/clients/jedis/JedisTest.java
+++ b/src/test/java/redis/clients/jedis/JedisTest.java
@@ -60,7 +60,8 @@ public class JedisTest extends JedisCommandsTestBase {
       jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
-    try (Jedis jedis = endpoint.getJedis()) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().build())) {
       assertEquals("PONG", jedis.ping());
     }
   }
@@ -108,7 +109,9 @@ public class JedisTest extends JedisCommandsTestBase {
   public void timeoutConnection() throws Exception {
     final String TIMEOUT_STR = "timeout";
 
-    Jedis jedis = endpoint.getJedis(15000);
+    Jedis jedis = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().timeoutMillis(15000).build());
+
     // read current config
     final String timeout = jedis.configGet(TIMEOUT_STR).get(TIMEOUT_STR);
     try {
@@ -123,7 +126,7 @@ public class JedisTest extends JedisCommandsTestBase {
       jedis.close();
     } finally {
       // reset config
-      jedis = endpoint.getJedis();
+      jedis = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder().build());
       jedis.configSet(TIMEOUT_STR, timeout);
       jedis.close();
     }
@@ -172,7 +175,8 @@ public class JedisTest extends JedisCommandsTestBase {
       j.set("foo", "bar");
     }
 
-    try (Jedis j2 = new Jedis(endpoint.getCustomizedURI(true, "/2").toString())) {
+    try (Jedis j2 = new Jedis(
+        endpoint.getURIBuilder().defaultCredentials().path("/2").build().toString())) {
       assertEquals("PONG", j2.ping());
       assertEquals("bar", j2.get("foo"));
     }
@@ -187,7 +191,8 @@ public class JedisTest extends JedisCommandsTestBase {
       j.set("foo", "bar");
     }
 
-    try (Jedis jedis = new Jedis(endpoint.getCustomizedURI(true, "/2"))) {
+    try (Jedis jedis = new Jedis(
+        endpoint.getURIBuilder().defaultCredentials().path("/2").build())) {
       assertEquals("PONG", jedis.ping());
       assertEquals("bar", jedis.get("foo"));
     }
@@ -203,7 +208,8 @@ public class JedisTest extends JedisCommandsTestBase {
       j.set("foo", "bar");
     }
 
-    try (Jedis j2 = new Jedis(endpoint.getCustomizedURI(true, "/2?protocol=3").toString())) {
+    try (Jedis j2 = new Jedis(
+        endpoint.getURIBuilder().defaultCredentials().path("/2?protocol=3").build().toString())) {
       assertEquals("PONG", j2.ping());
       assertEquals("bar", j2.get("foo"));
     }
@@ -219,7 +225,8 @@ public class JedisTest extends JedisCommandsTestBase {
       j.set("foo", "bar");
     }
 
-    try (Jedis jedis = new Jedis(endpoint.getCustomizedURI(true, "/2?protocol=3"))) {
+    try (Jedis jedis = new Jedis(
+        endpoint.getURIBuilder().defaultCredentials().path("/2?protocol=3").build())) {
       assertEquals("PONG", jedis.ping());
       assertEquals("bar", jedis.get("foo"));
     }
@@ -240,17 +247,17 @@ public class JedisTest extends JedisCommandsTestBase {
 
   @Test
   public void allowUrlWithNoDBAndNoPassword() {
-    EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone1");
+    EndpointConfig endpointStandalone1 = HostAndPorts.getRedisEndpoint("standalone1");
 
-    try (Jedis j1 = new Jedis(endpoint1.getURI().toString())) {
-      j1.auth(endpoint1.getPassword());
+    try (Jedis j1 = new Jedis(endpointStandalone1.getURI().toString())) {
+      j1.auth(endpointStandalone1.getPassword());
 //      assertEquals("localhost", j1.getClient().getHost());
 //      assertEquals(6380, j1.getClient().getPort());
       assertEquals(0, j1.getDB());
     }
 
-    try (Jedis j2 = new Jedis(endpoint1.getURI().toString())) {
-      j2.auth(endpoint1.getPassword());
+    try (Jedis j2 = new Jedis(endpointStandalone1.getURI().toString())) {
+      j2.auth(endpointStandalone1.getPassword());
 //      assertEquals("localhost", j2.getClient().getHost());
 //      assertEquals(6380, j2.getClient().getPort());
       assertEquals(0, j2.getDB());

--- a/src/test/java/redis/clients/jedis/ManagedConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/ManagedConnectionProviderTest.java
@@ -14,7 +14,8 @@ public class ManagedConnectionProviderTest {
 
   @Before
   public void setUp() {
-    connection = HostAndPorts.getRedisEndpoint("standalone0").getConnection();
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
+    connection = new Connection(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder().build());
   }
 
   @After

--- a/src/test/java/redis/clients/jedis/ManagedConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/ManagedConnectionProviderTest.java
@@ -14,8 +14,7 @@ public class ManagedConnectionProviderTest {
 
   @Before
   public void setUp() {
-    connection = new Connection(HostAndPorts.getRedisServers().get(0),
-        DefaultJedisClientConfig.builder().user("acljedis").password("fizzbuzz").build());
+    connection = HostAndPorts.getRedisEndpoint("standalone0").getConnection();
   }
 
   @After

--- a/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
@@ -33,9 +33,17 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
   private static final byte[] bfoo3 = { 0x07, 0x08, 0x03 };
   private static final byte[] bbar3 = { 0x09, 0x00, 0x03 };
 
-  private static final String host = endpoint.getHost();
-  private static final int port = 6386;
-  private static final int portAuth = endpoint.getPort() + 1;
+  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0-acl");
+
+  private static final EndpointConfig destEndpoint = HostAndPorts.getRedisEndpoint(
+      "standalone7-with-lfu-policy");
+
+  private static final EndpointConfig destEndpointWithAuth = HostAndPorts.getRedisEndpoint(
+      "standalone1");
+
+  private static final String host = destEndpoint.getHost();
+  private static final int port = destEndpoint.getPort();
+  private static final int portAuth = destEndpointWithAuth.getPort();
   private static final int db = 2;
   private static final int dbAuth = 3;
   private static final int timeout = Protocol.DEFAULT_TIMEOUT;
@@ -56,8 +64,8 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     dest.flushAll();
     dest.select(db);
 
-    destAuth = new Jedis(host, portAuth, 500);
-    destAuth.auth(endpoint.getPassword());
+    destAuth = new Jedis(destEndpointWithAuth.getHostAndPort(),
+        destEndpointWithAuth.getClientConfigBuilder().build());
     destAuth.flushAll();
     destAuth.select(dbAuth);
   }
@@ -258,7 +266,8 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     Pipeline p = jedis.pipelined();
 
     p.set("foo", "bar");
-    p.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), "foo");
+    p.migrate(host, portAuth, dbAuth, timeout,
+        new MigrateParams().auth(destEndpointWithAuth.getPassword()), "foo");
     p.get("foo");
 
     assertThat(p.syncAndReturnAll(),
@@ -274,7 +283,8 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     Pipeline p = jedis.pipelined();
 
     p.set(bfoo, bbar);
-    p.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), bfoo);
+    p.migrate(host, portAuth, dbAuth, timeout,
+        new MigrateParams().auth(destEndpointWithAuth.getPassword()), bfoo);
     p.get(bfoo);
 
     assertThat(p.syncAndReturnAll(),
@@ -287,13 +297,12 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
   public void migrateAuth2() {
     assertNull(jedis.get("foo"));
 
-
-
     Pipeline p = destAuth.pipelined();
 
     p.set("foo", "bar");
-    p.migrate(host, endpoint.getPort(), 0, timeout,
-        new MigrateParams().auth2("acljedis", "fizzbuzz"), "foo");
+    p.migrate(endpoint.getHost(), endpoint.getPort(), 0, timeout,
+        new MigrateParams().auth2(endpoint.getUsername(), endpoint.getPassword()),
+        "foo");
     p.get("foo");
 
     assertThat(p.syncAndReturnAll(),
@@ -309,8 +318,9 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     Pipeline p = dest.pipelined();
 
     p.set(bfoo, bbar);
-    p.migrate(host, endpoint.getPort(), 0, timeout,
-        new MigrateParams().auth2("acljedis", "fizzbuzz"), bfoo);
+    p.migrate(endpoint.getHost(), endpoint.getPort(), 0, timeout,
+        new MigrateParams().auth2(endpoint.getUsername(), endpoint.getPassword()),
+        bfoo);
     p.get(bfoo);
 
     assertThat(p.syncAndReturnAll(),

--- a/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
@@ -57,7 +57,7 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     dest.select(db);
 
     destAuth = new Jedis(host, portAuth, 500);
-    destAuth.auth("foobared");
+    destAuth.auth(endpoint.getPassword());
     destAuth.flushAll();
     destAuth.select(dbAuth);
   }
@@ -258,7 +258,7 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     Pipeline p = jedis.pipelined();
 
     p.set("foo", "bar");
-    p.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), "foo");
+    p.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), "foo");
     p.get("foo");
 
     assertThat(p.syncAndReturnAll(),
@@ -274,7 +274,7 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     Pipeline p = jedis.pipelined();
 
     p.set(bfoo, bbar);
-    p.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), bfoo);
+    p.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), bfoo);
     p.get(bfoo);
 
     assertThat(p.syncAndReturnAll(),
@@ -286,6 +286,8 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
   @Test
   public void migrateAuth2() {
     assertNull(jedis.get("foo"));
+
+
 
     Pipeline p = destAuth.pipelined();
 

--- a/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/MigratePipeliningTest.java
@@ -33,9 +33,9 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
   private static final byte[] bfoo3 = { 0x07, 0x08, 0x03 };
   private static final byte[] bbar3 = { 0x09, 0x00, 0x03 };
 
-  private static final String host = hnp.getHost();
+  private static final String host = endpoint.getHost();
   private static final int port = 6386;
-  private static final int portAuth = hnp.getPort() + 1;
+  private static final int portAuth = endpoint.getPort() + 1;
   private static final int db = 2;
   private static final int dbAuth = 3;
   private static final int timeout = Protocol.DEFAULT_TIMEOUT;
@@ -290,7 +290,7 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     Pipeline p = destAuth.pipelined();
 
     p.set("foo", "bar");
-    p.migrate(host, hnp.getPort(), 0, timeout,
+    p.migrate(host, endpoint.getPort(), 0, timeout,
         new MigrateParams().auth2("acljedis", "fizzbuzz"), "foo");
     p.get("foo");
 
@@ -307,7 +307,7 @@ public class MigratePipeliningTest extends JedisCommandsTestBase {
     Pipeline p = dest.pipelined();
 
     p.set(bfoo, bbar);
-    p.migrate(host, hnp.getPort(), 0, timeout,
+    p.migrate(host, endpoint.getPort(), 0, timeout,
         new MigrateParams().auth2("acljedis", "fizzbuzz"), bfoo);
     p.get(bfoo);
 

--- a/src/test/java/redis/clients/jedis/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/PipeliningTest.java
@@ -547,7 +547,7 @@ public class PipeliningTest extends JedisCommandsTestBase {
   public void testCloseable() throws IOException {
     // we need to test with fresh instance of Jedis
     Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
-    jedis2.auth("foobared");
+    jedis2.auth(endpoint.getPassword());
 
     Pipeline pipeline = jedis2.pipelined();
     Response<String> retFuture1 = pipeline.set("a", "1");

--- a/src/test/java/redis/clients/jedis/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/PipeliningTest.java
@@ -323,7 +323,7 @@ public class PipeliningTest extends JedisCommandsTestBase {
     p.waitReplicas(1, 10);
     p.sync();
 
-    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone4");
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone4-replica-of-standalone1");
 
     try (Jedis j = new Jedis(endpoint.getHostAndPort())) {
       j.auth(endpoint.getPassword());
@@ -338,7 +338,7 @@ public class PipeliningTest extends JedisCommandsTestBase {
     p.waitAOF(1L, 0L, 0L);
     p.sync();
 
-    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone4");
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone4-replica-of-standalone1");
 
     try (Jedis j = new Jedis(endpoint.getHostAndPort())) {
       j.auth(endpoint.getPassword());

--- a/src/test/java/redis/clients/jedis/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/PipeliningTest.java
@@ -323,8 +323,10 @@ public class PipeliningTest extends JedisCommandsTestBase {
     p.waitReplicas(1, 10);
     p.sync();
 
-    try (Jedis j = new Jedis(HostAndPorts.getRedisServers().get(4))) {
-      j.auth("foobared");
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone4");
+
+    try (Jedis j = new Jedis(endpoint.getHostAndPort())) {
+      j.auth(endpoint.getPassword());
       assertEquals("replicas", j.get("wait"));
     }
   }
@@ -336,8 +338,10 @@ public class PipeliningTest extends JedisCommandsTestBase {
     p.waitAOF(1L, 0L, 0L);
     p.sync();
 
-    try (Jedis j = new Jedis(HostAndPorts.getRedisServers().get(4))) {
-      j.auth("foobared");
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone4");
+
+    try (Jedis j = new Jedis(endpoint.getHostAndPort())) {
+      j.auth(endpoint.getPassword());
       assertEquals("aof", j.get("wait"));
     }
   }
@@ -523,14 +527,14 @@ public class PipeliningTest extends JedisCommandsTestBase {
   @Test
   public void testSyncWithNoCommandQueued() {
     // we need to test with fresh instance of Jedis
-    Jedis jedis2 = new Jedis(hnp.getHost(), hnp.getPort(), 500);
+    Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
 
     Pipeline pipeline = jedis2.pipelined();
     pipeline.sync();
 
     jedis2.close();
 
-    jedis2 = new Jedis(hnp.getHost(), hnp.getPort(), 500);
+    jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
 
     pipeline = jedis2.pipelined();
     List<Object> resp = pipeline.syncAndReturnAll();
@@ -542,7 +546,7 @@ public class PipeliningTest extends JedisCommandsTestBase {
   @Test
   public void testCloseable() throws IOException {
     // we need to test with fresh instance of Jedis
-    Jedis jedis2 = new Jedis(hnp.getHost(), hnp.getPort(), 500);
+    Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
     jedis2.auth("foobared");
 
     Pipeline pipeline = jedis2.pipelined();

--- a/src/test/java/redis/clients/jedis/ReliableTransactionTest.java
+++ b/src/test/java/redis/clients/jedis/ReliableTransactionTest.java
@@ -30,9 +30,11 @@ public class ReliableTransactionTest {
 
   @Before
   public void setUp() throws Exception {
-    conn = endpoint.getConnection(500);
+    conn = new Connection(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().timeoutMillis(500).build());
 
-    nj = endpoint.getJedis(500);
+    nj = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().timeoutMillis(500).build());
     nj.flushAll();
   }
 

--- a/src/test/java/redis/clients/jedis/ReliableTransactionTest.java
+++ b/src/test/java/redis/clients/jedis/ReliableTransactionTest.java
@@ -23,16 +23,16 @@ public class ReliableTransactionTest {
 
   final byte[] bmykey = { 0x42, 0x02, 0x03, 0x04 };
 
-  private static final HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
 
   private Connection conn;
   private Jedis nj;
 
   @Before
   public void setUp() throws Exception {
-    conn = new Connection(hnp, DefaultJedisClientConfig.builder().timeoutMillis(500).password("foobared").build());
+    conn = endpoint.getConnection(500);
 
-    nj = new Jedis(hnp, DefaultJedisClientConfig.builder().timeoutMillis(500).password("foobared").build());
+    nj = endpoint.getJedis(500);
     nj.flushAll();
   }
 
@@ -211,10 +211,6 @@ public class ReliableTransactionTest {
 
   @Test
   public void testCloseable() {
-    // we need to test with fresh instance of Jedis
-//    Jedis jedis2 = new Jedis(hnp.getHost(), hnp.getPort(), 500);
-//    jedis2.auth("foobared");
-
     ReliableTransaction transaction = new ReliableTransaction(conn);
     transaction.set("a", "1");
     transaction.set("b", "2");

--- a/src/test/java/redis/clients/jedis/SSLACLJedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/SSLACLJedisClusterTest.java
@@ -43,6 +43,7 @@ public class SSLACLJedisClusterTest extends JedisClusterTestBase {
 
   @BeforeClass
   public static void prepare() {
+    // We need to set up certificates first before connecting to the endpoint with enabled TLS
     SSLJedisTest.setupTrustStore();
 
     // TODO(imalinovskyi): Remove hardcoded connection settings

--- a/src/test/java/redis/clients/jedis/SSLACLJedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/SSLACLJedisClusterTest.java
@@ -43,14 +43,14 @@ public class SSLACLJedisClusterTest extends JedisClusterTestBase {
 
   @BeforeClass
   public static void prepare() {
+    SSLJedisTest.setupTrustStore();
+
     // TODO(imalinovskyi): Remove hardcoded connection settings
     //  once this test is refactored to support RE
     org.junit.Assume.assumeTrue("Not running ACL test on this version of Redis",
             RedisVersionUtil.checkRedisMajorVersionNumber(6,
                     new EndpointConfig(new HostAndPort("localhost", 8379),
-                            "default", "cluster")));
-
-    SSLJedisTest.setupTrustStore();
+                            "default", "cluster", true)));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/SSLACLJedisClusterTest.java
+++ b/src/test/java/redis/clients/jedis/SSLACLJedisClusterTest.java
@@ -43,8 +43,12 @@ public class SSLACLJedisClusterTest extends JedisClusterTestBase {
 
   @BeforeClass
   public static void prepare() {
+    // TODO(imalinovskyi): Remove hardcoded connection settings
+    //  once this test is refactored to support RE
     org.junit.Assume.assumeTrue("Not running ACL test on this version of Redis",
-        RedisVersionUtil.checkRedisMajorVersionNumber(6));
+            RedisVersionUtil.checkRedisMajorVersionNumber(6,
+                    new EndpointConfig(new HostAndPort("localhost", 8379),
+                            "default", "cluster")));
 
     SSLJedisTest.setupTrustStore();
   }

--- a/src/test/java/redis/clients/jedis/SSLACLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/SSLACLJedisTest.java
@@ -28,8 +28,9 @@ public class SSLACLJedisTest {
 
   @BeforeClass
   public static void prepare() {
-    // Use to check if the ACL test should be ran. ACL are available only in 6.0 and later
+    // We need to set up certificates first before connecting to the endpoint with enabled TLS
     SSLJedisTest.setupTrustStore();
+    // Use to check if the ACL test should be ran. ACL are available only in 6.0 and later
     org.junit.Assume.assumeTrue("Not running ACL test on this version of Redis",
         RedisVersionUtil.checkRedisMajorVersionNumber(6, endpoint));
   }

--- a/src/test/java/redis/clients/jedis/SSLACLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/SSLACLJedisTest.java
@@ -54,10 +54,12 @@ public class SSLACLJedisTest {
   @Test
   public void connectWithUrl() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    try (Jedis jedis = new Jedis(endpointWithDefaultUser.getCustomizedURI(true, "").toString())) {
+    try (Jedis jedis = new Jedis(
+        endpointWithDefaultUser.getURIBuilder().defaultCredentials().build().toString())) {
       assertEquals("PONG", jedis.ping());
     }
-    try (Jedis jedis = new Jedis(endpoint.getCustomizedURI(true, "").toString())) {
+    try (Jedis jedis = new Jedis(
+        endpoint.getURIBuilder().defaultCredentials().build().toString())) {
       assertEquals("PONG", jedis.ping());
     }
   }
@@ -65,10 +67,11 @@ public class SSLACLJedisTest {
   @Test
   public void connectWithUri() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    try (Jedis jedis = new Jedis(endpointWithDefaultUser.getCustomizedURI(true, ""))) {
+    try (Jedis jedis = new Jedis(
+        endpointWithDefaultUser.getURIBuilder().defaultCredentials().build())) {
       assertEquals("PONG", jedis.ping());
     }
-    try (Jedis jedis = new Jedis(endpoint.getCustomizedURI(true, ""))) {
+    try (Jedis jedis = new Jedis(endpoint.getURIBuilder().defaultCredentials().build())) {
       assertEquals("PONG", jedis.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/SSLJedisTest.java
+++ b/src/test/java/redis/clients/jedis/SSLJedisTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.net.URI;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.SecureRandom;
@@ -26,6 +25,8 @@ import org.junit.Test;
 
 public class SSLJedisTest {
 
+  protected static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0-tls");
+
   @BeforeClass
   public static void prepare() {
     setupTrustStore();
@@ -44,31 +45,31 @@ public class SSLJedisTest {
 
   @Test
   public void connectWithSsl() {
-    try (Jedis jedis = new Jedis("localhost", 6390, true)) {
-      jedis.auth("foobared");
+    try (Jedis jedis = new Jedis(endpoint.getHost(), endpoint.getPort(), true)) {
+      jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
   }
 
   @Test
   public void connectWithConfig() {
-    try (Jedis jedis = new Jedis(new HostAndPort("localhost", 6390),
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
         DefaultJedisClientConfig.builder().ssl(true).build())) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
   }
 
   @Test
   public void connectWithConfigInterface() {
-    try (Jedis jedis = new Jedis(new HostAndPort("localhost", 6390),
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
         new JedisClientConfig() {
           @Override
           public boolean isSsl() {
             return true;
           }
         })) {
-      jedis.auth("foobared");
+      jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
   }
@@ -79,8 +80,8 @@ public class SSLJedisTest {
   @Test
   public void connectWithUrl() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    try (Jedis jedis = new Jedis("rediss://localhost:6390")) {
-      jedis.auth("foobared");
+    try (Jedis jedis = new Jedis(endpoint.getURI().toString())) {
+      jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
   }
@@ -91,8 +92,8 @@ public class SSLJedisTest {
   @Test
   public void connectWithUri() {
     // The "rediss" scheme instructs jedis to open a SSL/TLS connection.
-    try (Jedis jedis = new Jedis(URI.create("rediss://localhost:6390"))) {
-      jedis.auth("foobared");
+    try (Jedis jedis = new Jedis(endpoint.getURI())) {
+      jedis.auth(endpoint.getPassword());
       assertEquals("PONG", jedis.ping());
     }
   }

--- a/src/test/java/redis/clients/jedis/SentineledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/SentineledConnectionProviderTest.java
@@ -22,9 +22,6 @@ public class SentineledConnectionProviderTest {
 
   private static final String MASTER_NAME = "mymaster";
 
-  //protected static HostAndPort master = HostAndPorts.getRedisServers().get(2);
-  //protected static HostAndPort slave1 = HostAndPorts.getRedisServers().get(3);
-
   protected static final HostAndPort sentinel1 = HostAndPorts.getSentinelServers().get(1);
   protected static final HostAndPort sentinel2 = HostAndPorts.getSentinelServers().get(3);
 

--- a/src/test/java/redis/clients/jedis/ShardedConnectionTest.java
+++ b/src/test/java/redis/clients/jedis/ShardedConnectionTest.java
@@ -9,13 +9,15 @@ import java.util.List;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 
 public class ShardedConnectionTest {
 
-  private static final HostAndPort redis1 = HostAndPorts.getRedisServers().get(0);
-  private static final HostAndPort redis2 = HostAndPorts.getRedisServers().get(1);
+  /**
+   * NOTE(imalinovskyi): Both endpoints should share the same password.
+   */
+  private static final EndpointConfig redis1 = HostAndPorts.getRedisEndpoint("standalone0");
+  private static final EndpointConfig redis2 = HostAndPorts.getRedisEndpoint("standalone1");
 
   private List<HostAndPort> shards;
   private JedisClientConfig clientConfig;
@@ -23,10 +25,10 @@ public class ShardedConnectionTest {
   @Before
   public void startUp() {
     shards = new ArrayList<>();
-    shards.add(redis1);
-    shards.add(redis2);
+    shards.add(redis1.getHostAndPort());
+    shards.add(redis2.getHostAndPort());
 
-    clientConfig = DefaultJedisClientConfig.builder().password("foobared").build();
+    clientConfig = redis1.getClientConfigBuilder().build();
 
     for (HostAndPort shard : shards) {
       try (Jedis j = new Jedis(shard, clientConfig)) {

--- a/src/test/java/redis/clients/jedis/ShardedPipelineTest.java
+++ b/src/test/java/redis/clients/jedis/ShardedPipelineTest.java
@@ -10,20 +10,20 @@ import redis.clients.jedis.util.Hashing;
 
 public class ShardedPipelineTest {
 
-  private static final HostAndPort redis1 = HostAndPorts.getRedisServers().get(0);
-  private static final HostAndPort redis2 = HostAndPorts.getRedisServers().get(1);
+  private static final EndpointConfig redis1 = HostAndPorts.getRedisEndpoint("standalone0");
+  private static final EndpointConfig redis2 = HostAndPorts.getRedisEndpoint("standalone1");
 
   private static final ConnectionPoolConfig DEFAULT_POOL_CONFIG = new ConnectionPoolConfig();
-  private static final DefaultJedisClientConfig DEFAULT_CLIENT_CONFIG = DefaultJedisClientConfig
-      .builder().password("foobared").build();
+  private static final DefaultJedisClientConfig DEFAULT_CLIENT_CONFIG = redis1.getClientConfigBuilder()
+      .build();
 
-  private List<HostAndPort> shards = Arrays.asList(redis1, redis2);
+  private List<HostAndPort> shards = Arrays.asList(redis1.getHostAndPort(), redis2.getHostAndPort());
 
   @Before
   public void setUp() {
     for (HostAndPort shard : shards) {
       try (Jedis j = new Jedis(shard)) {
-        j.auth("foobared");
+        j.auth(redis1.getPassword());
         j.flushAll();
       }
     }

--- a/src/test/java/redis/clients/jedis/ShardingTest.java
+++ b/src/test/java/redis/clients/jedis/ShardingTest.java
@@ -14,17 +14,17 @@ import redis.clients.jedis.util.Hashing;
 
 public class ShardingTest {
 
-  private static final HostAndPort redis1 = HostAndPorts.getRedisServers().get(0);
-  private static final HostAndPort redis2 = HostAndPorts.getRedisServers().get(1);
+  private static final EndpointConfig redis1 = HostAndPorts.getRedisEndpoint("standalone0");
+  private static final EndpointConfig redis2 = HostAndPorts.getRedisEndpoint("standalone1");
 
-  private JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().password("foobared").build();
+  private JedisClientConfig clientConfig = redis1.getClientConfigBuilder().build();
 
   @Before
   public void setUp() {
-    try (Jedis j = new Jedis(redis1, clientConfig)) {
+    try (Jedis j = redis1.getJedis()) {
       j.flushAll();
     }
-    try (Jedis j = new Jedis(redis2, clientConfig)) {
+    try (Jedis j = redis2.getJedis()) {
       j.flushAll();
     }
   }
@@ -32,8 +32,8 @@ public class ShardingTest {
   @Test
   public void trySharding() {
     List<HostAndPort> shards = new ArrayList<>();
-    shards.add(redis1);
-    shards.add(redis2);
+    shards.add(redis1.getHostAndPort());
+    shards.add(redis2.getHostAndPort());
     try (JedisSharding jedis = new JedisSharding(shards, clientConfig)) {
       for (int i = 0; i < 1000; i++) {
         jedis.set("key" + i, Integer.toString(i));
@@ -41,14 +41,14 @@ public class ShardingTest {
     }
 
     long totalDbSize = 0;
-    try (Jedis j = new Jedis(redis1)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(redis1.getHostAndPort())) {
+      j.auth(redis1.getPassword());
       long dbSize = j.dbSize();
       assertTrue(dbSize > 400);
       totalDbSize += dbSize;
     }
-    try (Jedis j = new Jedis(redis2)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(redis2.getHostAndPort())) {
+      j.auth(redis2.getPassword());
       long dbSize = j.dbSize();
       assertTrue(dbSize > 400);
       totalDbSize += dbSize;
@@ -59,8 +59,8 @@ public class ShardingTest {
   @Test
   public void tryShardingWithMurmur() {
     List<HostAndPort> shards = new ArrayList<>();
-    shards.add(redis1);
-    shards.add(redis2);
+    shards.add(redis1.getHostAndPort());
+    shards.add(redis2.getHostAndPort());
     try (JedisSharding jedis = new JedisSharding(shards, clientConfig, Hashing.MURMUR_HASH)) {
       for (int i = 0; i < 1000; i++) {
         jedis.set("key" + i, Integer.toString(i));
@@ -68,14 +68,14 @@ public class ShardingTest {
     }
 
     long totalDbSize = 0;
-    try (Jedis j = new Jedis(redis1)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(redis1.getHostAndPort())) {
+      j.auth(redis1.getPassword());
       long dbSize = j.dbSize();
       assertTrue(dbSize > 400);
       totalDbSize += dbSize;
     }
-    try (Jedis j = new Jedis(redis2)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(redis2.getHostAndPort())) {
+      j.auth(redis2.getPassword());
       long dbSize = j.dbSize();
       assertTrue(dbSize > 400);
       totalDbSize += dbSize;
@@ -86,8 +86,8 @@ public class ShardingTest {
   @Test
   public void tryShardingWithMD5() {
     List<HostAndPort> shards = new ArrayList<>();
-    shards.add(redis1);
-    shards.add(redis2);
+    shards.add(redis1.getHostAndPort());
+    shards.add(redis2.getHostAndPort());
     try (JedisSharding jedis = new JedisSharding(shards, clientConfig, Hashing.MD5)) {
       for (int i = 0; i < 1000; i++) {
         jedis.set("key" + i, Integer.toString(i));
@@ -95,14 +95,14 @@ public class ShardingTest {
     }
 
     long totalDbSize = 0;
-    try (Jedis j = new Jedis(redis1)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(redis1.getHostAndPort())) {
+      j.auth(redis1.getPassword());
       long dbSize = j.dbSize();
       assertTrue(dbSize > 400);
       totalDbSize += dbSize;
     }
-    try (Jedis j = new Jedis(redis2)) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(redis2.getHostAndPort())) {
+      j.auth(redis2.getPassword());
       long dbSize = j.dbSize();
       totalDbSize += dbSize;
     }
@@ -124,8 +124,8 @@ public class ShardingTest {
   @Test
   public void checkCloseable() {
     List<HostAndPort> shards = new ArrayList<>();
-    shards.add(redis1);
-    shards.add(redis2);
+    shards.add(redis1.getHostAndPort());
+    shards.add(redis2.getHostAndPort());
 
     JedisSharding jedis = new JedisSharding(shards, clientConfig);
     jedis.set("closeable", "true");
@@ -141,8 +141,8 @@ public class ShardingTest {
   @Test
   public void testGeneralCommand() {
     List<HostAndPort> shards = new ArrayList<>();
-    shards.add(redis1);
-    shards.add(redis2);
+    shards.add(redis1.getHostAndPort());
+    shards.add(redis2.getHostAndPort());
 
     try (JedisSharding jedis = new JedisSharding(shards, clientConfig)) {
       jedis.sendCommand("command", SET, "command", "general");

--- a/src/test/java/redis/clients/jedis/ShardingTest.java
+++ b/src/test/java/redis/clients/jedis/ShardingTest.java
@@ -21,10 +21,10 @@ public class ShardingTest {
 
   @Before
   public void setUp() {
-    try (Jedis j = redis1.getJedis()) {
+    try (Jedis j = new Jedis(redis1.getHostAndPort(), redis1.getClientConfigBuilder().build())) {
       j.flushAll();
     }
-    try (Jedis j = redis2.getJedis()) {
+    try (Jedis j = new Jedis(redis2.getHostAndPort(), redis2.getClientConfigBuilder().build())) {
       j.flushAll();
     }
   }

--- a/src/test/java/redis/clients/jedis/TransactionV2Test.java
+++ b/src/test/java/redis/clients/jedis/TransactionV2Test.java
@@ -32,9 +32,12 @@ public class TransactionV2Test {
 
   @Before
   public void setUp() throws Exception {
-    conn = endpoint.getConnection(500);
+    conn = new Connection(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().timeoutMillis(500).build());
 
-    nj = endpoint.getJedis(500);
+    nj = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().timeoutMillis(500).build());
+
     nj.flushAll();
   }
 

--- a/src/test/java/redis/clients/jedis/TransactionV2Test.java
+++ b/src/test/java/redis/clients/jedis/TransactionV2Test.java
@@ -25,16 +25,16 @@ public class TransactionV2Test {
 
   final byte[] bmykey = { 0x42, 0x02, 0x03, 0x04 };
 
-  private static final HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
 
   private Connection conn;
   private Jedis nj;
 
   @Before
   public void setUp() throws Exception {
-    conn = new Connection(hnp, DefaultJedisClientConfig.builder().timeoutMillis(500).password("foobared").build());
+    conn = endpoint.getConnection(500);
 
-    nj = new Jedis(hnp, DefaultJedisClientConfig.builder().timeoutMillis(500).password("foobared").build());
+    nj = endpoint.getJedis(500);
     nj.flushAll();
   }
 
@@ -212,10 +212,6 @@ public class TransactionV2Test {
 
   @Test
   public void testCloseable() {
-    // we need to test with fresh instance of Jedis
-//    Jedis jedis2 = new Jedis(hnp.getHost(), hnp.getPort(), 500);
-//    jedis2.auth("foobared");
-
     Transaction transaction = new Transaction(conn);
     transaction.set("a", "1");
     transaction.set("b", "2");

--- a/src/test/java/redis/clients/jedis/benchmark/GetSetBenchmark.java
+++ b/src/test/java/redis/clients/jedis/benchmark/GetSetBenchmark.java
@@ -4,19 +4,19 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 
-import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.HostAndPorts;
 
 public class GetSetBenchmark {
 
-  private static HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
   private static final int TOTAL_OPERATIONS = 100000;
 
   public static void main(String[] args) throws UnknownHostException, IOException {
-    Jedis jedis = new Jedis(hnp);
+    Jedis jedis = new Jedis(endpoint.getHostAndPort());
     jedis.connect();
-    jedis.auth("foobared");
+    jedis.auth(endpoint.getPassword());
     jedis.flushAll();
 
     long begin = Calendar.getInstance().getTimeInMillis();

--- a/src/test/java/redis/clients/jedis/benchmark/PipelinedGetSetBenchmark.java
+++ b/src/test/java/redis/clients/jedis/benchmark/PipelinedGetSetBenchmark.java
@@ -4,20 +4,17 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Calendar;
 
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.HostAndPorts;
+import redis.clients.jedis.*;
 
 public class PipelinedGetSetBenchmark {
 
-  private static HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
   private static final int TOTAL_OPERATIONS = 200000;
 
   public static void main(String[] args) throws UnknownHostException, IOException {
-    Jedis jedis = new Jedis(hnp);
+    Jedis jedis = new Jedis(endpoint.getHostAndPort());
     jedis.connect();
-    jedis.auth("foobared");
+    jedis.auth(endpoint.getPassword());
     jedis.flushAll();
 
     long begin = Calendar.getInstance().getTimeInMillis();

--- a/src/test/java/redis/clients/jedis/benchmark/PoolBenchmark.java
+++ b/src/test/java/redis/clients/jedis/benchmark/PoolBenchmark.java
@@ -6,20 +6,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.HostAndPorts;
+import redis.clients.jedis.*;
 
 public class PoolBenchmark {
 
-  private static HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
   private static final int TOTAL_OPERATIONS = 100000;
 
   public static void main(String[] args) throws Exception {
-    Jedis j = new Jedis(hnp);
+    Jedis j = new Jedis(endpoint.getHostAndPort());
     j.connect();
-    j.auth("foobared");
+    j.auth(endpoint.getPassword());
     j.flushAll();
     j.disconnect();
     long t = System.currentTimeMillis();
@@ -30,8 +27,8 @@ public class PoolBenchmark {
   }
 
   private static void withPool() throws Exception {
-    final JedisPool pool = new JedisPool(new GenericObjectPoolConfig<Jedis>(), hnp.getHost(),
-        hnp.getPort(), 2000, "foobared");
+    final JedisPool pool = new JedisPool(new GenericObjectPoolConfig<Jedis>(), endpoint.getHost(),
+        endpoint.getPort(), 2000, endpoint.getPassword());
     List<Thread> tds = new ArrayList<Thread>();
 
     final AtomicInteger ind = new AtomicInteger();

--- a/src/test/java/redis/clients/jedis/benchmark/PooledBenchmark.java
+++ b/src/test/java/redis/clients/jedis/benchmark/PooledBenchmark.java
@@ -4,19 +4,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.HostAndPorts;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.*;
 
 public class PooledBenchmark {
 
-  private static HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  private static EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
   private static final int TOTAL_OPERATIONS = 100000;
 
   public static void main(String[] args) throws Exception {
-    try (Jedis j = new Jedis(hnp.getHost(), hnp.getPort())) {
-      j.auth("foobared");
+    try (Jedis j = new Jedis(endpoint.getHost(), endpoint.getPort())) {
+      j.auth(endpoint.getPassword());
       j.flushAll();
       j.disconnect();
     }
@@ -27,7 +24,7 @@ public class PooledBenchmark {
   }
 
   private static void withPool() throws Exception {
-    final JedisPooled j = new JedisPooled(hnp.getHost(), hnp.getPort(), null, "foobared");
+    final JedisPooled j = new JedisPooled(endpoint.getHost(), endpoint.getPort(), null, endpoint.getPassword());
     List<Thread> tds = new ArrayList<>();
 
     final AtomicInteger ind = new AtomicInteger();

--- a/src/test/java/redis/clients/jedis/benchmark/ShardingBenchmark.java
+++ b/src/test/java/redis/clients/jedis/benchmark/ShardingBenchmark.java
@@ -5,20 +5,17 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Calendar;
 
-import redis.clients.jedis.DefaultJedisClientConfig;
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.HostAndPorts;
-import redis.clients.jedis.JedisSharding;
+import redis.clients.jedis.*;
 
 public class ShardingBenchmark {
 
-  private static HostAndPort hnp1 = HostAndPorts.getRedisServers().get(0);
-  private static HostAndPort hnp2 = HostAndPorts.getRedisServers().get(1);
+  private static EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone0");
+  private static EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("standalone1");
   private static final int TOTAL_OPERATIONS = 100000;
 
   public static void main(String[] args) throws UnknownHostException, IOException {
-    try (JedisSharding jedis = new JedisSharding(Arrays.asList(hnp1, hnp2),
-        DefaultJedisClientConfig.builder().password("foobared").build())) {
+    try (JedisSharding jedis = new JedisSharding(Arrays.asList(endpoint1.getHostAndPort(), endpoint2.getHostAndPort()),
+        endpoint1.getClientConfigBuilder().build())) {
 
       long begin = Calendar.getInstance().getTimeInMillis();
 

--- a/src/test/java/redis/clients/jedis/benchmark/ShardingBenchmark.java
+++ b/src/test/java/redis/clients/jedis/benchmark/ShardingBenchmark.java
@@ -9,13 +9,13 @@ import redis.clients.jedis.*;
 
 public class ShardingBenchmark {
 
-  private static EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone0");
-  private static EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("standalone1");
+  private static EndpointConfig endpointStandalone0 = HostAndPorts.getRedisEndpoint("standalone0");
+  private static EndpointConfig endpointStandalone1 = HostAndPorts.getRedisEndpoint("standalone1");
   private static final int TOTAL_OPERATIONS = 100000;
 
   public static void main(String[] args) throws UnknownHostException, IOException {
-    try (JedisSharding jedis = new JedisSharding(Arrays.asList(endpoint1.getHostAndPort(), endpoint2.getHostAndPort()),
-        endpoint1.getClientConfigBuilder().build())) {
+    try (JedisSharding jedis = new JedisSharding(Arrays.asList(endpointStandalone0.getHostAndPort(), endpointStandalone1.getHostAndPort()),
+        endpointStandalone0.getClientConfigBuilder().build())) {
 
       long begin = Calendar.getInstance().getTimeInMillis();
 

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsGenericCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsGenericCommandsTest.java
@@ -1082,8 +1082,8 @@ public class CommandObjectsGenericCommandsTest extends CommandObjectsStandaloneT
 
   private void assertKeyExists(int dstDb, String key, Object expectedValue) {
     // Cheat and use Jedis, it gives us access to any db.
-    try (Jedis jedis = new Jedis(nodeInfo)) {
-      jedis.auth("foobared");
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort())) {
+      jedis.auth(endpoint.getPassword());
       jedis.select(dstDb);
       assertThat(jedis.get(key), equalTo(expectedValue));
     }

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsModulesTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsModulesTestBase.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.commands.commandobjects;
 
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisProtocol;
 
@@ -9,11 +10,8 @@ import redis.clients.jedis.RedisProtocol;
  */
 public abstract class CommandObjectsModulesTestBase extends CommandObjectsTestBase {
 
-  private static final String address =
-      System.getProperty("modulesDocker", Protocol.DEFAULT_HOST + ':' + 6479);
-
   public CommandObjectsModulesTestBase(RedisProtocol protocol) {
-    super(protocol, HostAndPort.from(address), null);
+    super(protocol, HostAndPorts.getRedisEndpoint("modules-docker"));
   }
 
 }

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsStandaloneTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsStandaloneTestBase.java
@@ -9,7 +9,8 @@ import redis.clients.jedis.RedisProtocol;
 public abstract class CommandObjectsStandaloneTestBase extends CommandObjectsTestBase {
 
   public CommandObjectsStandaloneTestBase(RedisProtocol protocol) {
-    super(protocol, HostAndPorts.getRedisServers().get(0), "foobared");
+    super(protocol, HostAndPorts.getRedisEndpoint("standalone0").getHostAndPort(),
+        HostAndPorts.getRedisEndpoint("standalone0").getPassword());
   }
 
 }

--- a/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsStandaloneTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/commandobjects/CommandObjectsStandaloneTestBase.java
@@ -9,8 +9,7 @@ import redis.clients.jedis.RedisProtocol;
 public abstract class CommandObjectsStandaloneTestBase extends CommandObjectsTestBase {
 
   public CommandObjectsStandaloneTestBase(RedisProtocol protocol) {
-    super(protocol, HostAndPorts.getRedisEndpoint("standalone0").getHostAndPort(),
-        HostAndPorts.getRedisEndpoint("standalone0").getPassword());
+    super(protocol, HostAndPorts.getRedisEndpoint("standalone0"));
   }
 
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/AccessControlListCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AccessControlListCommandsTest.java
@@ -46,7 +46,7 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
   public static void prepare() throws Exception {
     // Use to check if the ACL test should be ran. ACL are available only in 6.0 and later
     org.junit.Assume.assumeTrue("Not running ACL test on this version of Redis",
-        RedisVersionUtil.checkRedisMajorVersionNumber(6));
+        RedisVersionUtil.checkRedisMajorVersionNumber(6, endpoint));
   }
 
   public AccessControlListCommandsTest(RedisProtocol protocol) {
@@ -359,7 +359,7 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
     }
 
     // test the ACL Log
-    jedis.auth("default", "foobared");
+    jedis.auth(endpoint.getUsername(), endpoint.getPassword());
 
     List<AccessControlLogEntry> aclEntries = jedis.aclLog();
     assertEquals("Number of log messages ", 1, aclEntries.size());
@@ -385,7 +385,7 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
     }
 
     // test the ACL Log
-    jedis.auth("default", "foobared");
+    jedis.auth(endpoint.getUsername(), endpoint.getPassword());
     assertEquals("Number of log messages ", 1, jedis.aclLog().size());
     assertEquals(10, jedis.aclLog().get(0).getCount());
     assertEquals("get", jedis.aclLog().get(0).getObject());
@@ -399,7 +399,7 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
     }
 
     // test the ACL Log
-    jedis.auth("default", "foobared");
+    jedis.auth(endpoint.getUsername(), endpoint.getPassword());
     assertEquals("Number of log messages ", 2, jedis.aclLog().size());
     assertEquals(1, jedis.aclLog().get(0).getCount());
     assertEquals("somekeynotallowed", jedis.aclLog().get(0).getObject());
@@ -418,7 +418,7 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
     }
     t.close();
 
-    jedis.auth("default", "foobared");
+    jedis.auth(endpoint.getUsername(), endpoint.getPassword());
     assertEquals("Number of log messages ", 1, jedis.aclLog().size());
     assertEquals(1, jedis.aclLog().get(0).getCount());
     assertEquals("multi", jedis.aclLog().get(0).getContext());
@@ -439,7 +439,7 @@ public class AccessControlListCommandsTest extends JedisCommandsTestBase {
     } catch (JedisAccessControlException e) {
     }
 
-    jedis.auth("default", "foobared");
+    jedis.auth(endpoint.getUsername(), endpoint.getPassword());
     assertEquals("Number of log messages ", 3, jedis.aclLog().size());
     assertEquals("Number of log messages ", 2, jedis.aclLog(2).size());
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
@@ -632,7 +632,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertEquals(1000, jedis2.objectIdletime("bar1").longValue());
     jedis2.close();
 
-    Jedis lfuJedis = lfuEndpoint.getJedis(500);
+    Jedis lfuJedis = new Jedis(lfuEndpoint.getHostAndPort(), lfuEndpoint.getClientConfigBuilder().timeoutMillis(500).build());;
     lfuJedis.restore("bar1", 1000, serialized, RestoreParams.restoreParams().replace().frequency(90));
     assertEquals(90, lfuJedis.objectFreq("bar1").longValue());
     lfuJedis.close();

--- a/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
@@ -21,17 +21,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Transaction;
+import redis.clients.jedis.*;
 import redis.clients.jedis.args.ExpiryOption;
 import redis.clients.jedis.params.ScanParams;
 import redis.clients.jedis.resps.ScanResult;
-import redis.clients.jedis.StreamEntryID;
 import redis.clients.jedis.args.FlushMode;
 import redis.clients.jedis.params.RestoreParams;
-import redis.clients.jedis.HostAndPorts;
-import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.util.SafeEncoder;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.params.SetParams;
@@ -57,7 +52,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
   final byte[] bex = { 0x65, 0x78 };
   final int expireSeconds = 2;
 
-  private static final HostAndPort lfuHnp = HostAndPorts.getRedisServers().get(7);
+  private static final EndpointConfig lfuEndpoint = HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy");
 
   public AllKindOfValuesCommandsTest(RedisProtocol redisProtocol) {
     super(redisProtocol);
@@ -604,7 +599,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
   @Test
   public void restoreParams() {
     // take a separate instance
-    Jedis jedis2 = new Jedis(hnp.getHost(), 6380, 500);
+    Jedis jedis2 = new Jedis(endpoint.getHost(), 6380, 500);
     jedis2.auth("foobared");
     jedis2.flushAll();
 
@@ -637,7 +632,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertEquals(1000, jedis2.objectIdletime("bar1").longValue());
     jedis2.close();
 
-    Jedis lfuJedis = new Jedis(lfuHnp.getHost(), lfuHnp.getPort(), 500);
+    Jedis lfuJedis = lfuEndpoint.getJedis();
     lfuJedis.restore("bar1", 1000, serialized, RestoreParams.restoreParams().replace().frequency(90));
     assertEquals(90, lfuJedis.objectFreq("bar1").longValue());
     lfuJedis.close();

--- a/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/AllKindOfValuesCommandsTest.java
@@ -599,8 +599,8 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
   @Test
   public void restoreParams() {
     // take a separate instance
-    Jedis jedis2 = new Jedis(endpoint.getHost(), 6380, 500);
-    jedis2.auth("foobared");
+    Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
+    jedis2.auth(endpoint.getPassword());
     jedis2.flushAll();
 
     jedis2.set("foo", "bar");
@@ -632,7 +632,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertEquals(1000, jedis2.objectIdletime("bar1").longValue());
     jedis2.close();
 
-    Jedis lfuJedis = lfuEndpoint.getJedis();
+    Jedis lfuJedis = lfuEndpoint.getJedis(500);
     lfuJedis.restore("bar1", 1000, serialized, RestoreParams.restoreParams().replace().frequency(90));
     assertEquals(90, lfuJedis.objectFreq("bar1").longValue());
     lfuJedis.close();
@@ -1141,7 +1141,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     assertEquals("NOAUTH Authentication required.", ex1.getMessage());
 
     // multi reset
-    jedis.auth("foobared");
+    jedis.auth(endpoint.getPassword());
     jedis.set(counter, "1");
 
     Transaction trans = jedis.multi();
@@ -1151,7 +1151,7 @@ public class AllKindOfValuesCommandsTest extends JedisCommandsTestBase {
     Exception ex2 = assertThrows(JedisDataException.class, trans::exec);
     assertEquals("EXECABORT Transaction discarded because of: NOAUTH Authentication required.", ex2.getMessage());
 
-    jedis.auth("foobared");
+    jedis.auth(endpoint.getPassword());
     assertEquals("1", jedis.get(counter));
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.args.ClientAttributeOption;
@@ -47,7 +46,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    client = new Jedis(hnp.getHost(), hnp.getPort(), 500);
+    client = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
     client.auth("foobared");
     client.clientSetname(clientName);
   }
@@ -97,7 +96,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void clientIdmultipleConnection() {
-    try (Jedis client2 = new Jedis(hnp.getHost(), hnp.getPort(), 500)) {
+    try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
       client2.auth("foobared");
       client2.clientSetname("fancy_jedis_another_name");
 
@@ -233,7 +232,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   @Test
   public void killUser() {
     client.aclSetUser("test_kill", "on", "+acl", ">password1");
-    try (Jedis client2 = new Jedis(hnp.getHost(), hnp.getPort(), 500)) {
+    try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
       client2.auth("test_kill", "password1");
 
       assertEquals(1, jedis.clientKill(new ClientKillParams().user("test_kill")));
@@ -250,7 +249,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
     // sleep twice the maxAge, to be sure
     Thread.sleep(maxAge * 2 * 1000);
 
-    try (Jedis client2 = new Jedis(hnp.getHost(), hnp.getPort(), 500)) {
+    try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
       client2.auth("foobared");
 
       long killedClients = jedis.clientKill(new ClientKillParams().maxAge(maxAge));
@@ -300,8 +299,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void trackingInfoResp3() {
-    Jedis clientResp3 = new Jedis(hnp, DefaultJedisClientConfig.builder()
-            .protocol(RedisProtocol.RESP3).password("foobared").build());
+    Jedis clientResp3 = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
+            .protocol(RedisProtocol.RESP3).build());
     TrackingInfo trackingInfo = clientResp3.clientTrackingInfo();
 
     assertEquals(1, trackingInfo.getFlags().size());

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -47,7 +47,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   public void setUp() throws Exception {
     super.setUp();
     client = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
-    client.auth("foobared");
+    client.auth(endpoint.getPassword());
     client.clientSetname(clientName);
   }
 
@@ -97,7 +97,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   @Test
   public void clientIdmultipleConnection() {
     try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
-      client2.auth("foobared");
+      client2.auth(endpoint.getPassword());
       client2.clientSetname("fancy_jedis_another_name");
 
       // client-id is monotonically increasing
@@ -110,7 +110,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
     long clientIdInitial = client.clientId();
     client.disconnect();
     client.connect();
-    client.auth("foobared");
+    client.auth(endpoint.getPassword());
     long clientIdAfterReconnect = client.clientId();
 
     assertTrue(clientIdInitial < clientIdAfterReconnect);
@@ -250,7 +250,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
     Thread.sleep(maxAge * 2 * 1000);
 
     try (Jedis client2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500)) {
-      client2.auth("foobared");
+      client2.auth(endpoint.getPassword());
 
       long killedClients = jedis.clientKill(new ClientKillParams().maxAge(maxAge));
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -27,15 +27,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import redis.clients.jedis.DefaultJedisClientConfig;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisMonitor;
-import redis.clients.jedis.Protocol;
-import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.*;
 import redis.clients.jedis.args.ClientPauseMode;
 import redis.clients.jedis.args.LatencyEvent;
 import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.params.CommandListFilterByParams;
 import redis.clients.jedis.params.LolwutParams;
 import redis.clients.jedis.resps.CommandDocument;
@@ -129,8 +124,7 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void roleMaster() {
-    try (Jedis master = new Jedis(HostAndPorts.getRedisServers().get(0),
-        DefaultJedisClientConfig.builder().password("foobared").build())) {
+    try (Jedis master = HostAndPorts.getRedisEndpoint("standalone0").getJedis()) {
 
       List<Object> role = master.role();
       assertEquals("master", role.get(0));
@@ -147,19 +141,20 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void roleSlave() {
-    try (Jedis slave = new Jedis(HostAndPorts.getRedisServers().get(4),
-        DefaultJedisClientConfig.builder().password("foobared").build())) {
+    EndpointConfig primaryEndpoint = HostAndPorts.getRedisEndpoint("standalone0");
+
+    try (Jedis slave = HostAndPorts.getRedisEndpoint("standalone4").getJedis()) {
 
       List<Object> role = slave.role();
       assertEquals("slave", role.get(0));
-      assertEquals((long) HostAndPorts.getRedisServers().get(0).getPort(), role.get(2));
+      assertEquals((long) primaryEndpoint.getPort(), role.get(2));
       assertEquals("connected", role.get(3));
       assertTrue(role.get(4) instanceof Long);
 
       // binary
       List<Object> brole = slave.roleBinary();
       assertArrayEquals("slave".getBytes(), (byte[]) brole.get(0));
-      assertEquals((long) HostAndPorts.getRedisServers().get(0).getPort(), brole.get(2));
+      assertEquals((long) primaryEndpoint.getPort(), brole.get(2));
       assertArrayEquals("connected".getBytes(), (byte[]) brole.get(3));
       assertTrue(brole.get(4) instanceof Long);
     }

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -187,8 +187,8 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
           Thread.sleep(100);
         } catch (InterruptedException e) {
         }
-        Jedis j = new Jedis();
-        j.auth("foobared");
+        Jedis j = new Jedis(endpoint.getHostAndPort());
+        j.auth(endpoint.getPassword());
         for (int i = 0; i < 5; i++) {
           j.incr("foobared");
         }

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -124,7 +124,10 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void roleMaster() {
-    try (Jedis master = HostAndPorts.getRedisEndpoint("standalone0").getJedis()) {
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
+
+    try (Jedis master = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().build())) {
 
       List<Object> role = master.role();
       assertEquals("master", role.get(0));
@@ -142,8 +145,11 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   @Test
   public void roleSlave() {
     EndpointConfig primaryEndpoint = HostAndPorts.getRedisEndpoint("standalone0");
+    EndpointConfig secondaryEndpoint = HostAndPorts.getRedisEndpoint(
+        "standalone4-replica-of-standalone1");
 
-    try (Jedis slave = HostAndPorts.getRedisEndpoint("standalone4-replica-of-standalone1").getJedis()) {
+    try (Jedis slave = new Jedis(secondaryEndpoint.getHostAndPort(),
+        secondaryEndpoint.getClientConfigBuilder().build())) {
 
       List<Object> role = slave.role();
       assertEquals("slave", role.get(0));

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -143,7 +143,7 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   public void roleSlave() {
     EndpointConfig primaryEndpoint = HostAndPorts.getRedisEndpoint("standalone0");
 
-    try (Jedis slave = HostAndPorts.getRedisEndpoint("standalone4").getJedis()) {
+    try (Jedis slave = HostAndPorts.getRedisEndpoint("standalone4-replica-of-standalone1").getJedis()) {
 
       List<Object> role = slave.role();
       assertEquals("slave", role.get(0));

--- a/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
@@ -26,10 +26,10 @@ public class FailoverCommandsTest {
   @Before
   public void prepare() {
     String role1, role2;
-    try (Jedis jedis1 = node1.getJedis()) {
+    try (Jedis jedis1 = new Jedis(node1.getHostAndPort(), node1.getClientConfigBuilder().build())) {
       role1 = (String) jedis1.role().get(0);
     }
-    try (Jedis jedis2 = node2.getJedis()) {
+    try (Jedis jedis2 = new Jedis(node2.getHostAndPort(), node2.getClientConfigBuilder().build())) {
       role2 = (String) jedis2.role().get(0);
     }
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
@@ -18,7 +18,7 @@ public class FailoverCommandsTest {
   private static final int INVALID_PORT = 6000;
 
   private static final EndpointConfig node1 = HostAndPorts.getRedisEndpoint("standalone9");
-  private static final EndpointConfig node2 = HostAndPorts.getRedisEndpoint("standalone10");
+  private static final EndpointConfig node2 = HostAndPorts.getRedisEndpoint("standalone10-replica-of-standalone9");
 
   private HostAndPort masterAddress;
   private HostAndPort replicaAddress;

--- a/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/FailoverCommandsTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 
+import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisDataException;
@@ -16,8 +17,8 @@ public class FailoverCommandsTest {
 
   private static final int INVALID_PORT = 6000;
 
-  private static final HostAndPort node1 = HostAndPorts.getRedisServers().get(9);
-  private static final HostAndPort node2 = HostAndPorts.getRedisServers().get(10);
+  private static final EndpointConfig node1 = HostAndPorts.getRedisEndpoint("standalone9");
+  private static final EndpointConfig node2 = HostAndPorts.getRedisEndpoint("standalone10");
 
   private HostAndPort masterAddress;
   private HostAndPort replicaAddress;
@@ -25,19 +26,19 @@ public class FailoverCommandsTest {
   @Before
   public void prepare() {
     String role1, role2;
-    try (Jedis jedis1 = new Jedis(node1)) {
+    try (Jedis jedis1 = node1.getJedis()) {
       role1 = (String) jedis1.role().get(0);
     }
-    try (Jedis jedis2 = new Jedis(node2)) {
+    try (Jedis jedis2 = node2.getJedis()) {
       role2 = (String) jedis2.role().get(0);
     }
 
     if ("master".equals(role1) && "slave".equals(role2)) {
-      masterAddress = node1;
-      replicaAddress = node2;
+      masterAddress = node1.getHostAndPort();
+      replicaAddress = node2.getHostAndPort();
     } else if ("master".equals(role2) && "slave".equals(role1)) {
-      masterAddress = node2;
-      replicaAddress = node1;
+      masterAddress = node2.getHostAndPort();
+      replicaAddress = node1.getHostAndPort();
     } else {
       fail();
     }

--- a/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
@@ -5,11 +5,7 @@ import java.util.Collection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runners.Parameterized.Parameters;
-import redis.clients.jedis.DefaultJedisClientConfig;
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.HostAndPorts;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.*;
 import redis.clients.jedis.commands.CommandsTestsParameters;
 
 public abstract class JedisCommandsTestBase {
@@ -25,7 +21,7 @@ public abstract class JedisCommandsTestBase {
     return CommandsTestsParameters.respVersions();
   }
 
-  protected static final HostAndPort hnp = HostAndPorts.getRedisServers().get(0);
+  protected static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
 
   protected final RedisProtocol protocol;
 
@@ -46,9 +42,7 @@ public abstract class JedisCommandsTestBase {
 
   @Before
   public void setUp() throws Exception {
-//    jedis = new Jedis(hnp, DefaultJedisClientConfig.builder().timeoutMillis(500).password("foobared").build());
-    jedis = new Jedis(hnp, DefaultJedisClientConfig.builder()
-        .protocol(protocol).timeoutMillis(500).password("foobared").build());
+    jedis = endpoint.getJedis(500);
     jedis.flushAll();
   }
 
@@ -58,8 +52,6 @@ public abstract class JedisCommandsTestBase {
   }
 
   protected Jedis createJedis() {
-//    return new Jedis(hnp, DefaultJedisClientConfig.builder().password("foobared").build());
-    return new Jedis(hnp, DefaultJedisClientConfig.builder()
-        .protocol(protocol).password("foobared").build());
+    return endpoint.getJedis();
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
@@ -54,6 +54,6 @@ public abstract class JedisCommandsTestBase {
 
   protected Jedis createJedis() {
     return new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
-        .protocol(protocol).timeoutMillis(500).build());
+        .protocol(protocol).build());
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/JedisCommandsTestBase.java
@@ -42,7 +42,8 @@ public abstract class JedisCommandsTestBase {
 
   @Before
   public void setUp() throws Exception {
-    jedis = endpoint.getJedis(500);
+    jedis = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
+        .protocol(protocol).timeoutMillis(500).build());
     jedis.flushAll();
   }
 
@@ -52,6 +53,7 @@ public abstract class JedisCommandsTestBase {
   }
 
   protected Jedis createJedis() {
-    return endpoint.getJedis();
+    return new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
+        .protocol(protocol).timeoutMillis(500).build());
   }
 }

--- a/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
@@ -32,9 +32,9 @@ public class MigrateTest extends JedisCommandsTestBase {
 
   private Jedis dest;
   private Jedis destAuth;
-  private static final String host = hnp.getHost();
+  private static final String host = endpoint.getHost();
   private static final int port = 6386;
-  private static final int portAuth = hnp.getPort() + 1;
+  private static final int portAuth = endpoint.getPort() + 1;
   private static final int db = 2;
   private static final int dbAuth = 3;
   private static final int timeout = Protocol.DEFAULT_TIMEOUT;
@@ -165,14 +165,14 @@ public class MigrateTest extends JedisCommandsTestBase {
   @Test
   public void migrateAuth2() {
     destAuth.set("foo", "bar");
-    assertEquals("OK", destAuth.migrate(host, hnp.getPort(), 0, timeout,
+    assertEquals("OK", destAuth.migrate(host, endpoint.getPort(), 0, timeout,
       new MigrateParams().auth2("acljedis", "fizzbuzz"), "foo"));
     assertEquals("bar", jedis.get("foo"));
     assertNull(destAuth.get("foo"));
 
     // binary
     dest.set(bfoo1, bbar1);
-    assertEquals("OK", dest.migrate(host, hnp.getPort(), 0, timeout,
+    assertEquals("OK", dest.migrate(host, endpoint.getPort(), 0, timeout,
       new MigrateParams().auth2("acljedis", "fizzbuzz"), bfoo1));
     assertArrayEquals(bbar1, jedis.get(bfoo1));
     assertNull(dest.get(bfoo1));

--- a/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
@@ -12,9 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Protocol;
-import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.*;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.params.MigrateParams;
 
@@ -32,9 +30,18 @@ public class MigrateTest extends JedisCommandsTestBase {
 
   private Jedis dest;
   private Jedis destAuth;
-  private static final String host = endpoint.getHost();
-  private static final int port = 6386;
-  private static final int portAuth = endpoint.getPort() + 1;
+
+  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0-acl");
+
+  private static final EndpointConfig destEndpoint = HostAndPorts.getRedisEndpoint(
+      "standalone7-with-lfu-policy");
+
+  private static final EndpointConfig destEndpointWithAuth = HostAndPorts.getRedisEndpoint(
+      "standalone1");
+
+  private static final String host = destEndpoint.getHost();
+  private static final int port = destEndpoint.getPort();
+  private static final int portAuth = destEndpointWithAuth.getPort();
   private static final int db = 2;
   private static final int dbAuth = 3;
   private static final int timeout = Protocol.DEFAULT_TIMEOUT;
@@ -52,8 +59,8 @@ public class MigrateTest extends JedisCommandsTestBase {
     dest.flushAll();
     dest.select(db);
 
-    destAuth = new Jedis(host, portAuth, 500);
-    destAuth.auth(endpoint.getPassword());
+    destAuth = new Jedis(destEndpointWithAuth.getHostAndPort(),
+        destEndpointWithAuth.getClientConfigBuilder().build());
     destAuth.flushAll();
     destAuth.select(dbAuth);
   }
@@ -150,14 +157,14 @@ public class MigrateTest extends JedisCommandsTestBase {
   @Test
   public void migrateAuth() {
     jedis.set("foo", "bar");
-    assertEquals("OK",
-      jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), "foo"));
+    assertEquals("OK", jedis.migrate(host, portAuth, dbAuth, timeout,
+        new MigrateParams().auth(destEndpointWithAuth.getPassword()), "foo"));
     assertEquals("bar", destAuth.get("foo"));
     assertNull(jedis.get("foo"));
 
     jedis.set(bfoo, bbar);
-    assertEquals("OK",
-      jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), bfoo));
+    assertEquals("OK", jedis.migrate(host, portAuth, dbAuth, timeout,
+        new MigrateParams().auth(destEndpointWithAuth.getPassword()), bfoo));
     assertArrayEquals(bbar, destAuth.get(bfoo));
     assertNull(jedis.get(bfoo));
   }
@@ -166,14 +173,14 @@ public class MigrateTest extends JedisCommandsTestBase {
   public void migrateAuth2() {
     destAuth.set("foo", "bar");
     assertEquals("OK", destAuth.migrate(host, endpoint.getPort(), 0, timeout,
-      new MigrateParams().auth2("acljedis", "fizzbuzz"), "foo"));
+        new MigrateParams().auth2(endpoint.getUsername(), endpoint.getPassword()), "foo"));
     assertEquals("bar", jedis.get("foo"));
     assertNull(destAuth.get("foo"));
 
     // binary
     dest.set(bfoo1, bbar1);
     assertEquals("OK", dest.migrate(host, endpoint.getPort(), 0, timeout,
-      new MigrateParams().auth2("acljedis", "fizzbuzz"), bfoo1));
+        new MigrateParams().auth2(endpoint.getUsername(), endpoint.getPassword()), bfoo1));
     assertArrayEquals(bbar1, jedis.get(bfoo1));
     assertNull(dest.get(bfoo1));
   }
@@ -182,10 +189,8 @@ public class MigrateTest extends JedisCommandsTestBase {
   public void migrateCopyReplaceAuth() {
     jedis.set("foo", "bar1");
     destAuth.set("foo", "bar2");
-    assertEquals(
-      "OK",
-      jedis.migrate(host, portAuth, dbAuth, timeout,
-        new MigrateParams().copy().replace().auth(endpoint.getPassword()), "foo"));
+    assertEquals("OK", jedis.migrate(host, portAuth, dbAuth, timeout,
+        new MigrateParams().copy().replace().auth(destEndpointWithAuth.getPassword()), "foo"));
     assertEquals("bar1", destAuth.get("foo"));
     assertEquals("bar1", jedis.get("foo"));
 
@@ -194,7 +199,7 @@ public class MigrateTest extends JedisCommandsTestBase {
     assertEquals(
       "OK",
       jedis.migrate(host, portAuth, dbAuth, timeout,
-        new MigrateParams().copy().replace().auth(endpoint.getPassword()), bfoo));
+        new MigrateParams().copy().replace().auth(destEndpointWithAuth.getPassword()), bfoo));
     assertArrayEquals(bbar1, destAuth.get(bfoo));
     assertArrayEquals(bbar1, jedis.get(bfoo));
   }

--- a/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/MigrateTest.java
@@ -53,7 +53,7 @@ public class MigrateTest extends JedisCommandsTestBase {
     dest.select(db);
 
     destAuth = new Jedis(host, portAuth, 500);
-    destAuth.auth("foobared");
+    destAuth.auth(endpoint.getPassword());
     destAuth.flushAll();
     destAuth.select(dbAuth);
   }
@@ -151,13 +151,13 @@ public class MigrateTest extends JedisCommandsTestBase {
   public void migrateAuth() {
     jedis.set("foo", "bar");
     assertEquals("OK",
-      jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), "foo"));
+      jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), "foo"));
     assertEquals("bar", destAuth.get("foo"));
     assertNull(jedis.get("foo"));
 
     jedis.set(bfoo, bbar);
     assertEquals("OK",
-      jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth("foobared"), bfoo));
+      jedis.migrate(host, portAuth, dbAuth, timeout, new MigrateParams().auth(endpoint.getPassword()), bfoo));
     assertArrayEquals(bbar, destAuth.get(bfoo));
     assertNull(jedis.get(bfoo));
   }
@@ -185,7 +185,7 @@ public class MigrateTest extends JedisCommandsTestBase {
     assertEquals(
       "OK",
       jedis.migrate(host, portAuth, dbAuth, timeout,
-        new MigrateParams().copy().replace().auth("foobared"), "foo"));
+        new MigrateParams().copy().replace().auth(endpoint.getPassword()), "foo"));
     assertEquals("bar1", destAuth.get("foo"));
     assertEquals("bar1", jedis.get("foo"));
 
@@ -194,7 +194,7 @@ public class MigrateTest extends JedisCommandsTestBase {
     assertEquals(
       "OK",
       jedis.migrate(host, portAuth, dbAuth, timeout,
-        new MigrateParams().copy().replace().auth("foobared"), bfoo));
+        new MigrateParams().copy().replace().auth(endpoint.getPassword()), bfoo));
     assertArrayEquals(bbar1, destAuth.get(bfoo));
     assertArrayEquals(bbar1, jedis.get(bfoo));
   }

--- a/src/test/java/redis/clients/jedis/commands/jedis/ObjectCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ObjectCommandsTest.java
@@ -13,11 +13,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.*;
 import redis.clients.jedis.exceptions.JedisDataException;
-import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.util.SafeEncoder;
 
 @RunWith(Parameterized.class)
@@ -25,7 +22,7 @@ public class ObjectCommandsTest extends JedisCommandsTestBase {
 
   private final String key = "mylist";
   private final byte[] binaryKey = SafeEncoder.encode(key);
-  private final HostAndPort lfuHnp = HostAndPorts.getRedisServers().get(7);
+  private final EndpointConfig lfuEndpoint = HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy");
   private Jedis lfuJedis;
 
   public ObjectCommandsTest(RedisProtocol protocol) {
@@ -37,7 +34,7 @@ public class ObjectCommandsTest extends JedisCommandsTestBase {
   public void setUp() throws Exception {
     super.setUp();
 
-    lfuJedis = new Jedis(lfuHnp.getHost(), lfuHnp.getPort(), 500);
+    lfuJedis = lfuEndpoint.getJedis();
     lfuJedis.connect();
     lfuJedis.flushAll();
   }

--- a/src/test/java/redis/clients/jedis/commands/jedis/ObjectCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ObjectCommandsTest.java
@@ -34,7 +34,8 @@ public class ObjectCommandsTest extends JedisCommandsTestBase {
   public void setUp() throws Exception {
     super.setUp();
 
-    lfuJedis = lfuEndpoint.getJedis();
+    lfuJedis = new Jedis(lfuEndpoint.getHostAndPort(),
+        lfuEndpoint.getClientConfigBuilder().build());
     lfuJedis.connect();
     lfuJedis.flushAll();
   }

--- a/src/test/java/redis/clients/jedis/commands/jedis/SentinelCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/SentinelCommandsTest.java
@@ -22,7 +22,9 @@ public class SentinelCommandsTest {
   protected static final String MASTER_NAME = "mymaster";
 
   protected static final List<HostAndPort> nodes =
-      Arrays.asList(HostAndPorts.getRedisServers().get(2), HostAndPorts.getRedisServers().get(3));
+      Arrays.asList(
+          HostAndPorts.getRedisEndpoint("standalone2-primary").getHostAndPort(),
+          HostAndPorts.getRedisEndpoint("standalone3-replica-of-standalone2").getHostAndPort());
   protected static final Set<String> nodesPorts = nodes.stream()
       .map(HostAndPort::getPort).map(String::valueOf).collect(Collectors.toSet());
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
@@ -49,7 +49,8 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
   public void setUp() throws Exception {
     super.setUp();
 
-    nj = endpoint.getJedis(500);
+    nj = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().timeoutMillis(500).build());
   }
 
   @After
@@ -363,7 +364,8 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
   @Test
   public void testCloseable() {
     // we need to test with fresh instance of Jedis
-    Jedis jedis2 = endpoint.getJedis(500);
+    Jedis jedis2 = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().timeoutMillis(500).build());;
 
     Transaction transaction = jedis2.multi();
     transaction.set("a", "1");

--- a/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
@@ -20,7 +20,6 @@ import org.junit.runners.Parameterized;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisProtocol;
@@ -50,7 +49,7 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
   public void setUp() throws Exception {
     super.setUp();
 
-    nj = new Jedis(hnp, DefaultJedisClientConfig.builder().timeoutMillis(500).password("foobared").build());
+    nj = endpoint.getJedis(500);
   }
 
   @After
@@ -365,7 +364,7 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
   @Test
   public void testCloseable() {
     // we need to test with fresh instance of Jedis
-    Jedis jedis2 = new Jedis(hnp.getHost(), hnp.getPort(), 500);
+    Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
     jedis2.auth("foobared");
 
     Transaction transaction = jedis2.multi();

--- a/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/TransactionCommandsTest.java
@@ -347,7 +347,6 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
   @Test
   public void testResetStateWithFullyExecutedTransaction() {
     Jedis jedis2 = createJedis();
-    jedis2.auth("foobared");
 
     Transaction t = jedis2.multi();
     t.set("mykey", "foo");
@@ -364,8 +363,7 @@ public class TransactionCommandsTest extends JedisCommandsTestBase {
   @Test
   public void testCloseable() {
     // we need to test with fresh instance of Jedis
-    Jedis jedis2 = new Jedis(endpoint.getHost(), endpoint.getPort(), 500);
-    jedis2.auth("foobared");
+    Jedis jedis2 = endpoint.getJedis(500);
 
     Transaction transaction = jedis2.multi();
     transaction.set("a", "1");

--- a/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledCommandsTestHelper.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledCommandsTestHelper.java
@@ -1,24 +1,19 @@
 package redis.clients.jedis.commands.unified.pooled;
 
-import redis.clients.jedis.DefaultJedisClientConfig;
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPooled;
-import redis.clients.jedis.HostAndPorts;
-import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.*;
 
 public class PooledCommandsTestHelper {
 
-  private static final HostAndPort nodeInfo = HostAndPorts.getRedisServers().get(0);
+  private static final EndpointConfig nodeInfo = HostAndPorts.getRedisEndpoint("standalone0");
 
   public static JedisPooled getPooled(RedisProtocol redisProtocol) {
-    return new JedisPooled(nodeInfo, DefaultJedisClientConfig.builder()
-        .protocol(redisProtocol).password("foobared").build());
+    return new JedisPooled(nodeInfo.getHostAndPort(), nodeInfo.getClientConfigBuilder()
+        .protocol(redisProtocol).build());
   }
 
   public static void clearData() {
-    try (Jedis node = new Jedis(nodeInfo)) {
-      node.auth("foobared");
+    try (Jedis node = new Jedis(nodeInfo.getHostAndPort())) {
+      node.auth(nodeInfo.getPassword());
       node.flushAll();
     }
   }

--- a/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
@@ -27,9 +27,9 @@ public class AutomaticFailoverTest {
   private static final Logger log = LoggerFactory.getLogger(AutomaticFailoverTest.class);
 
   // TODO(imalinovskyi): Figure out how we deploy this endpoint
-  private final HostAndPort hostPort_1 = new HostAndPort(HostAndPorts.getRedisEndpoint("standalone0").getHost(), 6378);
-  private final EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone0");
-  private final EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy");
+  private final HostAndPort hostPort_0 = new HostAndPort(HostAndPorts.getRedisEndpoint("standalone0").getHost(), 6378);
+  private final EndpointConfig endpointStandalone0 = HostAndPorts.getRedisEndpoint("standalone0");
+  private final EndpointConfig endpointStandalone7 = HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy");
 
   private final JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().build();
 
@@ -44,7 +44,8 @@ public class AutomaticFailoverTest {
 
   @Before
   public void setUp() {
-    jedis2 = endpoint2.getJedis();
+    jedis2 = new Jedis(endpointStandalone7.getHostAndPort(),
+        endpointStandalone7.getClientConfigBuilder().build());
     jedis2.flushAll();
   }
 
@@ -56,7 +57,7 @@ public class AutomaticFailoverTest {
   @Test
   public void pipelineWithSwitch() {
     MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
-        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPort_1, endpoint2.getHostAndPort())).build());
+        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPort_0, endpointStandalone7.getHostAndPort())).build());
 
     try (UnifiedJedis client = new UnifiedJedis(provider)) {
       AbstractPipeline pipe = client.pipelined();
@@ -73,7 +74,7 @@ public class AutomaticFailoverTest {
   @Test
   public void transactionWithSwitch() {
     MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
-        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPort_1, endpoint2.getHostAndPort())).build());
+        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPort_0, endpointStandalone7.getHostAndPort())).build());
 
     try (UnifiedJedis client = new UnifiedJedis(provider)) {
       AbstractTransaction tx = client.multi();
@@ -93,7 +94,7 @@ public class AutomaticFailoverTest {
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
-        getClusterConfigs(clientConfig, hostPort_1, endpoint2.getHostAndPort()))
+        getClusterConfigs(clientConfig, hostPort_0, endpointStandalone7.getHostAndPort()))
         .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
         .circuitBreakerSlidingWindowSize(slidingWindowSize);
 
@@ -131,7 +132,7 @@ public class AutomaticFailoverTest {
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
-        getClusterConfigs(clientConfig, hostPort_1, endpoint2.getHostAndPort()))
+        getClusterConfigs(clientConfig, hostPort_0, endpointStandalone7.getHostAndPort()))
         .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
         .circuitBreakerSlidingWindowSize(slidingWindowSize)
         .fallbackExceptionList(Arrays.asList(JedisConnectionException.class));
@@ -164,7 +165,7 @@ public class AutomaticFailoverTest {
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
-        getClusterConfigs(clientConfig, endpoint1.getHostAndPort(), endpoint2.getHostAndPort()))
+        getClusterConfigs(clientConfig, endpointStandalone0.getHostAndPort(), endpointStandalone7.getHostAndPort()))
         .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
         .circuitBreakerSlidingWindowSize(slidingWindowSize)
         .fallbackExceptionList(Arrays.asList(JedisAccessControlException.class));

--- a/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
@@ -27,8 +27,8 @@ public class AutomaticFailoverTest {
   private static final Logger log = LoggerFactory.getLogger(AutomaticFailoverTest.class);
 
   private final HostAndPort hostPortWithFailure = new HostAndPort(HostAndPorts.getRedisEndpoint("standalone0").getHost(), 6378);
-  private final EndpointConfig workingEndpointWithPriority1 = HostAndPorts.getRedisEndpoint("standalone0");
-  private final EndpointConfig workingEndpointWithPriority2 = HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy");
+  private final EndpointConfig endpointForAuthFailure = HostAndPorts.getRedisEndpoint("standalone0");
+  private final EndpointConfig workingEndpoint = HostAndPorts.getRedisEndpoint("standalone7-with-lfu-policy");
 
   private final JedisClientConfig clientConfig = DefaultJedisClientConfig.builder().build();
 
@@ -43,8 +43,8 @@ public class AutomaticFailoverTest {
 
   @Before
   public void setUp() {
-    jedis2 = new Jedis(workingEndpointWithPriority2.getHostAndPort(),
-        workingEndpointWithPriority2.getClientConfigBuilder().build());
+    jedis2 = new Jedis(workingEndpoint.getHostAndPort(),
+        workingEndpoint.getClientConfigBuilder().build());
     jedis2.flushAll();
   }
 
@@ -56,7 +56,7 @@ public class AutomaticFailoverTest {
   @Test
   public void pipelineWithSwitch() {
     MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
-        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpointWithPriority2.getHostAndPort())).build());
+        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpoint.getHostAndPort())).build());
 
     try (UnifiedJedis client = new UnifiedJedis(provider)) {
       AbstractPipeline pipe = client.pipelined();
@@ -73,7 +73,7 @@ public class AutomaticFailoverTest {
   @Test
   public void transactionWithSwitch() {
     MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
-        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpointWithPriority2.getHostAndPort())).build());
+        new MultiClusterClientConfig.Builder(getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpoint.getHostAndPort())).build());
 
     try (UnifiedJedis client = new UnifiedJedis(provider)) {
       AbstractTransaction tx = client.multi();
@@ -93,7 +93,7 @@ public class AutomaticFailoverTest {
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
-        getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpointWithPriority2.getHostAndPort()))
+        getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpoint.getHostAndPort()))
         .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
         .circuitBreakerSlidingWindowSize(slidingWindowSize);
 
@@ -131,7 +131,7 @@ public class AutomaticFailoverTest {
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
-        getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpointWithPriority2.getHostAndPort()))
+        getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpoint.getHostAndPort()))
         .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
         .circuitBreakerSlidingWindowSize(slidingWindowSize)
         .fallbackExceptionList(Arrays.asList(JedisConnectionException.class));
@@ -164,7 +164,7 @@ public class AutomaticFailoverTest {
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
-        getClusterConfigs(clientConfig, workingEndpointWithPriority1.getHostAndPort(), workingEndpointWithPriority2.getHostAndPort()))
+        getClusterConfigs(clientConfig, endpointForAuthFailure.getHostAndPort(), workingEndpoint.getHostAndPort()))
         .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
         .circuitBreakerSlidingWindowSize(slidingWindowSize)
         .fallbackExceptionList(Arrays.asList(JedisAccessControlException.class));

--- a/src/test/java/redis/clients/jedis/misc/ClusterInitErrorTest.java
+++ b/src/test/java/redis/clients/jedis/misc/ClusterInitErrorTest.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
@@ -21,9 +21,10 @@ public class ClusterInitErrorTest {
   @Test(expected = JedisClusterOperationException.class)
   public void initError() {
     Assert.assertNull(System.getProperty(INIT_NO_ERROR_PROPERTY));
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
     try (JedisCluster cluster = new JedisCluster(
-        Collections.singleton(HostAndPorts.getRedisServers().get(0)),
-        DefaultJedisClientConfig.builder().password("foobared").build())) {
+        Collections.singleton(endpoint.getHostAndPort()),
+        endpoint.getClientConfigBuilder().build())) {
       throw new IllegalStateException("should not reach here");
     }
   }
@@ -31,9 +32,10 @@ public class ClusterInitErrorTest {
   @Test
   public void initNoError() {
     System.setProperty(INIT_NO_ERROR_PROPERTY, "");
+    EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
     try (JedisCluster cluster = new JedisCluster(
-        Collections.singleton(HostAndPorts.getRedisServers().get(0)),
-        DefaultJedisClientConfig.builder().password("foobared").build())) {
+        Collections.singleton(endpoint.getHostAndPort()),
+        endpoint.getClientConfigBuilder().build())) {
       Assert.assertThrows(JedisClusterOperationException.class, () -> cluster.get("foo"));
     }
   }

--- a/src/test/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProviderTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.*;
  */
 public class MultiClusterPooledConnectionProviderTest {
 
-    private final EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone0");
-    private final EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("standalone1");
+    private final EndpointConfig endpointStandalone0 = HostAndPorts.getRedisEndpoint("standalone0");
+    private final EndpointConfig endpointStandalone1 = HostAndPorts.getRedisEndpoint("standalone1");
 
     private MultiClusterPooledConnectionProvider provider;
 
@@ -26,8 +26,8 @@ public class MultiClusterPooledConnectionProviderTest {
     public void setUp() {
 
         ClusterConfig[] clusterConfigs = new ClusterConfig[2];
-        clusterConfigs[0] = new ClusterConfig(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build());
-        clusterConfigs[1] = new ClusterConfig(endpoint2.getHostAndPort(), endpoint1.getClientConfigBuilder().build());
+        clusterConfigs[0] = new ClusterConfig(endpointStandalone0.getHostAndPort(), endpointStandalone0.getClientConfigBuilder().build());
+        clusterConfigs[1] = new ClusterConfig(endpointStandalone1.getHostAndPort(), endpointStandalone0.getClientConfigBuilder().build());
 
         provider = new MultiClusterPooledConnectionProvider(new MultiClusterClientConfig.Builder(clusterConfigs).build());
     }
@@ -138,8 +138,8 @@ public class MultiClusterPooledConnectionProviderTest {
         poolConfig.setMaxIdle(4);
         poolConfig.setMinIdle(1);
         ClusterConfig[] clusterConfigs = new ClusterConfig[2];
-        clusterConfigs[0] = new ClusterConfig(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build(), poolConfig);
-        clusterConfigs[1] = new ClusterConfig(endpoint2.getHostAndPort(), endpoint1.getClientConfigBuilder().build(), poolConfig);
+        clusterConfigs[0] = new ClusterConfig(endpointStandalone0.getHostAndPort(), endpointStandalone0.getClientConfigBuilder().build(), poolConfig);
+        clusterConfigs[1] = new ClusterConfig(endpointStandalone1.getHostAndPort(), endpointStandalone0.getClientConfigBuilder().build(), poolConfig);
         try (MultiClusterPooledConnectionProvider customProvider = new MultiClusterPooledConnectionProvider(
                 new MultiClusterClientConfig.Builder(clusterConfigs).build())) {
             MultiClusterPooledConnectionProvider.Cluster activeCluster = customProvider.getCluster();

--- a/src/test/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/MultiClusterPooledConnectionProviderTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.*;
  */
 public class MultiClusterPooledConnectionProviderTest {
 
-    private final HostAndPort hostAndPort1 = HostAndPorts.getRedisServers().get(0);
-    private final HostAndPort hostAndPort2 = HostAndPorts.getRedisServers().get(1);
+    private final EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("standalone0");
+    private final EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("standalone1");
 
     private MultiClusterPooledConnectionProvider provider;
 
@@ -26,8 +26,8 @@ public class MultiClusterPooledConnectionProviderTest {
     public void setUp() {
 
         ClusterConfig[] clusterConfigs = new ClusterConfig[2];
-        clusterConfigs[0] = new ClusterConfig(hostAndPort1, DefaultJedisClientConfig.builder().build());
-        clusterConfigs[1] = new ClusterConfig(hostAndPort2, DefaultJedisClientConfig.builder().build());
+        clusterConfigs[0] = new ClusterConfig(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build());
+        clusterConfigs[1] = new ClusterConfig(endpoint2.getHostAndPort(), endpoint1.getClientConfigBuilder().build());
 
         provider = new MultiClusterPooledConnectionProvider(new MultiClusterClientConfig.Builder(clusterConfigs).build());
     }
@@ -138,8 +138,8 @@ public class MultiClusterPooledConnectionProviderTest {
         poolConfig.setMaxIdle(4);
         poolConfig.setMinIdle(1);
         ClusterConfig[] clusterConfigs = new ClusterConfig[2];
-        clusterConfigs[0] = new ClusterConfig(hostAndPort1, DefaultJedisClientConfig.builder().build(), poolConfig);
-        clusterConfigs[1] = new ClusterConfig(hostAndPort2, DefaultJedisClientConfig.builder().build(), poolConfig);
+        clusterConfigs[0] = new ClusterConfig(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build(), poolConfig);
+        clusterConfigs[1] = new ClusterConfig(endpoint2.getHostAndPort(), endpoint1.getClientConfigBuilder().build(), poolConfig);
         try (MultiClusterPooledConnectionProvider customProvider = new MultiClusterPooledConnectionProvider(
                 new MultiClusterClientConfig.Builder(clusterConfigs).build())) {
             MultiClusterPooledConnectionProvider.Cluster activeCluster = customProvider.getCluster();

--- a/src/test/java/redis/clients/jedis/util/RedisVersionUtil.java
+++ b/src/test/java/redis/clients/jedis/util/RedisVersionUtil.java
@@ -1,14 +1,14 @@
 package redis.clients.jedis.util;
 
+import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.Jedis;
 
 public class RedisVersionUtil {
 
-  public static Integer getRedisMajorVersionNumber() {
+  public static Integer getRedisMajorVersionNumber(EndpointConfig endpoint) {
     String completeVersion = null;
 
-    try (Jedis jedis = new Jedis()) {
-      jedis.auth("foobared");
+    try (Jedis jedis = endpoint.getJedis()) {
       String info = jedis.info("server");
       String[] splitted = info.split("\\s+|:");
       for (int i = 0; i < splitted.length; i++) {
@@ -25,7 +25,7 @@ public class RedisVersionUtil {
     return Integer.parseInt(completeVersion.substring(0, completeVersion.indexOf(".")));
   }
 
-  public static boolean checkRedisMajorVersionNumber(int minVersion) {
-    return getRedisMajorVersionNumber() >= minVersion;
+  public static boolean checkRedisMajorVersionNumber(int minVersion, EndpointConfig endpoint) {
+    return getRedisMajorVersionNumber(endpoint) >= minVersion;
   }
 }

--- a/src/test/java/redis/clients/jedis/util/RedisVersionUtil.java
+++ b/src/test/java/redis/clients/jedis/util/RedisVersionUtil.java
@@ -8,7 +8,8 @@ public class RedisVersionUtil {
   public static Integer getRedisMajorVersionNumber(EndpointConfig endpoint) {
     String completeVersion = null;
 
-    try (Jedis jedis = endpoint.getJedis()) {
+    try (Jedis jedis = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().build())) {
       String info = jedis.info("server");
       String[] splitted = info.split("\\s+|:");
       for (int i = 0; i < splitted.length; i++) {

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -7,12 +7,28 @@
       "redis://localhost:6379"
     ]
   },
+  "standalone0-tls": {
+    "username": "default",
+    "password": "foobared",
+    "tls": true,
+    "endpoints": [
+      "rediss://localhost:6390"
+    ]
+  },
   "standalone0-acl": {
     "username": "acljedis",
     "password": "fizzbuzz",
     "tls": false,
     "endpoints": [
       "redis://localhost:6379"
+    ]
+  },
+  "standalone0-acl-tls": {
+    "username": "acljedis",
+    "password": "fizzbuzz",
+    "tls": true,
+    "endpoints": [
+      "rediss://localhost:6390"
     ]
   },
   "standalone1": {

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -1,0 +1,78 @@
+{
+  "standalone0": {
+    "username": "acljedis",
+    "password": "fizzbuzz",
+    "tls": false,
+    "endpoints": [
+      "localhost:6379"
+    ]
+  },
+  "standalone1": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "localhost:6380"
+    ]
+  },
+  "standalone2-primary": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "localhost:6381"
+    ]
+  },
+  "standalone3-replica-of-standalone2": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "localhost:6382"
+    ]
+  },
+  "standalone4-replica-of-standalone1": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "localhost:6383"
+    ]
+  },
+  "standalone5-primary": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "localhost:6384"
+    ]
+  },
+  "standalone6-replica-of-standalone5": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "localhost:6385"
+    ]
+  },
+  "standalone7-with-lfu-policy": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "localhost:6386"
+    ]
+  },
+  "standalone9": {
+    "tls": false,
+    "endpoints": [
+      "localhost:6388"
+    ]
+  },
+  "standalone10-replica-of-standalone9": {
+    "tls": false,
+    "endpoints": [
+      "localhost:6389"
+    ]
+  }
+}

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -1,5 +1,13 @@
 {
   "standalone0": {
+    "username": "default",
+    "password": "foobared",
+    "tls": false,
+    "endpoints": [
+      "redis://localhost:6379"
+    ]
+  },
+  "standalone0-acl": {
     "username": "acljedis",
     "password": "fizzbuzz",
     "tls": false,
@@ -73,6 +81,12 @@
     "tls": false,
     "endpoints": [
       "redis://localhost:6389"
+    ]
+  },
+  "modules-docker": {
+    "tls": false,
+    "endpoints": [
+      "redis://localhost:6479"
     ]
   }
 }

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -4,7 +4,7 @@
     "password": "fizzbuzz",
     "tls": false,
     "endpoints": [
-      "localhost:6379"
+      "redis://localhost:6379"
     ]
   },
   "standalone1": {
@@ -12,7 +12,7 @@
     "password": "foobared",
     "tls": false,
     "endpoints": [
-      "localhost:6380"
+      "redis://localhost:6380"
     ]
   },
   "standalone2-primary": {
@@ -20,7 +20,7 @@
     "password": "foobared",
     "tls": false,
     "endpoints": [
-      "localhost:6381"
+      "redis://localhost:6381"
     ]
   },
   "standalone3-replica-of-standalone2": {
@@ -28,7 +28,7 @@
     "password": "foobared",
     "tls": false,
     "endpoints": [
-      "localhost:6382"
+      "redis://localhost:6382"
     ]
   },
   "standalone4-replica-of-standalone1": {
@@ -36,7 +36,7 @@
     "password": "foobared",
     "tls": false,
     "endpoints": [
-      "localhost:6383"
+      "redis://localhost:6383"
     ]
   },
   "standalone5-primary": {
@@ -44,7 +44,7 @@
     "password": "foobared",
     "tls": false,
     "endpoints": [
-      "localhost:6384"
+      "redis://localhost:6384"
     ]
   },
   "standalone6-replica-of-standalone5": {
@@ -52,7 +52,7 @@
     "password": "foobared",
     "tls": false,
     "endpoints": [
-      "localhost:6385"
+      "redis://localhost:6385"
     ]
   },
   "standalone7-with-lfu-policy": {
@@ -60,19 +60,19 @@
     "password": "foobared",
     "tls": false,
     "endpoints": [
-      "localhost:6386"
+      "redis://localhost:6386"
     ]
   },
   "standalone9": {
     "tls": false,
     "endpoints": [
-      "localhost:6388"
+      "redis://localhost:6388"
     ]
   },
   "standalone10-replica-of-standalone9": {
     "tls": false,
     "endpoints": [
-      "localhost:6389"
+      "redis://localhost:6389"
     ]
   }
 }

--- a/src/test/resources/endpoints.json
+++ b/src/test/resources/endpoints.json
@@ -1,6 +1,5 @@
 {
   "standalone0": {
-    "username": "default",
     "password": "foobared",
     "tls": false,
     "endpoints": [


### PR DESCRIPTION
This PR aims to introduce a better way to manage connection settings in the tests while making minimal possible impact.

**Out of the scope:**
Rewriting/Updating all the tests to support endpoint swapping
