### PR TITLE
Add equals and hashCode to Timeseries Params classes

### DIFF
--- a/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
@@ -5,6 +5,7 @@ import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeywor
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
@@ -124,5 +125,37 @@ public class TSAddParams implements IParams {
       args.add(LABELS);
       labels.entrySet().forEach((entry) -> args.add(entry.getKey()).add(entry.getValue()));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSAddParams that = (TSAddParams) o;
+    return ignore == that.ignore && ignoreMaxTimediff == that.ignoreMaxTimediff &&
+        Double.compare(ignoreMaxValDiff, that.ignoreMaxValDiff) == 0 &&
+        Objects.equals(retentionPeriod, that.retentionPeriod) &&
+        encoding == that.encoding && Objects.equals(chunkSize, that.chunkSize) &&
+        duplicatePolicy == that.duplicatePolicy && onDuplicate == that.onDuplicate &&
+        Objects.equals(labels, that.labels);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hashCode(retentionPeriod);
+    result = 31 * result + Objects.hashCode(encoding);
+    result = 31 * result + Objects.hashCode(chunkSize);
+    result = 31 * result + Objects.hashCode(duplicatePolicy);
+    result = 31 * result + Objects.hashCode(onDuplicate);
+    result = 31 * result + Boolean.hashCode(ignore);
+    result = 31 * result + Long.hashCode(ignoreMaxTimediff);
+    result = 31 * result + Double.hashCode(ignoreMaxValDiff);
+    result = 31 * result + Objects.hashCode(labels);
+    return result;
   }
 }

--- a/src/main/java/redis/clients/jedis/timeseries/TSAlterParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSAlterParams.java
@@ -6,6 +6,7 @@ import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeywor
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
@@ -105,5 +106,34 @@ public class TSAlterParams implements IParams {
       args.add(LABELS);
       labels.entrySet().forEach((entry) -> args.add(entry.getKey()).add(entry.getValue()));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSAlterParams that = (TSAlterParams) o;
+    return ignore == that.ignore && ignoreMaxTimediff == that.ignoreMaxTimediff &&
+        Double.compare(ignoreMaxValDiff, that.ignoreMaxValDiff) == 0 &&
+        Objects.equals(retentionPeriod, that.retentionPeriod) &&
+        Objects.equals(chunkSize, that.chunkSize) &&
+        duplicatePolicy == that.duplicatePolicy && Objects.equals(labels, that.labels);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hashCode(retentionPeriod);
+    result = 31 * result + Objects.hashCode(chunkSize);
+    result = 31 * result + Objects.hashCode(duplicatePolicy);
+    result = 31 * result + Boolean.hashCode(ignore);
+    result = 31 * result + Long.hashCode(ignoreMaxTimediff);
+    result = 31 * result + Double.hashCode(ignoreMaxValDiff);
+    result = 31 * result + Objects.hashCode(labels);
+    return result;
   }
 }

--- a/src/main/java/redis/clients/jedis/timeseries/TSArithByParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSArithByParams.java
@@ -5,6 +5,7 @@ import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeywor
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
@@ -116,5 +117,37 @@ class TSArithByParams<T extends TSArithByParams<?>> implements IParams {
       args.add(LABELS);
       labels.entrySet().forEach((entry) -> args.add(entry.getKey()).add(entry.getValue()));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSArithByParams<?> that = (TSArithByParams<?>) o;
+    return ignore == that.ignore && ignoreMaxTimediff == that.ignoreMaxTimediff &&
+        Double.compare(ignoreMaxValDiff, that.ignoreMaxValDiff) == 0 &&
+        Objects.equals(timestamp, that.timestamp) &&
+        Objects.equals(retentionPeriod, that.retentionPeriod) &&
+        encoding == that.encoding && Objects.equals(chunkSize, that.chunkSize) &&
+        duplicatePolicy == that.duplicatePolicy && Objects.equals(labels, that.labels);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hashCode(timestamp);
+    result = 31 * result + Objects.hashCode(retentionPeriod);
+    result = 31 * result + Objects.hashCode(encoding);
+    result = 31 * result + Objects.hashCode(chunkSize);
+    result = 31 * result + Objects.hashCode(duplicatePolicy);
+    result = 31 * result + Boolean.hashCode(ignore);
+    result = 31 * result + Long.hashCode(ignoreMaxTimediff);
+    result = 31 * result + Double.hashCode(ignoreMaxValDiff);
+    result = 31 * result + Objects.hashCode(labels);
+    return result;
   }
 }

