### PR TITLE
Support caching null values

### DIFF
--- a/src/main/java/redis/clients/jedis/csc/CacheConnection.java
+++ b/src/main/java/redis/clients/jedis/csc/CacheConnection.java
@@ -81,12 +81,10 @@ public class CacheConnection extends Connection {
     // CACHE MISS !!
     clientSideCache.getStats().miss();
     T value = super.executeCommand(commandObject);
-    if (value != null) {
-      cacheEntry = new CacheEntry<>(cacheKey, value, this);
-      clientSideCache.set(cacheKey, cacheEntry);
-      // this line actually provides a deep copy of cached object instance 
-      value = cacheEntry.getValue();
-    }
+    cacheEntry = new CacheEntry<>(cacheKey, value, this);
+    clientSideCache.set(cacheKey, cacheEntry);
+    // this line actually provides a deep copy of cached object instance 
+    value = cacheEntry.getValue();
     return value;
   }
 

--- a/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
+++ b/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
@@ -510,4 +510,30 @@ public class ClientSideCacheFunctionalityTest extends ClientSideCacheTestBase {
     }
   }
 
+  @Test
+  public void testNullValue() throws InterruptedException {
+    int MAX_SIZE = 20;
+    String nonExisting = "non-existing-key";
+    control.del(nonExisting);
+
+    TestCache cache = new TestCache(MAX_SIZE, new HashMap<>(), DefaultCacheable.INSTANCE);
+
+    try (JedisPooled jedis = new JedisPooled(hnp, clientConfig.get(), cache)) {
+      CacheStats stats = cache.getStats();
+
+      String val = jedis.get(nonExisting);
+      assertEquals(0, stats.getHitCount());
+      assertEquals(1, stats.getMissCount());
+
+      val = jedis.get(nonExisting);
+      assertEquals(1, stats.getHitCount());
+      assertEquals(1, stats.getMissCount());
+
+      control.set(nonExisting, "bar");
+      val = jedis.get(nonExisting);
+      assertEquals(1, stats.getHitCount());
+      assertEquals(2, stats.getMissCount());
+    }
+  }
+
 }

--- a/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
+++ b/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -522,15 +523,23 @@ public class ClientSideCacheFunctionalityTest extends ClientSideCacheTestBase {
       CacheStats stats = cache.getStats();
 
       String val = jedis.get(nonExisting);
+      assertNull(val);
+      assertEquals(1, cache.getSize());
       assertEquals(0, stats.getHitCount());
       assertEquals(1, stats.getMissCount());
 
       val = jedis.get(nonExisting);
+      assertNull(val);
+      assertEquals(1, cache.getSize());
+      assertNull(cache.getCacheEntries().iterator().next().getValue());
       assertEquals(1, stats.getHitCount());
       assertEquals(1, stats.getMissCount());
 
       control.set(nonExisting, "bar");
       val = jedis.get(nonExisting);
+      assertEquals("bar", val);
+      assertEquals(1, cache.getSize());
+      assertEquals("bar", cache.getCacheEntries().iterator().next().getValue());
       assertEquals(1, stats.getHitCount());
       assertEquals(2, stats.getMissCount());
     }

--- a/src/test/java/redis/clients/jedis/csc/UnifiedJedisClientSideCacheTestBase.java
+++ b/src/test/java/redis/clients/jedis/csc/UnifiedJedisClientSideCacheTestBase.java
@@ -56,10 +56,9 @@ public abstract class UnifiedJedisClientSideCacheTestBase {
       control.del("foo");
       assertThat(map, Matchers.aMapWithSize(1));
       assertNull(jedis.get("foo"));
-      assertThat(map, Matchers.aMapWithSize(0));
-      assertThat(map, Matchers.aMapWithSize(0));
+      assertThat(map, Matchers.aMapWithSize(1));
       assertNull(jedis.get("foo"));
-      assertThat(map, Matchers.aMapWithSize(0));
+      assertThat(map, Matchers.aMapWithSize(1));
     }
   }
 
@@ -84,9 +83,9 @@ public abstract class UnifiedJedisClientSideCacheTestBase {
       control.flushAll();
       assertThat(map, Matchers.aMapWithSize(1));
       assertNull(jedis.get("foo"));
-      assertThat(map, Matchers.aMapWithSize(0));
+      assertThat(map, Matchers.aMapWithSize(1));
       assertNull(jedis.get("foo"));
-      assertThat(map, Matchers.aMapWithSize(0));
+      assertThat(map, Matchers.aMapWithSize(1));
     }
   }
 


### PR DESCRIPTION
Redis server sends invalidation messages for non-defined keys queried by client.
this pr will enable the caching of null results/responses from server side. 