### PR TITLE
Remove List tests asserting timeouts

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/ListCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ListCommandsTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static redis.clients.jedis.util.AssertUtil.assertByteArrayListEquals;
 
@@ -495,17 +494,11 @@ public class ListCommandsTest extends JedisCommandsTestBase {
     assertArrayEquals(bbar, bresult.getValue());
   }
 
-  @Test
+  @Test(timeout = 5000L)
   public void blpopDoubleWithSleep() {
-    long startMillis, totalMillis;
-
-    startMillis = System.currentTimeMillis();
     KeyValue<String, String> result = jedis.blpop(0.04, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
     assertNull(result);
 
-    startMillis = System.currentTimeMillis();
     new Thread(() -> {
       try {
         Thread.sleep(30);
@@ -517,8 +510,6 @@ public class ListCommandsTest extends JedisCommandsTestBase {
       }
     }).start();
     result = jedis.blpop(1.2, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
 
     assertNotNull(result);
     assertEquals("foo", result.getKey());
@@ -617,17 +608,11 @@ public class ListCommandsTest extends JedisCommandsTestBase {
     assertArrayEquals(bbar, bresult.getValue());
   }
 
-  @Test
+  @Test(timeout = 5000L)
   public void brpopDoubleWithSleep() {
-    long startMillis, totalMillis;
-
-    startMillis = System.currentTimeMillis();
     KeyValue<String, String> result = jedis.brpop(0.04, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
     assertNull(result);
 
-    startMillis = System.currentTimeMillis();
     new Thread(() -> {
       try {
         Thread.sleep(30);
@@ -639,8 +624,6 @@ public class ListCommandsTest extends JedisCommandsTestBase {
       }
     }).start();
     result = jedis.brpop(1.2, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
 
     assertNotNull(result);
     assertEquals("foo", result.getKey());

--- a/src/test/java/redis/clients/jedis/commands/unified/ListCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/ListCommandsTestBase.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static redis.clients.jedis.util.AssertUtil.assertByteArrayListEquals;
 
@@ -491,17 +490,11 @@ public abstract class ListCommandsTestBase extends UnifiedJedisCommandsTestBase 
     assertArrayEquals(bbar, bresult.getValue());
   }
 
-  @Test
+  @Test(timeout = 5000L)
   public void blpopDoubleWithSleep() {
-    long startMillis, totalMillis;
-
-    startMillis = System.currentTimeMillis();
     KeyValue<String, String> result = jedis.blpop(0.04, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
     assertNull(result);
 
-    startMillis = System.currentTimeMillis();
     new Thread(() -> {
       try {
         Thread.sleep(30);
@@ -511,8 +504,6 @@ public abstract class ListCommandsTestBase extends UnifiedJedisCommandsTestBase 
       jedis.lpush("foo", "bar");
     }).start();
     result = jedis.blpop(1.2, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
 
     assertNotNull(result);
     assertEquals("foo", result.getKey());
@@ -611,17 +602,11 @@ public abstract class ListCommandsTestBase extends UnifiedJedisCommandsTestBase 
     assertArrayEquals(bbar, bresult.getValue());
   }
 
-  @Test
+  @Test(timeout = 5000L)
   public void brpopDoubleWithSleep() {
-    long startMillis, totalMillis;
-
-    startMillis = System.currentTimeMillis();
     KeyValue<String, String> result = jedis.brpop(0.04, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
     assertNull(result);
 
-    startMillis = System.currentTimeMillis();
     new Thread(() -> {
       try {
         Thread.sleep(30);
@@ -631,8 +616,6 @@ public abstract class ListCommandsTestBase extends UnifiedJedisCommandsTestBase 
       jedis.lpush("foo", "bar");
     }).start();
     result = jedis.brpop(1.2, "foo");
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
 
     assertNotNull(result);
     assertEquals("foo", result.getKey());

--- a/src/test/java/redis/clients/jedis/commands/unified/pipeline/ListPipelineCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pipeline/ListPipelineCommandsTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -15,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import redis.clients.jedis.RedisProtocol;
 import redis.clients.jedis.Response;
 import redis.clients.jedis.args.ListDirection;
@@ -524,21 +524,13 @@ public class ListPipelineCommandsTest extends PipelineCommandsTestBase {
     assertThat(bresult3.get().getValue(), equalTo(bcar));
   }
 
-  @Test
+  @Test(timeout = 5000L)
   public void blpopDoubleWithSleep() {
-    long startMillis, totalMillis;
-
-    startMillis = System.currentTimeMillis();
-
     Response<KeyValue<String, String>> result = pipe.blpop(0.04, "foo");
     pipe.sync();
 
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
-
     assertThat(result.get(), nullValue());
 
-    startMillis = System.currentTimeMillis();
     new Thread(() -> {
       try {
         Thread.sleep(30);
@@ -550,9 +542,6 @@ public class ListPipelineCommandsTest extends PipelineCommandsTestBase {
 
     result = pipe.blpop(1.2, "foo");
     pipe.sync();
-
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
 
     assertThat(result.get().getKey(), equalTo("foo"));
     assertThat(result.get().getValue(), equalTo("bar"));
@@ -646,21 +635,13 @@ public class ListPipelineCommandsTest extends PipelineCommandsTestBase {
     assertThat(bresult3.get().getValue(), equalTo(bcar));
   }
 
-  @Test
+  @Test(timeout = 5000L)
   public void brpopDoubleWithSleep() {
-    long startMillis, totalMillis;
-
-    startMillis = System.currentTimeMillis();
-
     Response<KeyValue<String, String>> result = pipe.brpop(0.04, "foo");
     pipe.sync();
 
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
-
     assertThat(result.get(), nullValue());
 
-    startMillis = System.currentTimeMillis();
     new Thread(() -> {
       try {
         Thread.sleep(30);
@@ -672,9 +653,6 @@ public class ListPipelineCommandsTest extends PipelineCommandsTestBase {
 
     result = pipe.brpop(1.2, "foo");
     pipe.sync();
-
-    totalMillis = System.currentTimeMillis() - startMillis;
-    assertTrue("TotalMillis=" + totalMillis, totalMillis < 200);
 
     assertThat(result.get().getKey(), equalTo("foo"));
     assertThat(result.get().getValue(), equalTo("bar"));


### PR DESCRIPTION
As a client library, it should be enough to send the command arguments and get & parse the reply properly.

Note: These tests have become flaky recently.