### PR TITLE
Support IGNORE and other optional arguments for timeseries commands

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -3946,9 +3946,15 @@ public class CommandObjects {
     return new CommandObject<>(commandArguments(TimeSeriesCommand.ADD).key(key).add(timestamp).add(value), BuilderFactory.LONG);
   }
 
+  @Deprecated
   public final CommandObject<Long> tsAdd(String key, long timestamp, double value, TSCreateParams createParams) {
-    return new CommandObject<>(commandArguments(TimeSeriesCommand.ADD).key(key)
-        .add(timestamp).add(value).addParams(createParams), BuilderFactory.LONG);
+    return new CommandObject<>(commandArguments(TimeSeriesCommand.ADD).key(key).add(timestamp).add(value)
+        .addParams(createParams), BuilderFactory.LONG);
+  }
+
+  public final CommandObject<Long> tsAdd(String key, long timestamp, double value, TSAddParams addParams) {
+    return new CommandObject<>(commandArguments(TimeSeriesCommand.ADD).key(key).add(timestamp).add(value)
+        .addParams(addParams), BuilderFactory.LONG);
   }
 
   public final CommandObject<List<Long>> tsMAdd(Map.Entry<String, TSElement>... entries) {
@@ -3968,6 +3974,11 @@ public class CommandObjects {
         .add(TimeSeriesKeyword.TIMESTAMP).add(timestamp), BuilderFactory.LONG);
   }
 
+  public final CommandObject<Long> tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams) {
+    return new CommandObject<>(commandArguments(TimeSeriesCommand.INCRBY).key(key).add(addend)
+        .addParams(incrByParams), BuilderFactory.LONG);
+  }
+
   public final CommandObject<Long> tsDecrBy(String key, double value) {
     return new CommandObject<>(commandArguments(TimeSeriesCommand.DECRBY).key(key).add(value), BuilderFactory.LONG);
   }
@@ -3975,6 +3986,11 @@ public class CommandObjects {
   public final CommandObject<Long> tsDecrBy(String key, double value, long timestamp) {
     return new CommandObject<>(commandArguments(TimeSeriesCommand.DECRBY).key(key).add(value)
         .add(TimeSeriesKeyword.TIMESTAMP).add(timestamp), BuilderFactory.LONG);
+  }
+
+  public final CommandObject<Long> tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams) {
+    return new CommandObject<>(commandArguments(TimeSeriesCommand.DECRBY).key(key).add(subtrahend)
+        .addParams(decrByParams), BuilderFactory.LONG);
   }
 
   public final CommandObject<List<TSElement>> tsRange(String key, long fromTimestamp, long toTimestamp) {

--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -3974,7 +3974,7 @@ public class CommandObjects {
         .add(TimeSeriesKeyword.TIMESTAMP).add(timestamp), BuilderFactory.LONG);
   }
 
-  public final CommandObject<Long> tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams) {
+  public final CommandObject<Long> tsIncrBy(String key, double addend, TSIncrOrDecrByParams incrByParams) {
     return new CommandObject<>(commandArguments(TimeSeriesCommand.INCRBY).key(key).add(addend)
         .addParams(incrByParams), BuilderFactory.LONG);
   }
@@ -3988,7 +3988,7 @@ public class CommandObjects {
         .add(TimeSeriesKeyword.TIMESTAMP).add(timestamp), BuilderFactory.LONG);
   }
 
-  public final CommandObject<Long> tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams) {
+  public final CommandObject<Long> tsDecrBy(String key, double subtrahend, TSIncrOrDecrByParams decrByParams) {
     return new CommandObject<>(commandArguments(TimeSeriesCommand.DECRBY).key(key).add(subtrahend)
         .addParams(decrByParams), BuilderFactory.LONG);
   }

--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -3949,6 +3949,11 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<Long> tsAdd(String key, long timestamp, double value, TSAddParams addParams) {
+    return appendCommand(commandObjects.tsAdd(key, timestamp, value, addParams));
+  }
+
+  @Override
   public Response<List<Long>> tsMAdd(Map.Entry<String, TSElement>... entries) {
     return appendCommand(commandObjects.tsMAdd(entries));
   }
@@ -3964,6 +3969,11 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<Long> tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams) {
+    return appendCommand(commandObjects.tsIncrBy(key, addend, incrByParams));
+  }
+
+  @Override
   public Response<Long> tsDecrBy(String key, double value) {
     return appendCommand(commandObjects.tsDecrBy(key, value));
   }
@@ -3971,6 +3981,11 @@ public abstract class PipeliningBase
   @Override
   public Response<Long> tsDecrBy(String key, double value, long timestamp) {
     return appendCommand(commandObjects.tsDecrBy(key, value, timestamp));
+  }
+
+  @Override
+  public Response<Long> tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams) {
+    return appendCommand(commandObjects.tsDecrBy(key, subtrahend, decrByParams));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -3969,7 +3969,7 @@ public abstract class PipeliningBase
   }
 
   @Override
-  public Response<Long> tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams) {
+  public Response<Long> tsIncrBy(String key, double addend, TSIncrOrDecrByParams incrByParams) {
     return appendCommand(commandObjects.tsIncrBy(key, addend, incrByParams));
   }
 
@@ -3984,7 +3984,7 @@ public abstract class PipeliningBase
   }
 
   @Override
-  public Response<Long> tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams) {
+  public Response<Long> tsDecrBy(String key, double subtrahend, TSIncrOrDecrByParams decrByParams) {
     return appendCommand(commandObjects.tsDecrBy(key, subtrahend, decrByParams));
   }
 

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -4474,6 +4474,11 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public long tsAdd(String key, long timestamp, double value, TSAddParams addParams) {
+    return executeCommand(commandObjects.tsAdd(key, timestamp, value, addParams));
+  }
+
+  @Override
   public List<Long> tsMAdd(Map.Entry<String, TSElement>... entries) {
     return executeCommand(commandObjects.tsMAdd(entries));
   }
@@ -4489,6 +4494,11 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public long tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams) {
+    return executeCommand(commandObjects.tsIncrBy(key, addend, incrByParams));
+  }
+
+  @Override
   public long tsDecrBy(String key, double value) {
     return executeCommand(commandObjects.tsDecrBy(key, value));
   }
