### PR TITLE
Disable Redis Graph tests

### DIFF
--- a/src/test/java/redis/clients/jedis/modules/graph/GraphAPITest.java
+++ b/src/test/java/redis/clients/jedis/modules/graph/GraphAPITest.java
@@ -22,9 +22,9 @@ import redis.clients.jedis.graph.Record;
 import redis.clients.jedis.graph.ResultSet;
 import redis.clients.jedis.graph.Statistics;
 import redis.clients.jedis.graph.entities.*;
-
 import redis.clients.jedis.modules.RedisModuleCommandsTestBase;
 
+@org.junit.Ignore
 @RunWith(Parameterized.class)
 public class GraphAPITest extends RedisModuleCommandsTestBase {
 

--- a/src/test/java/redis/clients/jedis/modules/graph/GraphPipelineTest.java
+++ b/src/test/java/redis/clients/jedis/modules/graph/GraphPipelineTest.java
@@ -26,6 +26,7 @@ import redis.clients.jedis.graph.entities.Node;
 import redis.clients.jedis.graph.entities.Property;
 import redis.clients.jedis.modules.RedisModuleCommandsTestBase;
 
+@org.junit.Ignore
 @RunWith(Parameterized.class)
 public class GraphPipelineTest extends RedisModuleCommandsTestBase {
 

--- a/src/test/java/redis/clients/jedis/modules/graph/GraphTransactionTest.java
+++ b/src/test/java/redis/clients/jedis/modules/graph/GraphTransactionTest.java
@@ -23,6 +23,7 @@ import redis.clients.jedis.graph.entities.Node;
 import redis.clients.jedis.graph.entities.Property;
 import redis.clients.jedis.modules.RedisModuleCommandsTestBase;
 
+@org.junit.Ignore
 @RunWith(Parameterized.class)
 public class GraphTransactionTest extends RedisModuleCommandsTestBase {
 

--- a/src/test/java/redis/clients/jedis/modules/graph/GraphValuesTest.java
+++ b/src/test/java/redis/clients/jedis/modules/graph/GraphValuesTest.java
@@ -12,6 +12,7 @@ import redis.clients.jedis.graph.Record;
 import redis.clients.jedis.graph.ResultSet;
 import redis.clients.jedis.modules.RedisModuleCommandsTestBase;
 
+@org.junit.Ignore
 @RunWith(Parameterized.class)
 public class GraphValuesTest extends RedisModuleCommandsTestBase {
 


### PR DESCRIPTION
We use redis-stack-server image to test all module commands. RedisGraph module has been removed from that image.