--- a/src/main/java/redis/clients/jedis/timeseries/TSCreateParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSCreateParams.java
@@ -5,6 +5,7 @@ import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeywor
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
@@ -120,5 +121,35 @@ public class TSCreateParams implements IParams {
       args.add(LABELS);
       labels.entrySet().forEach((entry) -> args.add(entry.getKey()).add(entry.getValue()));
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSCreateParams that = (TSCreateParams) o;
+    return ignore == that.ignore && ignoreMaxTimediff == that.ignoreMaxTimediff &&
+        Double.compare(ignoreMaxValDiff, that.ignoreMaxValDiff) == 0 &&
+        Objects.equals(retentionPeriod, that.retentionPeriod) &&
+        encoding == that.encoding && Objects.equals(chunkSize, that.chunkSize) &&
+        duplicatePolicy == that.duplicatePolicy && Objects.equals(labels, that.labels);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hashCode(retentionPeriod);
+    result = 31 * result + Objects.hashCode(encoding);
+    result = 31 * result + Objects.hashCode(chunkSize);
+    result = 31 * result + Objects.hashCode(duplicatePolicy);
+    result = 31 * result + Boolean.hashCode(ignore);
+    result = 31 * result + Long.hashCode(ignoreMaxTimediff);
+    result = 31 * result + Double.hashCode(ignoreMaxValDiff);
+    result = 31 * result + Objects.hashCode(labels);
+    return result;
   }
 }

--- a/src/main/java/redis/clients/jedis/timeseries/TSGetParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSGetParams.java
@@ -27,4 +27,22 @@ public class TSGetParams implements IParams {
       args.add(LATEST);
     }
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSGetParams that = (TSGetParams) o;
+    return latest == that.latest;
+  }
+
+  @Override
+  public int hashCode() {
+    return Boolean.hashCode(latest);
+  }
 }

--- a/src/main/java/redis/clients/jedis/timeseries/TSMGetParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSMGetParams.java
@@ -4,6 +4,7 @@ import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeywor
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.SELECTED_LABELS;
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.WITHLABELS;
 
+import java.util.Arrays;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
@@ -54,5 +55,27 @@ public class TSMGetParams implements IParams {
         args.add(label);
       }
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSMGetParams that = (TSMGetParams) o;
+    return latest == that.latest && withLabels == that.withLabels &&
+        Arrays.equals(selectedLabels, that.selectedLabels);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Boolean.hashCode(latest);
+    result = 31 * result + Boolean.hashCode(withLabels);
+    result = 31 * result + Arrays.hashCode(selectedLabels);
+    return result;
   }
 }

--- a/src/main/java/redis/clients/jedis/timeseries/TSMRangeParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSMRangeParams.java
@@ -7,6 +7,8 @@ import static redis.clients.jedis.timeseries.TimeSeriesProtocol.PLUS;
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.*;
 import static redis.clients.jedis.util.SafeEncoder.encode;
 