@@ -4496,6 +4506,11 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   @Override
   public long tsDecrBy(String key, double value, long timestamp) {
     return executeCommand(commandObjects.tsDecrBy(key, value, timestamp));
+  }
+
+  @Override
+  public long tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams) {
+    return executeCommand(commandObjects.tsDecrBy(key, subtrahend, decrByParams));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -4494,7 +4494,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
-  public long tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams) {
+  public long tsIncrBy(String key, double addend, TSIncrOrDecrByParams incrByParams) {
     return executeCommand(commandObjects.tsIncrBy(key, addend, incrByParams));
   }
 
@@ -4509,7 +4509,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
-  public long tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams) {
+  public long tsDecrBy(String key, double subtrahend, TSIncrOrDecrByParams decrByParams) {
     return executeCommand(commandObjects.tsDecrBy(key, subtrahend, decrByParams));
   }
 

--- a/src/main/java/redis/clients/jedis/timeseries/EncodingFormat.java
+++ b/src/main/java/redis/clients/jedis/timeseries/EncodingFormat.java
@@ -1,0 +1,24 @@
+package redis.clients.jedis.timeseries;
+
+import redis.clients.jedis.args.Rawable;
+import redis.clients.jedis.util.SafeEncoder;
+
+/**
+ * Specifies the series samples encoding format.
+ */
+public enum EncodingFormat implements Rawable {
+
+  COMPRESSED,
+  UNCOMPRESSED;
+
+  private final byte[] raw;
+
+  private EncodingFormat() {
+    raw = SafeEncoder.encode(name());
+  }
+
+  @Override
+  public byte[] getRaw() {
+    return raw;
+  }
+}

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
@@ -59,15 +59,32 @@ public interface RedisTimeSeriesCommands {
   long tsAdd(String key, long timestamp, double value);
 
   /**
-   * {@code TS.ADD key timestamp value [RETENTION retentionTime] [ENCODING [COMPRESSED|UNCOMPRESSED]] [CHUNK_SIZE size] [ON_DUPLICATE policy] [LABELS label value..]}
-   *
    * @param key
    * @param timestamp
    * @param value
    * @param createParams
    * @return timestamp
+   * @deprecated Use {@link RedisTimeSeriesCommands#tsAdd(java.lang.String, long, double, redis.clients.jedis.timeseries.TSAddParams)}.
    */
+  @Deprecated
   long tsAdd(String key, long timestamp, double value, TSCreateParams createParams);
+
+  /**
+   * {@code TS.ADD key timestamp value
+   * [RETENTION retentionTime]
+   * [ENCODING <COMPRESSED|UNCOMPRESSED>]
+   * [CHUNK_SIZE size]
+   * [DUPLICATE_POLICY policy]
+   * [ON_DUPLICATE policy_ovr]
+   * [LABELS label value..]}
+   *
+   * @param key
+   * @param timestamp
+   * @param value
+   * @param addParams
+   * @return timestamp
+   */
+  long tsAdd(String key, long timestamp, double value, TSAddParams addParams);
 
   /**
    * {@code TS.MADD key timestamp value [key timestamp value ...]}
@@ -81,9 +98,43 @@ public interface RedisTimeSeriesCommands {
 
   long tsIncrBy(String key, double value, long timestamp);
 
+  /**
+   * {@code TS.INCRBY key addend
+   * [TIMESTAMP timestamp]
+   * [RETENTION retentionPeriod]
+   * [ENCODING <COMPRESSED|UNCOMPRESSED>]
+   * [CHUNK_SIZE size]
+   * [DUPLICATE_POLICY policy]
+   * [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
+   * [LABELS [label value ...]]}
+   *
+   * @param key
+   * @param addend
+   * @param incrByParams
+   * @return timestamp
+   */
+  long tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams);
+
   long tsDecrBy(String key, double value);
 
   long tsDecrBy(String key, double value, long timestamp);
+
+  /**
+   * {@code TS.DECRBY key subtrahend
+   * [TIMESTAMP timestamp]
+   * [RETENTION retentionPeriod]
+   * [ENCODING <COMPRESSED|UNCOMPRESSED>]
+   * [CHUNK_SIZE size]
+   * [DUPLICATE_POLICY policy]
+   * [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
+   * [LABELS [label value ...]]}
+   *
+   * @param key
+   * @param subtrahend
+   * @param decrByParams
+   * @return timestamp
+   */
+  long tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams);
 
   /**
    * {@code TS.RANGE key fromTimestamp toTimestamp}

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesCommands.java
@@ -113,7 +113,7 @@ public interface RedisTimeSeriesCommands {
    * @param incrByParams
    * @return timestamp
    */
-  long tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams);
+  long tsIncrBy(String key, double addend, TSIncrOrDecrByParams incrByParams);
 
   long tsDecrBy(String key, double value);
 
@@ -134,7 +134,7 @@ public interface RedisTimeSeriesCommands {
    * @param decrByParams
    * @return timestamp
    */
-  long tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams);
+  long tsDecrBy(String key, double subtrahend, TSIncrOrDecrByParams decrByParams);
 
   /**
    * {@code TS.RANGE key fromTimestamp toTimestamp}

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
@@ -29,13 +29,13 @@ public interface RedisTimeSeriesPipelineCommands {
 
   Response<Long> tsIncrBy(String key, double value, long timestamp);
 
-  Response<Long> tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams);
+  Response<Long> tsIncrBy(String key, double addend, TSIncrOrDecrByParams incrByParams);
 
   Response<Long> tsDecrBy(String key, double value);
 
   Response<Long> tsDecrBy(String key, double value, long timestamp);
 
-  Response<Long> tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams);
+  Response<Long> tsDecrBy(String key, double subtrahend, TSIncrOrDecrByParams decrByParams);
 
   Response<List<TSElement>> tsRange(String key, long fromTimestamp, long toTimestamp);
 

--- a/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/timeseries/RedisTimeSeriesPipelineCommands.java
@@ -18,7 +18,10 @@ public interface RedisTimeSeriesPipelineCommands {
 
   Response<Long> tsAdd(String key, long timestamp, double value);
 
+  @Deprecated
   Response<Long> tsAdd(String key, long timestamp, double value, TSCreateParams createParams);
+
+  Response<Long> tsAdd(String key, long timestamp, double value, TSAddParams addParams);
 
   Response<List<Long>> tsMAdd(Map.Entry<String, TSElement>... entries);
 
@@ -26,9 +29,13 @@ public interface RedisTimeSeriesPipelineCommands {
 
   Response<Long> tsIncrBy(String key, double value, long timestamp);
 
+  Response<Long> tsIncrBy(String key, double addend, TSIncrByDecrByParams incrByParams);
+
   Response<Long> tsDecrBy(String key, double value);
 
   Response<Long> tsDecrBy(String key, double value, long timestamp);
+
+  Response<Long> tsDecrBy(String key, double subtrahend, TSIncrByDecrByParams decrByParams);
 
   Response<List<TSElement>> tsRange(String key, long fromTimestamp, long toTimestamp);
 

--- a/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
@@ -9,25 +9,26 @@ import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
 /**
- * Represents optional arguments of TS.CREATE command.
+ * Represents optional arguments of TS.ADD command.
  */
