### PR TITLE
Add javadoc to clear up implicit behavior

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -199,8 +199,8 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
    * the following fields: user, password, database, protocol version, and whether to use SSL.
    *
    * For example, if the URI is "redis://user:password@localhost:6379/1", the user and password fields will be set
-   * to "user" and "password" respectively, the database field will be set to 1. If those fields are also set in
-   * the JedisClientConfig object, the URI values will take precedence.
+   * to "user" and "password" respectively, the database field will be set to 1. Those fields will be ignored
+   * from the JedisClientConfig object.
    *
    * @param uri The URI to connect to
    * @param config The JedisClientConfig object to use

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -193,6 +193,18 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
         .hostnameVerifier(hostnameVerifier).build());
   }
 
+  /**
+   * Create a new Jedis with the provided URI and JedisClientConfig object. Note that all fields
+   * that can be parsed from the URI will be used instead of the corresponding configuration values. This includes
+   * the following fields: user, password, database, protocol version, and whether to use SSL.
+   *
+   * For example, if the URI is "redis://user:password@localhost:6379/1", the user and password fields will be set
+   * to "user" and "password" respectively, the database field will be set to 1. If those fields are also set in
+   * the JedisClientConfig object, the URI values will take precedence.
+   *
+   * @param uri The URI to connect to
+   * @param config The JedisClientConfig object to use
+   */
   public Jedis(final URI uri, JedisClientConfig config) {
     if (!JedisURIHelper.isValid(uri)) {
       throw new InvalidURIException(String.format(

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -82,6 +82,18 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
         .ssl(JedisURIHelper.isRedisSSLScheme(uri)).build());
   }
 
+  /**
+   * Create a new UnifiedJedis with the provided URI and JedisClientConfig object. Note that all fields
+   * that can be parsed from the URI will be used instead of the corresponding configuration values. This includes
+   * the following fields: user, password, database, protocol version, and whether to use SSL.
+   *
+   * For example, if the URI is "redis://user:password@localhost:6379/1", the user and password fields will be set
+   * to "user" and "password" respectively, the database field will be set to 1. If those fields are also set in
+   * the JedisClientConfig object, the URI values will take precedence.
+   *
+   * @param uri The URI to connect to
+   * @param config The JedisClientConfig object to use
+   */
   public UnifiedJedis(final URI uri, JedisClientConfig config) {
     this(JedisURIHelper.getHostAndPort(uri), DefaultJedisClientConfig.builder()
         .connectionTimeoutMillis(config.getConnectionTimeoutMillis())

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -88,8 +88,8 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
    * the following fields: user, password, database, protocol version, and whether to use SSL.
    *
    * For example, if the URI is "redis://user:password@localhost:6379/1", the user and password fields will be set
-   * to "user" and "password" respectively, the database field will be set to 1. If those fields are also set in
-   * the JedisClientConfig object, the URI values will take precedence.
+   * to "user" and "password" respectively, the database field will be set to 1. Those fields will be ignored
+   * from the JedisClientConfig object.
    *
    * @param uri The URI to connect to
    * @param config The JedisClientConfig object to use


### PR DESCRIPTION
This should probably be fixed with some kind of configuration merging, but in an effort to avoid breaking changes, these docs should at least make the behavior clear.


Fixes #3982. 