### PR TITLE
DOC-4450 added hgetall and hvals command examples

### DIFF
--- a/src/test/java/io/redis/examples/CmdsHashExample.java
+++ b/src/test/java/io/redis/examples/CmdsHashExample.java
@@ -5,7 +5,6 @@ package io.redis.examples;
 import org.junit.Assert;
 import org.junit.Test;
 // REMOVE_END
-import static java.util.stream.Collectors.toList;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,6 +14,8 @@ import java.util.Collections;
 // HIDE_START
 import redis.clients.jedis.UnifiedJedis;
 // HIDE_END
+
+import static java.util.stream.Collectors.toList;
 
 // HIDE_START
 public class CmdsHashExample {

--- a/src/test/java/io/redis/examples/CmdsHashExample.java
+++ b/src/test/java/io/redis/examples/CmdsHashExample.java
@@ -5,12 +5,12 @@ package io.redis.examples;
 import org.junit.Assert;
 import org.junit.Test;
 // REMOVE_END
+import static java.util.stream.Collectors.toList;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 import java.util.Collections;
-import static java.util.stream.Collectors.*;
 
 // HIDE_START
 import redis.clients.jedis.UnifiedJedis;

--- a/src/test/java/io/redis/examples/CmdsHashExample.java
+++ b/src/test/java/io/redis/examples/CmdsHashExample.java
@@ -4,11 +4,14 @@ package io.redis.examples;
 
 import org.junit.Assert;
 import org.junit.Test;
+// REMOVE_END
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.Collections;
+import static java.util.stream.Collectors.*;
 
-// REMOVE_END
 // HIDE_START
 import redis.clients.jedis.UnifiedJedis;
 // HIDE_END
@@ -18,63 +21,11 @@ public class CmdsHashExample {
     @Test
     public void run() {
         UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
-
         //REMOVE_START
         // Clear any keys here before using them in tests.
         jedis.del("myhash");
         //REMOVE_END
 // HIDE_END
-
-
-        // STEP_START hdel
-
-        // STEP_END
-
-        // Tests for 'hdel' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hexists
-
-        // STEP_END
-
-        // Tests for 'hexists' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hexpire
-
-        // STEP_END
-
-        // Tests for 'hexpire' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hexpireat
-
-        // STEP_END
-
-        // Tests for 'hexpireat' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hexpiretime
-
-        // STEP_END
-
-        // Tests for 'hexpiretime' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
 
         // STEP_START hget
         Map<String, String> hGetExampleParams = new HashMap<>();
@@ -89,155 +40,42 @@ public class CmdsHashExample {
         String hGetResult3 = jedis.hget("myhash", "field2");
         System.out.println(hGetResult3);    // >>> null
         // STEP_END
-
-        // Tests for 'hget' step.
         // REMOVE_START
+        // Tests for 'hget' step.
         Assert.assertEquals(1, hGetResult1);
         Assert.assertEquals("foo", hGetResult2);
         Assert.assertNull(hGetResult3);
         jedis.del("myhash");
         // REMOVE_END
 
-
         // STEP_START hgetall
+        Map<String, String> hGetAllExampleParams = new HashMap<>();
+        hGetAllExampleParams.put("field1", "Hello");
+        hGetAllExampleParams.put("field2", "World");
 
+        long hGetAllResult1 = jedis.hset("myhash", hGetAllExampleParams);
+        System.out.println(hGetAllResult1); // >>> 2
+
+        Map<String, String> hGetAllResult2 = jedis.hgetAll("myhash");
+        System.out.println(
+            hGetAllResult2.entrySet().stream()
+                .sorted((s1, s2)-> s1.getKey().compareTo(s2.getKey()))
+                .collect(toList())
+                .toString()
+        );
+        // >>> [field1=Hello, field2=World]
         // STEP_END
-
+        // REMOVE_START
         // Tests for 'hgetall' step.
-        // REMOVE_START
-
+        Assert.assertEquals(2, hGetAllResult1);
+        Assert.assertEquals("[field1=Hello, field2=World]",
+            hGetAllResult2.entrySet().stream()
+                .sorted((s1, s2)-> s1.getKey().compareTo(s2.getKey()))
+                .collect(toList())
+                .toString()
+        );
+        jedis.del("myhash");
         // REMOVE_END
-
-
-        // STEP_START hincrby
-
-        // STEP_END
-
-        // Tests for 'hincrby' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hincrbyfloat
-
-        // STEP_END
-
-        // Tests for 'hincrbyfloat' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hkeys
-
-        // STEP_END
-
-        // Tests for 'hkeys' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hlen
-
-        // STEP_END
-
-        // Tests for 'hlen' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hmget
-
-        // STEP_END
-
-        // Tests for 'hmget' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hmset
-
-        // STEP_END
-
-        // Tests for 'hmset' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hpersist
-
-        // STEP_END
-
-        // Tests for 'hpersist' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hpexpire
-
-        // STEP_END
-
-        // Tests for 'hpexpire' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hpexpireat
-
-        // STEP_END
-
-        // Tests for 'hpexpireat' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hpexpiretime
-
-        // STEP_END
-
-        // Tests for 'hpexpiretime' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hpttl
-
-        // STEP_END
-
-        // Tests for 'hpttl' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hrandfield
-
-        // STEP_END
-
-        // Tests for 'hrandfield' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hscan
-
-        // STEP_END
-
-        // Tests for 'hscan' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
 
         // STEP_START hset
         Map<String, String> hSetExampleParams = new HashMap<>();
@@ -269,9 +107,8 @@ public class CmdsHashExample {
         // >>> Key: field2, Value: Hi
         // >>> Key: field1, Value: Hello
         // STEP_END
-
-        // Tests for 'hset' step.
         // REMOVE_START
+        // Tests for 'hset' step.
         Assert.assertEquals(1, hSetResult1);
         Assert.assertEquals("Hello", hSetResult2);
         Assert.assertEquals(2, hSetResult3);
@@ -284,47 +121,25 @@ public class CmdsHashExample {
         jedis.del("myhash");
         // REMOVE_END
 
-
-        // STEP_START hsetnx
-
-        // STEP_END
-
-        // Tests for 'hsetnx' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START hstrlen
-
-        // STEP_END
-
-        // Tests for 'hstrlen' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
-        // STEP_START httl
-
-        // STEP_END
-
-        // Tests for 'httl' step.
-        // REMOVE_START
-
-        // REMOVE_END
-
-
         // STEP_START hvals
+        Map<String, String> hValsExampleParams = new HashMap<>();
+        hValsExampleParams.put("field1", "Hello");
+        hValsExampleParams.put("field2", "World");
 
+        long hValsResult1 = jedis.hset("myhash", hValsExampleParams);
+        System.out.println(hValsResult1); // >>> 2
+
+        List<String> hValsResult2 = jedis.hvals("myhash");
+        Collections.sort(hValsResult2);
+        System.out.println(hValsResult2);
+        // >>> [Hello, World]
         // STEP_END
-
+        // REMOVE_START       
         // Tests for 'hvals' step.
-        // REMOVE_START
-
+        Assert.assertEquals(2, hValsResult1);
+        Assert.assertEquals("[Hello, World]", hValsResult2.toString());
+        jedis.del("myhash");
         // REMOVE_END
-
-
 // HIDE_START
         
     }

--- a/src/test/java/io/redis/examples/CmdsHashExample.java
+++ b/src/test/java/io/redis/examples/CmdsHashExample.java
@@ -59,9 +59,9 @@ public class CmdsHashExample {
         Map<String, String> hGetAllResult2 = jedis.hgetAll("myhash");
         System.out.println(
             hGetAllResult2.entrySet().stream()
-                .sorted((s1, s2)-> s1.getKey().compareTo(s2.getKey()))
-                .collect(toList())
-                .toString()
+                    .sorted((s1, s2)-> s1.getKey().compareTo(s2.getKey()))
+                    .collect(toList())
+                    .toString()
         );
         // >>> [field1=Hello, field2=World]
         // STEP_END
@@ -70,9 +70,9 @@ public class CmdsHashExample {
         Assert.assertEquals(2, hGetAllResult1);
         Assert.assertEquals("[field1=Hello, field2=World]",
             hGetAllResult2.entrySet().stream()
-                .sorted((s1, s2)-> s1.getKey().compareTo(s2.getKey()))
-                .collect(toList())
-                .toString()
+                    .sorted((s1, s2)-> s1.getKey().compareTo(s2.getKey()))
+                    .collect(toList())
+                    .toString()
         );
         jedis.del("myhash");
         // REMOVE_END


### PR DESCRIPTION
[DOC-4450](https://redislabs.atlassian.net/browse/DOC-4450) and [DOC-4455](https://redislabs.atlassian.net/browse/DOC-4455)

Jedis versions of the examples in the [`HGETALL`](https://redis.io/docs/latest/commands/hgetall/) and [`HVALS`](https://redis.io/docs/latest/commands/hvals/) pages. I've also removed the empty placeholders I added previously (they were causing problems) and tidied the formatting up a bit.

[DOC-4450]: https://redislabs.atlassian.net/browse/DOC-4450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-4455]: https://redislabs.atlassian.net/browse/DOC-4455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