### PR TITLE
Support [S]PUBLISH in pipelines and transactions

### DIFF
--- a/src/main/java/redis/clients/jedis/AbstractTransaction.java
+++ b/src/main/java/redis/clients/jedis/AbstractTransaction.java
@@ -36,4 +36,12 @@ public abstract class AbstractTransaction extends PipeliningBase implements Clos
   public Response<Long> waitReplicas(int replicas, long timeout) {
     return appendCommand(commandObjects.waitReplicas(replicas, timeout));
   }
+
+  public Response<Long> publish(String channel, String message) {
+    return appendCommand(commandObjects.publish(channel, message));
+  }
+
+  public Response<Long> publish(byte[] channel, byte[] message) {
+    return appendCommand(commandObjects.publish(channel, message));
+  }
 }

--- a/src/main/java/redis/clients/jedis/ClusterPipeline.java
+++ b/src/main/java/redis/clients/jedis/ClusterPipeline.java
@@ -46,6 +46,13 @@ public class ClusterPipeline extends MultiNodePipelineBase {
     return cco;
   }
 
+  /**
+   * This method must be called after constructor, if graph commands are going to be used.
+   */
+  public void prepareGraphCommands() {
+    super.prepareGraphCommands(provider);
+  }
+
   @Override
   public void close() {
     try {
@@ -65,10 +72,11 @@ public class ClusterPipeline extends MultiNodePipelineBase {
     return provider.getConnection(nodeKey);
   }
 
-  /**
-   * This method must be called after constructor, if graph commands are going to be used.
-   */
-  public void prepareGraphCommands() {
-    super.prepareGraphCommands(provider);
+  public Response<Long> spublish(String channel, String message) {
+    return appendCommand(commandObjects.spublish(channel, message));
+  }
+
+  public Response<Long> spublish(byte[] channel, byte[] message) {
+    return appendCommand(commandObjects.spublish(channel, message));
   }
 }

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -349,7 +349,7 @@ public class Connection implements Closeable {
     try {
       return Protocol.read(inputStream);
 //      Object read = Protocol.read(inputStream);
-//      System.out.println(SafeEncoder.encodeObject(read));
+//      System.out.println(redis.clients.jedis.util.SafeEncoder.encodeObject(read));
 //      return read;
     } catch (JedisConnectionException exc) {
       broken = true;

--- a/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterPipeliningTest.java
@@ -1025,6 +1025,18 @@ public class ClusterPipeliningTest {
   }
 
   @Test
+  public void spublishInPipeline() {
+    try (JedisCluster jedis = new JedisCluster(nodes, DEFAULT_CLIENT_CONFIG)) {
+      ClusterPipeline pipelined = jedis.pipelined();
+      Response<Long> p1 = pipelined.publish("foo", "bar");
+      Response<Long> p2 = pipelined.publish("foo".getBytes(), "bar".getBytes());
+      pipelined.sync();
+      assertEquals(0, p1.get().longValue());
+      assertEquals(0, p2.get().longValue());
+    }
+  }
+
+  @Test
   public void simple() { // TODO: move into 'redis.clients.jedis.commands.unified.cluster' package
     try (JedisCluster jedis = new JedisCluster(nodes, DEFAULT_CLIENT_CONFIG)) {
       final int count = 10;

--- a/src/test/java/redis/clients/jedis/PipeliningTest.java
+++ b/src/test/java/redis/clients/jedis/PipeliningTest.java
@@ -257,7 +257,7 @@ public class PipeliningTest extends JedisCommandsTestBase {
   }
 
   @Test
-  public void pipelineWithPubSub() {
+  public void publishInPipeline() {
     Pipeline pipelined = jedis.pipelined();
     Response<Long> p1 = pipelined.publish("foo", "bar");
     Response<Long> p2 = pipelined.publish("foo".getBytes(), "bar".getBytes());

--- a/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
@@ -17,7 +17,6 @@ import redis.clients.jedis.AbstractPipeline;
 import redis.clients.jedis.AbstractTransaction;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.Response;
-import redis.clients.jedis.Transaction;
 import redis.clients.jedis.commands.unified.UnifiedJedisCommandsTestBase;
 import redis.clients.jedis.exceptions.JedisDataException;
 

--- a/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
@@ -17,6 +17,7 @@ import redis.clients.jedis.AbstractPipeline;
 import redis.clients.jedis.AbstractTransaction;
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.Response;
+import redis.clients.jedis.Transaction;
 import redis.clients.jedis.commands.unified.UnifiedJedisCommandsTestBase;
 import redis.clients.jedis.exceptions.JedisDataException;
 
@@ -106,7 +107,6 @@ public class PooledMiscellaneousTest extends UnifiedJedisCommandsTestBase {
 
   @Test
   public void watch() {
-    List<Object> resp;
     try (AbstractTransaction tx = jedis.transaction(false)) {
       assertEquals("OK", tx.watch("mykey", "somekey"));
       tx.multi();
@@ -114,10 +114,22 @@ public class PooledMiscellaneousTest extends UnifiedJedisCommandsTestBase {
       jedis.set("mykey", "bar");
 
       tx.set("mykey", "foo");
-      resp = tx.exec();
+      assertNull(tx.exec());
+
+      assertEquals("bar", jedis.get("mykey"));
     }
-    assertNull(resp);
-    assertEquals("bar", jedis.get("mykey"));
+  }
+
+  @Test
+  public void publishInTransaction() {
+    try (AbstractTransaction tx = jedis.multi()) {
+      Response<Long> p1 = tx.publish("foo", "bar");
+      Response<Long> p2 = tx.publish("foo".getBytes(), "bar".getBytes());
+      tx.exec();
+
+      assertEquals(0, p1.get().longValue());
+      assertEquals(0, p2.get().longValue());
+    }
   }
 
   @Test


### PR DESCRIPTION
1. We already have PUBLISH in simple Pipeline.
2. We have SPUBLISH only in JedisCluster; so it's only added in ClusterPipeline.
3. We don't have transaction with cluster. So obviously [S]PUBLISH isn't implemented for such case.