+import java.util.Arrays;
+import java.util.Objects;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
@@ -259,5 +261,51 @@ public class TSMRangeParams implements IParams {
     if (groupByLabel != null && groupByReduce != null) {
       args.add(GROUPBY).add(groupByLabel).add(REDUCE).add(groupByReduce);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSMRangeParams that = (TSMRangeParams) o;
+    return latest == that.latest && withLabels == that.withLabels &&
+        bucketDuration == that.bucketDuration && empty == that.empty &&
+        Objects.equals(fromTimestamp, that.fromTimestamp) &&
+        Objects.equals(toTimestamp, that.toTimestamp) &&
+        Arrays.equals(filterByTimestamps, that.filterByTimestamps) &&
+        Arrays.equals(filterByValues, that.filterByValues) &&
+        Arrays.equals(selectedLabels, that.selectedLabels) &&
+        Objects.equals(count, that.count) && Arrays.equals(align, that.align) &&
+        aggregationType == that.aggregationType &&
+        Arrays.equals(bucketTimestamp, that.bucketTimestamp) &&
+        Arrays.equals(filters, that.filters) &&
+        Objects.equals(groupByLabel, that.groupByLabel) &&
+        Objects.equals(groupByReduce, that.groupByReduce);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hashCode(fromTimestamp);
+    result = 31 * result + Objects.hashCode(toTimestamp);
+    result = 31 * result + Boolean.hashCode(latest);
+    result = 31 * result + Arrays.hashCode(filterByTimestamps);
+    result = 31 * result + Arrays.hashCode(filterByValues);
+    result = 31 * result + Boolean.hashCode(withLabels);
+    result = 31 * result + Arrays.hashCode(selectedLabels);
+    result = 31 * result + Objects.hashCode(count);
+    result = 31 * result + Arrays.hashCode(align);
+    result = 31 * result + Objects.hashCode(aggregationType);
+    result = 31 * result + Long.hashCode(bucketDuration);
+    result = 31 * result + Arrays.hashCode(bucketTimestamp);
+    result = 31 * result + Boolean.hashCode(empty);
+    result = 31 * result + Arrays.hashCode(filters);
+    result = 31 * result + Objects.hashCode(groupByLabel);
+    result = 31 * result + Objects.hashCode(groupByReduce);
+    return result;
   }
 }

--- a/src/main/java/redis/clients/jedis/timeseries/TSRangeParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSRangeParams.java
@@ -7,6 +7,8 @@ import static redis.clients.jedis.timeseries.TimeSeriesProtocol.PLUS;
 import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.*;
 import static redis.clients.jedis.util.SafeEncoder.encode;
 
+import java.util.Arrays;
+import java.util.Objects;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.params.IParams;
 
@@ -204,5 +206,41 @@ public class TSRangeParams implements IParams {
         args.add(EMPTY);
       }
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TSRangeParams that = (TSRangeParams) o;
+    return latest == that.latest && bucketDuration == that.bucketDuration && empty == that.empty &&
+        Objects.equals(fromTimestamp, that.fromTimestamp) &&
+        Objects.equals(toTimestamp, that.toTimestamp) &&
+        Arrays.equals(filterByTimestamps, that.filterByTimestamps) &&
+        Arrays.equals(filterByValues, that.filterByValues) &&
+        Objects.equals(count, that.count) && Arrays.equals(align, that.align) &&
+        aggregationType == that.aggregationType &&
+        Arrays.equals(bucketTimestamp, that.bucketTimestamp);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hashCode(fromTimestamp);
+    result = 31 * result + Objects.hashCode(toTimestamp);
+    result = 31 * result + Boolean.hashCode(latest);
+    result = 31 * result + Arrays.hashCode(filterByTimestamps);
+    result = 31 * result + Arrays.hashCode(filterByValues);
+    result = 31 * result + Objects.hashCode(count);
+    result = 31 * result + Arrays.hashCode(align);
+    result = 31 * result + Objects.hashCode(aggregationType);
+    result = 31 * result + Long.hashCode(bucketDuration);
+    result = 31 * result + Arrays.hashCode(bucketTimestamp);
+    result = 31 * result + Boolean.hashCode(empty);
+    return result;
   }
 }


### PR DESCRIPTION
In order to properly test Software using Jedis Timeseries functionaily, we should be able to easily compare Params Objects.
To achieve this i added equals/hashCode methods to those params objects.

This sparked from this discussion:
https://github.com/redis/jedis/discussions/3943