-public class TSCreateParams implements IParams {
+public class TSAddParams implements IParams {
 
   private Long retentionPeriod;
   private boolean uncompressed;
   private boolean compressed;
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
+  private DuplicatePolicy onDuplicate;
   private Map<String, String> labels;
 
-  public TSCreateParams() {
+  public TSAddParams() {
   }
 
-  public static TSCreateParams createParams() {
-    return new TSCreateParams();
+  public static TSAddParams addParams() {
+    return new TSAddParams();
   }
 
-  public TSCreateParams retention(long retentionPeriod) {
+  public TSAddParams retention(long retentionPeriod) {
     this.retentionPeriod = retentionPeriod;
     return this;
   }
@@ -36,7 +37,7 @@ public class TSCreateParams implements IParams {
    * ENCODING UNCOMPRESSED
    * @return this
    */
-  public TSCreateParams uncompressed() {
+  public TSAddParams uncompressed() {
     this.uncompressed = true;
     this.compressed = false;
     return this;
@@ -46,19 +47,24 @@ public class TSCreateParams implements IParams {
    * ENCODING COMPRESSED
    * @return this
    */
-  public TSCreateParams compressed() {
+  public TSAddParams compressed() {
     this.compressed = true;
     this.uncompressed = false;
     return this;
   }
 
-  public TSCreateParams chunkSize(long chunkSize) {
+  public TSAddParams chunkSize(long chunkSize) {
     this.chunkSize = chunkSize;
     return this;
   }
 
-  public TSCreateParams duplicatePolicy(DuplicatePolicy duplicatePolicy) {
+  public TSAddParams duplicatePolicy(DuplicatePolicy duplicatePolicy) {
     this.duplicatePolicy = duplicatePolicy;
+    return this;
+  }
+
+  public TSAddParams onDuplicate(DuplicatePolicy onDuplicate) {
+    this.onDuplicate = onDuplicate;
     return this;
   }
 
@@ -68,7 +74,7 @@ public class TSCreateParams implements IParams {
    * @param labels label-value pairs
    * @return the object itself
    */
-  public TSCreateParams labels(Map<String, String> labels) {
+  public TSAddParams labels(Map<String, String> labels) {
     this.labels = labels;
     return this;
   }
@@ -76,7 +82,7 @@ public class TSCreateParams implements IParams {
   /**
    * Add label-value pair. Multiple pairs can be added through chaining.
    */
-  public TSCreateParams label(String label, String value) {
+  public TSAddParams label(String label, String value) {
     if (this.labels == null) {
       this.labels = new LinkedHashMap<>();
     }
@@ -103,6 +109,14 @@ public class TSCreateParams implements IParams {
 
     if (duplicatePolicy != null) {
       args.add(DUPLICATE_POLICY).add(duplicatePolicy);
+    }
+
+    if (duplicatePolicy != null) {
+      args.add(DUPLICATE_POLICY).add(duplicatePolicy);
+    }
+
+    if (onDuplicate != null) {
+      args.add(ON_DUPLICATE).add(onDuplicate);
     }
 
     if (labels != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
@@ -14,8 +14,7 @@ import redis.clients.jedis.params.IParams;
 public class TSAddParams implements IParams {
 
   private Long retentionPeriod;
-  private boolean uncompressed;
-  private boolean compressed;
+  private EncodingFormat encoding;
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
   private DuplicatePolicy onDuplicate;
@@ -33,23 +32,8 @@ public class TSAddParams implements IParams {
     return this;
   }
 
-  /**
-   * ENCODING UNCOMPRESSED
-   * @return this
-   */
-  public TSAddParams uncompressed() {
-    this.uncompressed = true;
-    this.compressed = false;
-    return this;
-  }
-
-  /**
-   * ENCODING COMPRESSED
-   * @return this
-   */
-  public TSAddParams compressed() {
-    this.compressed = true;
-    this.uncompressed = false;
+  public TSAddParams encoding(EncodingFormat encoding) {
+    this.encoding = encoding;
     return this;
   }
 
@@ -97,10 +81,8 @@ public class TSAddParams implements IParams {
       args.add(RETENTION).add(toByteArray(retentionPeriod));
     }
 
-    if (uncompressed) {
-      args.add(ENCODING).add(UNCOMPRESSED);
-    } else if (compressed) {
-      args.add(ENCODING).add(COMPRESSED);
+    if (encoding != null) {
+      args.add(ENCODING).add(encoding);
     }
 
     if (chunkSize != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
@@ -18,6 +18,11 @@ public class TSAddParams implements IParams {
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
   private DuplicatePolicy onDuplicate;
+
+  private boolean ignore;
+  private long ignoreMaxTimediff;
+  private double ignoreMaxValDiff;
+
   private Map<String, String> labels;
 
   public TSAddParams() {
@@ -52,6 +57,13 @@ public class TSAddParams implements IParams {
     return this;
   }
 
+  public TSAddParams ignore(long maxTimediff, double maxValDiff) {
+    this.ignore = true;
+    this.ignoreMaxTimediff = maxTimediff;
+    this.ignoreMaxValDiff = maxValDiff;
+    return this;
+  }
+
   /**
    * Set label-value pairs
    *
@@ -65,6 +77,9 @@ public class TSAddParams implements IParams {
 
   /**
    * Add label-value pair. Multiple pairs can be added through chaining.
+   * @param label
+   * @param value
+   * @return the object itself
    */
   public TSAddParams label(String label, String value) {
     if (this.labels == null) {
@@ -99,6 +114,10 @@ public class TSAddParams implements IParams {
 
     if (onDuplicate != null) {
       args.add(ON_DUPLICATE).add(onDuplicate);
+    }
+
+    if (ignore) {
+      args.add(IGNORE).add(ignoreMaxTimediff).add(ignoreMaxValDiff);
     }
 
     if (labels != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TSAlterParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSAlterParams.java
@@ -17,6 +17,11 @@ public class TSAlterParams implements IParams {
   private Long retentionPeriod;
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
+
+  private boolean ignore;
+  private long ignoreMaxTimediff;
+  private double ignoreMaxValDiff;
+
   private Map<String, String> labels;
 
   public TSAlterParams() {
@@ -41,11 +46,30 @@ public class TSAlterParams implements IParams {
     return this;
   }
 
+  public TSAlterParams ignore(long maxTimediff, double maxValDiff) {
+    this.ignore = true;
+    this.ignoreMaxTimediff = maxTimediff;
+    this.ignoreMaxValDiff = maxValDiff;
+    return this;
+  }
+
+  /**
+   * Set label-value pairs
+   *
+   * @param labels label-value pairs
+   * @return the object itself
+   */
   public TSAlterParams labels(Map<String, String> labels) {
     this.labels = labels;
     return this;
   }
 
+  /**
+   * Add label-value pair. Multiple pairs can be added through chaining.
+   * @param label
+   * @param value
+   * @return the object itself
+   */
   public TSAlterParams label(String label, String value) {
     if (this.labels == null) {
       this.labels = new LinkedHashMap<>();
@@ -71,6 +95,10 @@ public class TSAlterParams implements IParams {
 
     if (duplicatePolicy != null) {
       args.add(DUPLICATE_POLICY).add(duplicatePolicy);
+    }
+
+    if (ignore) {
+      args.add(IGNORE).add(ignoreMaxTimediff).add(ignoreMaxValDiff);
     }
 
     if (labels != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TSCreateParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSCreateParams.java
@@ -14,8 +14,7 @@ import redis.clients.jedis.params.IParams;
 public class TSCreateParams implements IParams {
 
   private Long retentionPeriod;
-  private boolean uncompressed;
-  private boolean compressed;
+  private EncodingFormat encoding;
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
   private Map<String, String> labels;
@@ -32,23 +31,18 @@ public class TSCreateParams implements IParams {
     return this;
   }
 
-  /**
-   * ENCODING UNCOMPRESSED
-   * @return this
-   */
+  // TODO: deprecate
   public TSCreateParams uncompressed() {
-    this.uncompressed = true;
-    this.compressed = false;
-    return this;
+    return encoding(EncodingFormat.UNCOMPRESSED);
   }
 
-  /**
-   * ENCODING COMPRESSED
-   * @return this
-   */
+  // TODO: deprecate
   public TSCreateParams compressed() {
-    this.compressed = true;
-    this.uncompressed = false;
+    return encoding(EncodingFormat.COMPRESSED);
+  }
+
+  public TSCreateParams encoding(EncodingFormat encoding) {
+    this.encoding = encoding;
     return this;
   }
 
@@ -91,10 +85,8 @@ public class TSCreateParams implements IParams {
       args.add(RETENTION).add(toByteArray(retentionPeriod));
     }
 
-    if (uncompressed) {
-      args.add(ENCODING).add(UNCOMPRESSED);
-    } else if (compressed) {
-      args.add(ENCODING).add(COMPRESSED);
+    if (encoding != null) {
+      args.add(ENCODING).add(encoding);
     }
 
     if (chunkSize != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TSCreateParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSCreateParams.java
@@ -17,6 +17,11 @@ public class TSCreateParams implements IParams {
   private EncodingFormat encoding;
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
+
+  private boolean ignore;
+  private long ignoreMaxTimediff;
+  private double ignoreMaxValDiff;
+
   private Map<String, String> labels;
 
   public TSCreateParams() {
@@ -56,6 +61,13 @@ public class TSCreateParams implements IParams {
     return this;
   }
 
+  public TSCreateParams ignore(long maxTimediff, double maxValDiff) {
+    this.ignore = true;
+    this.ignoreMaxTimediff = maxTimediff;
+    this.ignoreMaxValDiff = maxValDiff;
+    return this;
+  }
+
   /**
    * Set label-value pairs
    *
@@ -69,6 +81,9 @@ public class TSCreateParams implements IParams {
 
   /**
    * Add label-value pair. Multiple pairs can be added through chaining.
+   * @param label
+   * @param value
+   * @return the object itself
    */
   public TSCreateParams label(String label, String value) {
     if (this.labels == null) {
@@ -95,6 +110,10 @@ public class TSCreateParams implements IParams {
 
     if (duplicatePolicy != null) {
       args.add(DUPLICATE_POLICY).add(duplicatePolicy);
+    }
+
+    if (ignore) {
+      args.add(IGNORE).add(ignoreMaxTimediff).add(ignoreMaxValDiff);
     }
 
     if (labels != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TSIncrByDecrByParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSIncrByDecrByParams.java
@@ -9,10 +9,11 @@ import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
 /**
- * Represents optional arguments of TS.CREATE command.
+ * Represents optional arguments of TS.INCRBY or TS.DECRBY commands.
  */
-public class TSCreateParams implements IParams {
+public class TSIncrByDecrByParams implements IParams {
 
+  private Long timestamp;
   private Long retentionPeriod;
   private boolean uncompressed;
   private boolean compressed;
@@ -20,14 +21,19 @@ public class TSCreateParams implements IParams {
   private DuplicatePolicy duplicatePolicy;
   private Map<String, String> labels;
 
-  public TSCreateParams() {
+  public TSIncrByDecrByParams() {
   }
 
-  public static TSCreateParams createParams() {
-    return new TSCreateParams();
+  public static TSIncrByDecrByParams params() {
+    return new TSIncrByDecrByParams();
   }
 
-  public TSCreateParams retention(long retentionPeriod) {
+  public TSIncrByDecrByParams timestamp(long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  public TSIncrByDecrByParams retention(long retentionPeriod) {
     this.retentionPeriod = retentionPeriod;
     return this;
   }
@@ -36,7 +42,7 @@ public class TSCreateParams implements IParams {
    * ENCODING UNCOMPRESSED
    * @return this
    */
-  public TSCreateParams uncompressed() {
+  public TSIncrByDecrByParams uncompressed() {
     this.uncompressed = true;
     this.compressed = false;
     return this;
@@ -46,18 +52,18 @@ public class TSCreateParams implements IParams {
    * ENCODING COMPRESSED
    * @return this
    */
-  public TSCreateParams compressed() {
+  public TSIncrByDecrByParams compressed() {
     this.compressed = true;
     this.uncompressed = false;
     return this;
   }
 
-  public TSCreateParams chunkSize(long chunkSize) {
+  public TSIncrByDecrByParams chunkSize(long chunkSize) {
     this.chunkSize = chunkSize;
     return this;
   }
 
-  public TSCreateParams duplicatePolicy(DuplicatePolicy duplicatePolicy) {
+  public TSIncrByDecrByParams duplicatePolicy(DuplicatePolicy duplicatePolicy) {
     this.duplicatePolicy = duplicatePolicy;
     return this;
   }
@@ -68,7 +74,7 @@ public class TSCreateParams implements IParams {
    * @param labels label-value pairs
    * @return the object itself
    */
-  public TSCreateParams labels(Map<String, String> labels) {
+  public TSIncrByDecrByParams labels(Map<String, String> labels) {
     this.labels = labels;
     return this;
   }
@@ -76,7 +82,7 @@ public class TSCreateParams implements IParams {
   /**
    * Add label-value pair. Multiple pairs can be added through chaining.
    */
-  public TSCreateParams label(String label, String value) {
+  public TSIncrByDecrByParams label(String label, String value) {
     if (this.labels == null) {
       this.labels = new LinkedHashMap<>();
     }
@@ -86,6 +92,10 @@ public class TSCreateParams implements IParams {
 
   @Override
   public void addParams(CommandArguments args) {
+
+    if (timestamp != null) {
+      args.add(TIMESTAMP).add(timestamp);
+    }
 
     if (retentionPeriod != null) {
       args.add(RETENTION).add(toByteArray(retentionPeriod));

--- a/src/main/java/redis/clients/jedis/timeseries/TSIncrByDecrByParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSIncrByDecrByParams.java
@@ -15,8 +15,7 @@ public class TSIncrByDecrByParams implements IParams {
 
   private Long timestamp;
   private Long retentionPeriod;
-  private boolean uncompressed;
-  private boolean compressed;
+  private EncodingFormat encoding;
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
   private Map<String, String> labels;
@@ -38,23 +37,8 @@ public class TSIncrByDecrByParams implements IParams {
     return this;
   }
 
-  /**
-   * ENCODING UNCOMPRESSED
-   * @return this
-   */
-  public TSIncrByDecrByParams uncompressed() {
-    this.uncompressed = true;
-    this.compressed = false;
-    return this;
-  }
-
-  /**
-   * ENCODING COMPRESSED
-   * @return this
-   */
-  public TSIncrByDecrByParams compressed() {
-    this.compressed = true;
-    this.uncompressed = false;
+  public TSIncrByDecrByParams encoding(EncodingFormat encoding) {
+    this.encoding = encoding;
     return this;
   }
 
@@ -101,10 +85,8 @@ public class TSIncrByDecrByParams implements IParams {
       args.add(RETENTION).add(toByteArray(retentionPeriod));
     }
 
-    if (uncompressed) {
-      args.add(ENCODING).add(UNCOMPRESSED);
-    } else if (compressed) {
-      args.add(ENCODING).add(COMPRESSED);
+    if (encoding != null) {
+      args.add(ENCODING).add(encoding);
     }
 
     if (chunkSize != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TSIncrOrDecrByParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSIncrOrDecrByParams.java
@@ -11,44 +11,64 @@ import redis.clients.jedis.params.IParams;
 /**
  * Represents optional arguments of TS.INCRBY or TS.DECRBY commands.
  */
-public class TSIncrByDecrByParams implements IParams {
+public class TSIncrOrDecrByParams implements IParams {
 
   private Long timestamp;
   private Long retentionPeriod;
   private EncodingFormat encoding;
   private Long chunkSize;
   private DuplicatePolicy duplicatePolicy;
+
+  private boolean ignore;
+  private long ignoreMaxTimediff;
+  private double ignoreMaxValDiff;
+
   private Map<String, String> labels;
 
-  public TSIncrByDecrByParams() {
+  public TSIncrOrDecrByParams() {
   }
 
-  public static TSIncrByDecrByParams params() {
-    return new TSIncrByDecrByParams();
+  public static TSIncrOrDecrByParams params() {
+    return new TSIncrOrDecrByParams();
   }
 
-  public TSIncrByDecrByParams timestamp(long timestamp) {
+  public static TSIncrOrDecrByParams incrByParams() {
+    return new TSIncrOrDecrByParams();
+  }
+
+  public static TSIncrOrDecrByParams decrByParams() {
+    return new TSIncrOrDecrByParams();
+  }
+
+  public TSIncrOrDecrByParams timestamp(long timestamp) {
     this.timestamp = timestamp;
     return this;
   }
 
-  public TSIncrByDecrByParams retention(long retentionPeriod) {
+  public TSIncrOrDecrByParams retention(long retentionPeriod) {
     this.retentionPeriod = retentionPeriod;
     return this;
   }
 
-  public TSIncrByDecrByParams encoding(EncodingFormat encoding) {
+  public TSIncrOrDecrByParams encoding(EncodingFormat encoding) {
     this.encoding = encoding;
     return this;
   }
 
-  public TSIncrByDecrByParams chunkSize(long chunkSize) {
+  public TSIncrOrDecrByParams chunkSize(long chunkSize) {
     this.chunkSize = chunkSize;
     return this;
   }
 
-  public TSIncrByDecrByParams duplicatePolicy(DuplicatePolicy duplicatePolicy) {
+  public TSIncrOrDecrByParams duplicatePolicy(DuplicatePolicy duplicatePolicy) {
     this.duplicatePolicy = duplicatePolicy;
+    return this;
+  }
+
+  public TSIncrOrDecrByParams ignore(long maxTimediff, double maxValDiff) {
+    this.ignore = true;
+    this.ignoreMaxTimediff = maxTimediff;
+    this.ignoreMaxValDiff = maxValDiff;
     return this;
   }
 
@@ -58,15 +78,18 @@ public class TSIncrByDecrByParams implements IParams {
    * @param labels label-value pairs
    * @return the object itself
    */
-  public TSIncrByDecrByParams labels(Map<String, String> labels) {
+  public TSIncrOrDecrByParams labels(Map<String, String> labels) {
     this.labels = labels;
     return this;
   }
 
   /**
    * Add label-value pair. Multiple pairs can be added through chaining.
+   * @param label
+   * @param value
+   * @return the object itself
    */
-  public TSIncrByDecrByParams label(String label, String value) {
+  public TSIncrOrDecrByParams label(String label, String value) {
     if (this.labels == null) {
       this.labels = new LinkedHashMap<>();
     }
@@ -95,6 +118,10 @@ public class TSIncrByDecrByParams implements IParams {
 
     if (duplicatePolicy != null) {
       args.add(DUPLICATE_POLICY).add(duplicatePolicy);
+    }
+
+    if (ignore) {
+      args.add(IGNORE).add(ignoreMaxTimediff).add(ignoreMaxValDiff);
     }
 
     if (labels != null) {

--- a/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TimeSeriesProtocol.java
@@ -57,6 +57,7 @@ public class TimeSeriesProtocol {
     UNCOMPRESSED,
     CHUNK_SIZE,
     DUPLICATE_POLICY,
+    IGNORE,
     ON_DUPLICATE,
     ALIGN,
     FILTER_BY_TS,

--- a/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
@@ -143,7 +143,7 @@ public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTe
 
   @Test
   public void testTsDecrByWithParams() {
-    TSIncrByDecrByParams DecrByParams = mock(TSIncrByDecrByParams.class);
+    TSIncrOrDecrByParams DecrByParams = mock(TSIncrOrDecrByParams.class);
     when(commandObjects.tsDecrBy("myTimeSeries", 1.0, DecrByParams)).thenReturn(longCommandObject);
 
     Response<Long> response = pipeliningBase.tsDecrBy("myTimeSeries", 1.0, DecrByParams);
@@ -216,7 +216,7 @@ public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTe
 
   @Test
   public void testTsIncrByWithParams() {
-    TSIncrByDecrByParams incrByParams = mock(TSIncrByDecrByParams.class);
+    TSIncrOrDecrByParams incrByParams = mock(TSIncrOrDecrByParams.class);
     when(commandObjects.tsIncrBy("myTimeSeries", 1.0, incrByParams)).thenReturn(longCommandObject);
 
     Response<Long> response = pipeliningBase.tsIncrBy("myTimeSeries", 1.0, incrByParams);

--- a/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/pipeline/PipeliningBaseTimeSeriesCommandsTest.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.mocked.pipeline;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.AbstractMap;
@@ -11,17 +12,7 @@ import java.util.Map;
 
 import org.junit.Test;
 import redis.clients.jedis.Response;
-import redis.clients.jedis.timeseries.AggregationType;
-import redis.clients.jedis.timeseries.TSAlterParams;
-import redis.clients.jedis.timeseries.TSCreateParams;
-import redis.clients.jedis.timeseries.TSElement;
-import redis.clients.jedis.timeseries.TSGetParams;
-import redis.clients.jedis.timeseries.TSInfo;
-import redis.clients.jedis.timeseries.TSMGetElement;
-import redis.clients.jedis.timeseries.TSMGetParams;
-import redis.clients.jedis.timeseries.TSMRangeElements;
-import redis.clients.jedis.timeseries.TSMRangeParams;
-import redis.clients.jedis.timeseries.TSRangeParams;
+import redis.clients.jedis.timeseries.*;
 
 public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTestBase {
 
@@ -52,6 +43,18 @@ public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTe
     when(commandObjects.tsAdd("myTimeSeries", 1000L, 42.0, createParams)).thenReturn(longCommandObject);
 
     Response<Long> response = pipeliningBase.tsAdd("myTimeSeries", 1000L, 42.0, createParams);
+
+    assertThat(commands, contains(longCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testTsAddWithParams() {
+    TSAddParams addParams = mock(TSAddParams.class);
+
+    when(commandObjects.tsAdd("myTimeSeries", 1000L, 42.0, addParams)).thenReturn(longCommandObject);
+
+    Response<Long> response = pipeliningBase.tsAdd("myTimeSeries", 1000L, 42.0, addParams);
 
     assertThat(commands, contains(longCommandObject));
     assertThat(response, is(predefinedResponse));
@@ -139,6 +142,17 @@ public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTe
   }
 
   @Test
+  public void testTsDecrByWithParams() {
+    TSIncrByDecrByParams DecrByParams = mock(TSIncrByDecrByParams.class);
+    when(commandObjects.tsDecrBy("myTimeSeries", 1.0, DecrByParams)).thenReturn(longCommandObject);
+
+    Response<Long> response = pipeliningBase.tsDecrBy("myTimeSeries", 1.0, DecrByParams);
+
+    assertThat(commands, contains(longCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
   public void testTsDel() {
     when(commandObjects.tsDel("myTimeSeries", 1000L, 2000L)).thenReturn(longCommandObject);
 
@@ -195,6 +209,17 @@ public class PipeliningBaseTimeSeriesCommandsTest extends PipeliningBaseMockedTe
     when(commandObjects.tsIncrBy("myTimeSeries", 1.0, 1000L)).thenReturn(longCommandObject);
 
     Response<Long> response = pipeliningBase.tsIncrBy("myTimeSeries", 1.0, 1000L);
+
+    assertThat(commands, contains(longCommandObject));
+    assertThat(response, is(predefinedResponse));
+  }
+
+  @Test
+  public void testTsIncrByWithParams() {
+    TSIncrByDecrByParams incrByParams = mock(TSIncrByDecrByParams.class);
+    when(commandObjects.tsIncrBy("myTimeSeries", 1.0, incrByParams)).thenReturn(longCommandObject);
+
+    Response<Long> response = pipeliningBase.tsIncrBy("myTimeSeries", 1.0, incrByParams);
 
     assertThat(commands, contains(longCommandObject));
     assertThat(response, is(predefinedResponse));

--- a/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
@@ -220,7 +220,7 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
   public void testTsDecrByWithParams() {
     String key = "testKey";
     double value = 1.5;
-    TSIncrByDecrByParams decrByParams = mock(TSIncrByDecrByParams.class);
+    TSIncrOrDecrByParams decrByParams = mock(TSIncrOrDecrByParams.class);
     long expectedResponse = 5L;
 
     when(commandObjects.tsDecrBy(key, value, decrByParams)).thenReturn(longCommandObject);
@@ -341,7 +341,7 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
   public void testTsIncrByWithParams() {
     String key = "testKey";
     double value = 2.5;
-    TSIncrByDecrByParams incrByParams = mock(TSIncrByDecrByParams.class);
+    TSIncrOrDecrByParams incrByParams = mock(TSIncrOrDecrByParams.class);
     long expectedResponse = 5L;
 
     when(commandObjects.tsIncrBy(key, value, incrByParams)).thenReturn(longCommandObject);

--- a/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/mocked/unified/UnifiedJedisTimeSeriesCommandsTest.java
@@ -15,17 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import redis.clients.jedis.timeseries.AggregationType;
-import redis.clients.jedis.timeseries.TSAlterParams;
-import redis.clients.jedis.timeseries.TSCreateParams;
-import redis.clients.jedis.timeseries.TSElement;
-import redis.clients.jedis.timeseries.TSGetParams;
-import redis.clients.jedis.timeseries.TSInfo;
-import redis.clients.jedis.timeseries.TSMGetElement;
-import redis.clients.jedis.timeseries.TSMGetParams;
-import redis.clients.jedis.timeseries.TSMRangeElements;
-import redis.clients.jedis.timeseries.TSMRangeParams;
-import redis.clients.jedis.timeseries.TSRangeParams;
+import redis.clients.jedis.timeseries.*;
 
 public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBase {
 
@@ -70,6 +60,25 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
     long timestamp = 1582605077000L;
     double value = 123.45;
     TSCreateParams createParams = new TSCreateParams().retention(86400000L); // 1 day retention
+    long expectedResponse = timestamp; // Timestamp of the added value
+
+    when(commandObjects.tsAdd(key, timestamp, value, createParams)).thenReturn(longCommandObject);
+    when(commandExecutor.executeCommand(longCommandObject)).thenReturn(expectedResponse);
+
+    long result = jedis.tsAdd(key, timestamp, value, createParams);
+
+    assertEquals(expectedResponse, result);
+
+    verify(commandExecutor).executeCommand(longCommandObject);
+    verify(commandObjects).tsAdd(key, timestamp, value, createParams);
+  }
+
+  @Test
+  public void testTsAddWithParams() {
+    String key = "testKey";
+    long timestamp = 1582605077000L;
+    double value = 123.45;
+    TSAddParams createParams = mock(TSAddParams.class);
     long expectedResponse = timestamp; // Timestamp of the added value
 
     when(commandObjects.tsAdd(key, timestamp, value, createParams)).thenReturn(longCommandObject);
@@ -194,7 +203,7 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
     String key = "testKey";
     double value = 1.5;
     long timestamp = 1582605077000L;
-    long expectedResponse = -1L; // Assuming the decrement results in a total of -1
+    long expectedResponse = 5L;
 
     when(commandObjects.tsDecrBy(key, value, timestamp)).thenReturn(longCommandObject);
     when(commandExecutor.executeCommand(longCommandObject)).thenReturn(expectedResponse);
@@ -205,6 +214,24 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
 
     verify(commandExecutor).executeCommand(longCommandObject);
     verify(commandObjects).tsDecrBy(key, value, timestamp);
+  }
+
+  @Test
+  public void testTsDecrByWithParams() {
+    String key = "testKey";
+    double value = 1.5;
+    TSIncrByDecrByParams decrByParams = mock(TSIncrByDecrByParams.class);
+    long expectedResponse = 5L;
+
+    when(commandObjects.tsDecrBy(key, value, decrByParams)).thenReturn(longCommandObject);
+    when(commandExecutor.executeCommand(longCommandObject)).thenReturn(expectedResponse);
+
+    long result = jedis.tsDecrBy(key, value, decrByParams);
+
+    assertEquals(expectedResponse, result);
+
+    verify(commandExecutor).executeCommand(longCommandObject);
+    verify(commandObjects).tsDecrBy(key, value, decrByParams);
   }
 
   @Test
@@ -297,7 +324,7 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
     String key = "testKey";
     double value = 2.5;
     long timestamp = 1582605077000L;
-    long expectedResponse = 5L; // Assuming the increment results in a total of 5
+    long expectedResponse = 5L;
 
     when(commandObjects.tsIncrBy(key, value, timestamp)).thenReturn(longCommandObject);
     when(commandExecutor.executeCommand(longCommandObject)).thenReturn(expectedResponse);
@@ -308,6 +335,24 @@ public class UnifiedJedisTimeSeriesCommandsTest extends UnifiedJedisMockedTestBa
 
     verify(commandExecutor).executeCommand(longCommandObject);
     verify(commandObjects).tsIncrBy(key, value, timestamp);
+  }
+
+  @Test
+  public void testTsIncrByWithParams() {
+    String key = "testKey";
+    double value = 2.5;
+    TSIncrByDecrByParams incrByParams = mock(TSIncrByDecrByParams.class);
+    long expectedResponse = 5L;
+
+    when(commandObjects.tsIncrBy(key, value, incrByParams)).thenReturn(longCommandObject);
+    when(commandExecutor.executeCommand(longCommandObject)).thenReturn(expectedResponse);
+
+    long result = jedis.tsIncrBy(key, value, incrByParams);
+
+    assertEquals(expectedResponse, result);
+
+    verify(commandExecutor).executeCommand(longCommandObject);
+    verify(commandObjects).tsIncrBy(key, value, incrByParams);
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/modules/timeseries/TimeSeriesTest.java
+++ b/src/test/java/redis/clients/jedis/modules/timeseries/TimeSeriesTest.java
@@ -123,6 +123,23 @@ public class TimeSeriesTest extends RedisModuleCommandsTestBase {
   }
 
   @Test
+  public void createAndAlterParams() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("l1", "v1");
+    labels.put("l2", "v2");
+
+    assertEquals("OK", client.tsCreate("ts-params",
+        TSCreateParams.createParams().retention(60000).encoding(EncodingFormat.UNCOMPRESSED).chunkSize(4096)
+            .duplicatePolicy(DuplicatePolicy.BLOCK).ignore(50, 12.5).labels(labels)));
+
+    labels.put("l1", "v11");
+    labels.remove("l2");
+    labels.put("l3", "v33");
+    assertEquals("OK", client.tsAlter("ts-params", TSAlterParams.alterParams().retention(15000).chunkSize(8192)
+        .duplicatePolicy(DuplicatePolicy.SUM).ignore(50, 12.5).labels(labels)));
+  }
+
+  @Test
   public void testRule() {
     assertEquals("OK", client.tsCreate("source"));
     assertEquals("OK", client.tsCreate("dest", TSCreateParams.createParams().retention(10)));
@@ -155,11 +172,11 @@ public class TimeSeriesTest extends RedisModuleCommandsTestBase {
 
     assertEquals(1000L, client.tsAdd("add1", 1000L, 1.1,
         TSAddParams.addParams().retention(10000).encoding(EncodingFormat.UNCOMPRESSED).chunkSize(1000)
-            .duplicatePolicy(DuplicatePolicy.FIRST).onDuplicate(DuplicatePolicy.LAST).labels(labels)));
+            .duplicatePolicy(DuplicatePolicy.FIRST).onDuplicate(DuplicatePolicy.LAST).ignore(50, 12.5).labels(labels)));
 
     assertEquals(1000L, client.tsAdd("add2", 1000L, 1.1,
         TSAddParams.addParams().retention(10000).encoding(EncodingFormat.COMPRESSED).chunkSize(1000)
-            .duplicatePolicy(DuplicatePolicy.MIN).onDuplicate(DuplicatePolicy.MAX).labels(labels)));
+            .duplicatePolicy(DuplicatePolicy.MIN).onDuplicate(DuplicatePolicy.MAX).ignore(50, 12.5).labels(labels)));
   }
 
   @Test
@@ -436,20 +453,20 @@ public class TimeSeriesTest extends RedisModuleCommandsTestBase {
     labels.put("l2", "v2");
 
     assertEquals(1000L, client.tsIncrBy("incr1", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.UNCOMPRESSED)
-            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+        TSIncrOrDecrByParams.incrByParams().timestamp(1000).retention(10000).encoding(EncodingFormat.UNCOMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.FIRST).ignore(50, 12.5).labels(labels)));
 
     assertEquals(1000L, client.tsIncrBy("incr2", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.COMPRESSED)
-            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.MIN).labels(labels)));
+        TSIncrOrDecrByParams.incrByParams().timestamp(1000).retention(10000).encoding(EncodingFormat.COMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.MIN).ignore(50, 12.5).labels(labels)));
 
     assertEquals(1000L, client.tsDecrBy("decr1", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.COMPRESSED)
-            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.LAST).labels(labels)));
+        TSIncrOrDecrByParams.decrByParams().timestamp(1000).retention(10000).encoding(EncodingFormat.COMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.LAST).ignore(50, 12.5).labels(labels)));
 
     assertEquals(1000L, client.tsDecrBy("decr2", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.UNCOMPRESSED)
-            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.MAX).labels(labels)));
+        TSIncrOrDecrByParams.decrByParams().timestamp(1000).retention(10000).encoding(EncodingFormat.UNCOMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.MAX).ignore(50, 12.5).labels(labels)));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/modules/timeseries/TimeSeriesTest.java
+++ b/src/test/java/redis/clients/jedis/modules/timeseries/TimeSeriesTest.java
@@ -148,6 +148,21 @@ public class TimeSeriesTest extends RedisModuleCommandsTestBase {
   }
 
   @Test
+  public void addParams() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("l1", "v1");
+    labels.put("l2", "v2");
+
+    assertEquals(1000L, client.tsAdd("add1", 1000L, 1.1,
+        TSAddParams.addParams().retention(10000).uncompressed().chunkSize(1000)
+            .duplicatePolicy(DuplicatePolicy.FIRST).onDuplicate(DuplicatePolicy.LAST).labels(labels)));
+
+    assertEquals(1000L, client.tsAdd("add2", 1000L, 1.1,
+        TSAddParams.addParams().retention(10000).compressed().chunkSize(1000)
+            .duplicatePolicy(DuplicatePolicy.FIRST).onDuplicate(DuplicatePolicy.LAST).labels(labels)));
+  }
+
+  @Test
   public void testAdd() {
     Map<String, String> labels = new HashMap<>();
     labels.put("l1", "v1");
@@ -412,6 +427,29 @@ public class TimeSeriesTest extends RedisModuleCommandsTestBase {
 
     client.tsIncrBy("seriesIncDec", 100);
     client.tsDecrBy("seriesIncDec", 33);
+  }
+
+  @Test
+  public void incrByDecrByParams() {
+    Map<String, String> labels = new HashMap<>();
+    labels.put("l1", "v1");
+    labels.put("l2", "v2");
+
+    assertEquals(1000L, client.tsIncrBy("incr1", 1.1,
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).uncompressed().chunkSize(1000)
+            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+
+    assertEquals(1000L, client.tsIncrBy("incr2", 1.1,
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).compressed().chunkSize(1000)
+            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+
+    assertEquals(1000L, client.tsDecrBy("decr1", 1.1,
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).uncompressed().chunkSize(1000)
+            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+
+    assertEquals(1000L, client.tsDecrBy("decr2", 1.1,
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).compressed().chunkSize(1000)
+            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/modules/timeseries/TimeSeriesTest.java
+++ b/src/test/java/redis/clients/jedis/modules/timeseries/TimeSeriesTest.java
@@ -154,12 +154,12 @@ public class TimeSeriesTest extends RedisModuleCommandsTestBase {
     labels.put("l2", "v2");
 
     assertEquals(1000L, client.tsAdd("add1", 1000L, 1.1,
-        TSAddParams.addParams().retention(10000).uncompressed().chunkSize(1000)
+        TSAddParams.addParams().retention(10000).encoding(EncodingFormat.UNCOMPRESSED).chunkSize(1000)
             .duplicatePolicy(DuplicatePolicy.FIRST).onDuplicate(DuplicatePolicy.LAST).labels(labels)));
 
     assertEquals(1000L, client.tsAdd("add2", 1000L, 1.1,
-        TSAddParams.addParams().retention(10000).compressed().chunkSize(1000)
-            .duplicatePolicy(DuplicatePolicy.FIRST).onDuplicate(DuplicatePolicy.LAST).labels(labels)));
+        TSAddParams.addParams().retention(10000).encoding(EncodingFormat.COMPRESSED).chunkSize(1000)
+            .duplicatePolicy(DuplicatePolicy.MIN).onDuplicate(DuplicatePolicy.MAX).labels(labels)));
   }
 
   @Test
@@ -436,20 +436,20 @@ public class TimeSeriesTest extends RedisModuleCommandsTestBase {
     labels.put("l2", "v2");
 
     assertEquals(1000L, client.tsIncrBy("incr1", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).uncompressed().chunkSize(1000)
-            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.UNCOMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
 
     assertEquals(1000L, client.tsIncrBy("incr2", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).compressed().chunkSize(1000)
-            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.COMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.MIN).labels(labels)));
 
     assertEquals(1000L, client.tsDecrBy("decr1", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).uncompressed().chunkSize(1000)
-            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.COMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.LAST).labels(labels)));
 
     assertEquals(1000L, client.tsDecrBy("decr2", 1.1,
-        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).compressed().chunkSize(1000)
-            .duplicatePolicy(DuplicatePolicy.FIRST).labels(labels)));
+        TSIncrByDecrByParams.params().timestamp(1000).retention(10000).encoding(EncodingFormat.UNCOMPRESSED)
+            .chunkSize(1000).duplicatePolicy(DuplicatePolicy.MAX).labels(labels)));
   }
 
   @Test


### PR DESCRIPTION
* Re-implement TS.ADD command with optional arguments
* Implement TS.INCRBY and TS.DECRBY commands with optional arguments
* Support IGNORE argument for TS.[ CREATE | ALTER | ADD | INCRBY | DECRBY] commands