### PR TITLE
Fix sporadic test failing with OOM

### DIFF
--- a/.github/workflows/test-on-docker.yml
+++ b/.github/workflows/test-on-docker.yml
@@ -83,7 +83,7 @@ jobs:
             mvn -Dtest=$TESTS clean compile test
           fi
         env:
-          JVM_OPTS: "-XX:+PrintFlagsFinal -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -XX:HeapDumpPath=${{ runner.temp }}/heapdump-${{ matrix.redis_version }}.hprof"
+          JVM_OPTS: "-XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -XX:HeapDumpPath=${{ runner.temp }}/heapdump-${{ matrix.redis_version }}.hprof"
           TESTS: ${{ github.event.inputs.specific_test || '' }}
       - name: Upload Heap Dumps
         if: failure()
@@ -91,6 +91,7 @@ jobs:
         with:
           name: heap-dumps-${{ matrix.redis_version }}
           path: ${{ runner.temp }}/heapdump-${{ matrix.redis_version }}.hprof
+          retention-days: 5
       - name: Upload Surefire Dump File
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test-on-docker.yml
+++ b/.github/workflows/test-on-docker.yml
@@ -83,7 +83,19 @@ jobs:
             mvn -Dtest=$TESTS clean compile test
           fi
         env:
+          JVM_OPTS: "-XX:+PrintFlagsFinal -XX:+HeapDumpOnOutOfMemoryError -XX:+ExitOnOutOfMemoryError -XX:HeapDumpPath=${{ runner.temp }}/heapdump-${{ matrix.redis_version }}.hprof"
           TESTS: ${{ github.event.inputs.specific_test || '' }}
+      - name: Upload Heap Dumps
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: heap-dumps-${{ matrix.redis_version }}
+          path: ${{ runner.temp }}/heapdump-${{ matrix.redis_version }}.hprof
+      - name: Upload Surefire Dump File
+        uses: actions/upload-artifact@v3
+        with:
+          name: surefire-dumpstream
+          path: target/surefire-reports/*.dumpstream
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven.surefire.version}</version>
 				<configuration>
+					<argLine>${JVM_OPTS}</argLine>
 					<systemPropertyVariables>
 						<redis-hosts>${redis-hosts}</redis-hosts>
 					</systemPropertyVariables>

--- a/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationUnitTests.java
+++ b/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationUnitTests.java
@@ -297,16 +297,16 @@ public class TokenBasedAuthenticationUnitTests {
 
     TokenManager tokenManager = new TokenManager(identityProvider, new TokenManagerConfig(0.7F, 200,
         2000, new TokenManagerConfig.RetryPolicy(numberOfRetries - 1, 100)));
-    try {
 
-    TokenListener listener = mock(TokenListener.class);
-    tokenManager.start(listener, false);
-    requesLatch.await();
-    await().pollDelay(ONE_HUNDRED_MILLISECONDS).atMost(FIVE_HUNDRED_MILLISECONDS)
-        .untilAsserted(() -> verify(listener).onTokenRenewed(argument.capture()));
-    verify(identityProvider, times(numberOfRetries)).requestToken();
-    verify(listener, never()).onError(any());
-    assertEquals("tokenValX", argument.getValue().getValue());
+    try {
+      TokenListener listener = mock(TokenListener.class);
+      tokenManager.start(listener, false);
+      requesLatch.await();
+      await().pollDelay(ONE_HUNDRED_MILLISECONDS).atMost(FIVE_HUNDRED_MILLISECONDS)
+          .untilAsserted(() -> verify(listener).onTokenRenewed(argument.capture()));
+      verify(identityProvider, times(numberOfRetries)).requestToken();
+      verify(listener, never()).onError(any());
+      assertEquals("tokenValX", argument.getValue().getValue());
     } finally {
       tokenManager.stop();
     }

--- a/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationUnitTests.java
+++ b/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationUnitTests.java
@@ -83,6 +83,7 @@ public class TokenBasedAuthenticationUnitTests {
 
     await().pollInterval(ONE_HUNDRED_MILLISECONDS).atMost(FIVE_HUNDRED_MILLISECONDS)
         .until(numberOfEvictions::get, Matchers.greaterThanOrEqualTo(1));
+    pool.close();
   }
 
   public void withLowerRefreshBounds_testJedisAuthXManagerTriggersEvict() throws Exception {
@@ -108,6 +109,7 @@ public class TokenBasedAuthenticationUnitTests {
 
     await().pollInterval(ONE_HUNDRED_MILLISECONDS).atMost(FIVE_HUNDRED_MILLISECONDS)
         .until(numberOfEvictions::get, Matchers.greaterThanOrEqualTo(1));
+    pool.close();
   }
 
   public static class TokenManagerConfigWrapper extends TokenManagerConfig {
@@ -229,6 +231,7 @@ public class TokenBasedAuthenticationUnitTests {
 
     manager.start();
     assertEquals(tokenHolder[0].getValue(), "tokenVal");
+    manager.stop();
   }
 
   @Test
@@ -300,6 +303,7 @@ public class TokenBasedAuthenticationUnitTests {
     verify(identityProvider, times(numberOfRetries)).requestToken();
     verify(listener, never()).onError(any());
     assertEquals("tokenValX", argument.getValue().getValue());
+    tokenManager.stop();
   }
 
   @Test
@@ -338,5 +342,6 @@ public class TokenBasedAuthenticationUnitTests {
     await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
       verify(manager, times(1)).authenticateConnections(any());
     });
+    manager.stop();
   }
 }


### PR DESCRIPTION
Missing AuthXManager shutdown in tests causes the token renew thread to run after the test completion. 
When used with Mockito.mock() this leads to a growing number of mocked objects and eventually to OOM.

- Invoke AuthXManager.close()
- Updated GitHub test workflow to publish heap dump on OOM errors in the test 