### PR TITLE
Implement  command (no arg) 

### DIFF
--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -8253,6 +8253,12 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
     return CommandInfo.COMMAND_INFO_RESPONSE.build(connection.getOne());
   }
 
+  public Map<String, CommandInfo> command() {
+    checkIsInMultiOrPipeline();
+    connection.sendCommand(COMMAND);
+    return CommandInfo.COMMAND_INFO_RESPONSE.build(connection.getOne());
+  }
+
   public List<String> commandList() {
     checkIsInMultiOrPipeline();
     connection.sendCommand(COMMAND, LIST);

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -21,7 +21,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import com.google.gson.annotations.Since;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -504,10 +503,10 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
 
 
   @Test
-  public void command() {
+  public void commandNoArgs() {
     Map<String, CommandInfo> infos = jedis.command();
 
-    assertThat(infos.size(),greaterThan(0));
+    assertThat(infos.size(), greaterThan(0));
 
     CommandInfo getInfo = infos.get("get");
     assertEquals(2, getInfo.getArity());

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import com.google.gson.annotations.Since;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -499,6 +500,28 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     List<KeyValue<String, List<String>>> keySandFlags = jedis.commandGetKeysAndFlags("SET", "k1", "v1");
     assertEquals("k1", keySandFlags.get(0).getKey());
     assertEquals(2, keySandFlags.get(0).getValue().size());
+  }
+
+
+  @Test
+  public void command() {
+    Map<String, CommandInfo> infos = jedis.command();
+
+    assertThat(infos.size(),greaterThan(0));
+
+    CommandInfo getInfo = infos.get("get");
+    assertEquals(2, getInfo.getArity());
+    assertEquals(2, getInfo.getFlags().size());
+    assertEquals(1, getInfo.getFirstKey());
+    assertEquals(1, getInfo.getLastKey());
+    assertEquals(1, getInfo.getStep());
+
+    assertNull(infos.get("foo")); // non-existing command
+
+    CommandInfo setInfo = infos.get("set");
+    assertEquals(3, setInfo.getAclCategories().size());
+    assertEquals(0, setInfo.getTips().size());
+    assertEquals(0, setInfo.getSubcommands().size());
   }
 
   @Test


### PR DESCRIPTION
[COMMAND spec](https://redis.io/docs/latest/commands/command/)

I am adding it for completeness and as an alternative to `COMMAND INFO` for Redis server prior 7.0.0.

`COMMAND` (no args) is available with Redis 2.x
`COMMAND INFO` is available since REDIS version 7.0.0

Relates to: #2922
Support COMMAND commands (#2922)
commit: 35904380a3388721bf27980171e6446b5181c3e8

Closes #793