### PR TITLE
DOC-4445 server management command examples

### DIFF
--- a/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
+++ b/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
@@ -1,0 +1,43 @@
+// EXAMPLE: cmds_servermgmt
+// REMOVE_START
+package io.redis.examples;
+
+import org.junit.Assert;
+import org.junit.Test;
+// REMOVE_END
+import java.util.Set;
+
+// HIDE_START
+import redis.clients.jedis.UnifiedJedis;
+
+public class CmdsServerMgmtExample {
+    @Test
+    public void run() {
+        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+
+        // STEP_START flushall
+        //REMOVE_START
+        jedis.set("testkey1", "1");
+        jedis.set("testkey2", "2");
+        jedis.set("testkey3", "3");
+        //REMOVE_END
+        String flushAllResult1 = jedis.flushAll();
+        System.out.println(flushAllResult1); // >>> OK
+
+        Set<String> flushAllResult2 = jedis.keys("*");
+        System.out.println(flushAllResult2); // >>> []
+        // STEP_END
+        // REMOVE_START
+        Assert.assertEquals("OK", flushAllResult1);
+        Assert.assertEquals("[]", flushAllResult2.toString());
+        // REMOVE_END
+
+        // STEP_START info
+
+        // Not currently supported by Jedis.
+
+        // STEP_END
+
+// HIDE_END
+    }
+}

--- a/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
+++ b/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
@@ -15,6 +15,7 @@ public class CmdsServerMgmtExample {
     @Test
     public void run() {
         UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+// HIDE_END
 
         // STEP_START flushall
         // REMOVE_START
@@ -50,6 +51,8 @@ public class CmdsServerMgmtExample {
         Assert.assertEquals("# Server", infoResult.substring(0, 8));
         // REMOVE_END
         
-// HIDE_END
+// HIDE_START
+        jedis.close();
     }
 }
+// HIDE_END

--- a/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
+++ b/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 // REMOVE_END
 import java.util.Set;
 
+import redis.clients.jedis.Jedis;
 // HIDE_START
 import redis.clients.jedis.UnifiedJedis;
 
@@ -33,11 +34,22 @@ public class CmdsServerMgmtExample {
         // REMOVE_END
 
         // STEP_START info
+        // Note: you must use the `Jedis` class to access the `info`
+        // command rather than `UnifiedJedis`.
+        Jedis jedis2 = new Jedis("redis://localhost:6379");
 
-        // Not currently supported by Jedis.
+        String infoResult = jedis2.info();
+        
+        // Check the first 8 characters of the result (the full `info` string
+        // is much longer than this).
+        System.out.println(infoResult.substring(0, 8)); // >>> # Server
 
+        jedis2.close();
         // STEP_END
-
+        // REMOVE_START
+        Assert.assertEquals("# Server", infoResult.substring(0, 8));
+        // REMOVE_END
+        
 // HIDE_END
     }
 }

--- a/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
+++ b/src/test/java/io/redis/examples/CmdsServerMgmtExample.java
@@ -17,11 +17,11 @@ public class CmdsServerMgmtExample {
         UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
 
         // STEP_START flushall
-        //REMOVE_START
+        // REMOVE_START
         jedis.set("testkey1", "1");
         jedis.set("testkey2", "2");
         jedis.set("testkey3", "3");
-        //REMOVE_END
+        // REMOVE_END
         String flushAllResult1 = jedis.flushAll();
         System.out.println(flushAllResult1); // >>> OK
 


### PR DESCRIPTION
[DOC-4445](https://redislabs.atlassian.net/browse/DOC-4445) and [DOC-4460](https://redislabs.atlassian.net/browse/DOC-4460).

Jedis versions of the [`FLUSHALL`](https://redis.io/docs/latest/commands/flushall/) and [`INFO`](https://redis.io/docs/latest/commands/info/) commands.

Note: `INFO` doesn't seem to be supported by `UnifiedJedis` but it is mentioned in other places. I figured the best way to handle it was to say it was not supported but let me know if you want to show an alternative way to access it.

[DOC-4445]: https://redislabs.atlassian.net/browse/DOC-4445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-4460]: https://redislabs.atlassian.net/browse/DOC-4460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