### PR TITLE
DOC-4495 sadd and smembers examples

### DIFF
--- a/src/test/java/io/redis/examples/CmdsSetExample.java
+++ b/src/test/java/io/redis/examples/CmdsSetExample.java
@@ -32,9 +32,7 @@ public class CmdsSetExample {
         System.out.println(sAddResult3); // >>> 0
 
         Set<String> sAddResult4 = jedis.smembers("myset");
-        System.out.println(
-            sAddResult4.stream().sorted().collect(toList()).toString()
-        );
+        System.out.println(sAddResult4.stream().sorted().collect(toList()));
         // >>> [Hello, World]
         // STEP_END
         // REMOVE_START
@@ -50,9 +48,7 @@ public class CmdsSetExample {
         System.out.println(sMembersResult1); // >>> 2
 
         Set<String> sMembersResult2 = jedis.smembers("myset");
-        System.out.println(
-            sMembersResult2.stream().sorted().collect(toList()).toString()
-        );
+        System.out.println(sMembersResult2.stream().sorted().collect(toList()));
         // >>> [Hello, World]
         // STEP_END
         // REMOVE_START

--- a/src/test/java/io/redis/examples/CmdsSetExample.java
+++ b/src/test/java/io/redis/examples/CmdsSetExample.java
@@ -17,7 +17,6 @@ public class CmdsSetExample {
     public void run() {
         UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
         //REMOVE_START
-        // Clear any keys here before using them in tests.
         jedis.del("myset");
         //REMOVE_END
 // HIDE_END
@@ -60,7 +59,6 @@ public class CmdsSetExample {
         Assert.assertEquals(2, sMembersResult1);
         Assert.assertArrayEquals(new String[] {"Hello", "World"}, sMembersResult2.stream().sorted().toArray());
         // REMOVE_END
-
         // HIDE_START
     }
 }

--- a/src/test/java/io/redis/examples/CmdsSetExample.java
+++ b/src/test/java/io/redis/examples/CmdsSetExample.java
@@ -1,0 +1,67 @@
+// EXAMPLE: cmds_set
+// REMOVE_START
+package io.redis.examples;
+
+import org.junit.Assert;
+import org.junit.Test;
+// REMOVE_END
+import static java.util.stream.Collectors.toList;
+
+import java.util.Set;
+
+// HIDE_START
+import redis.clients.jedis.UnifiedJedis;
+
+public class CmdsSetExample {
+    @Test
+    public void run() {
+        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+        //REMOVE_START
+        // Clear any keys here before using them in tests.
+        jedis.del("myset");
+        //REMOVE_END
+// HIDE_END
+
+        // STEP_START sadd
+        long sAddResult1 = jedis.sadd("myset", "Hello");
+        System.out.println(sAddResult1); // >>> 1
+
+        long sAddResult2 = jedis.sadd("myset", "World");
+        System.out.println(sAddResult2); // >>> 1
+
+        long sAddResult3 = jedis.sadd("myset", "World");
+        System.out.println(sAddResult3); // >>> 0
+
+        Set<String> sAddResult4 = jedis.smembers("myset");
+        System.out.println(
+            sAddResult4.stream().sorted().collect(toList()).toString()
+        );
+        // >>> [Hello, World]
+        // STEP_END
+        // REMOVE_START
+        Assert.assertEquals(1, sAddResult1);
+        Assert.assertEquals(1, sAddResult2);
+        Assert.assertEquals(0, sAddResult3);
+        Assert.assertArrayEquals(new String[] {"Hello", "World"}, sAddResult4.stream().sorted().toArray());
+        jedis.del("myset");
+        // REMOVE_END
+
+        // STEP_START smembers
+        long sMembersResult1 = jedis.sadd("myset", "Hello", "World");
+        System.out.println(sMembersResult1); // >>> 2
+
+        Set<String> sMembersResult2 = jedis.smembers("myset");
+        System.out.println(
+            sMembersResult2.stream().sorted().collect(toList()).toString()
+        );
+        // >>> [Hello, World]
+        // STEP_END
+        // REMOVE_START
+        Assert.assertEquals(2, sMembersResult1);
+        Assert.assertArrayEquals(new String[] {"Hello", "World"}, sMembersResult2.stream().sorted().toArray());
+        // REMOVE_END
+
+        // HIDE_START
+    }
+}
+// HIDE_END


### PR DESCRIPTION
[DOC-4495](https://redislabs.atlassian.net/browse/DOC-4495) and [DOC-4500](https://redislabs.atlassian.net/browse/DOC-4500)

Jedis versions of the examples for [`SADD`](https://redis.io/docs/latest/commands/sadd/) and [`SMEMBERS`](https://redis.io/docs/latest/commands/smembers/). I've wrapped a couple of long `System.out.println()` lines to fit the example tab better but let me know if there's a better way to format these.

[DOC-4495]: https://redislabs.atlassian.net/browse/DOC-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-4500]: https://redislabs.atlassian.net/browse/DOC-4500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