### PR TITLE
DOC-4440 added auth command examples using Jedis class

### DIFF
--- a/src/test/java/io/redis/examples/CmdsCnxmgmtExample.java
+++ b/src/test/java/io/redis/examples/CmdsCnxmgmtExample.java
@@ -2,25 +2,45 @@
 // REMOVE_START
 package io.redis.examples;
 
+import org.junit.Assert;
 import org.junit.Test;
 // REMOVE_END
+
+import redis.clients.jedis.Jedis;
 
 // HIDE_START
 public class CmdsCnxmgmtExample {
     @Test
     public void run() {
 // HIDE_END
+        Jedis jedis = new Jedis("redis://localhost:6379");
 
         // STEP_START auth1
-
-        // Not currently supported by Jedis.
-
+        // REMOVE_START
+        jedis.configSet("requirepass", "temp_pass");
+        // REMOVE_END
+        // Note: you must use the `Jedis` class rather than `UnifiedJedis`
+        // to access the `auth` commands.
+        String authResult1 = jedis.auth("default",  "temp_pass");
+        System.out.println(authResult1); // >>> OK
+        // REMOVE_START
+        Assert.assertEquals("OK", authResult1);
+        jedis.configSet("requirepass", "");
+        // REMOVE_END
         // STEP_END
        
         // STEP_START auth2
-        
-        // Not currently supported by Jedis.
-
+        // REMOVE_START
+        jedis.aclSetUser("test-user", "on", ">strong_password", "+acl");
+        // REMOVE_END
+        // Note: you must use the `Jedis` class rather than `UnifiedJedis`
+        // to access the `auth` commands.
+        String authResult2 = jedis.auth("test-user", "strong_password");
+        System.out.println(authResult2); // >>> OK
+        // REMOVE_START
+        Assert.assertEquals("OK", authResult2);
+        jedis.aclDelUser("test-user");
+        // REMOVE_END
         // STEP_END
         
         // HIDE_START

--- a/src/test/java/io/redis/examples/CmdsCnxmgmtExample.java
+++ b/src/test/java/io/redis/examples/CmdsCnxmgmtExample.java
@@ -1,0 +1,29 @@
+// EXAMPLE: cmds_cnxmgmt
+// REMOVE_START
+package io.redis.examples;
+
+import org.junit.Test;
+// REMOVE_END
+
+// HIDE_START
+public class CmdsCnxmgmtExample {
+    @Test
+    public void run() {
+// HIDE_END
+
+        // STEP_START auth1
+
+        // Not currently supported by Jedis.
+
+        // STEP_END
+       
+        // STEP_START auth2
+        
+        // Not currently supported by Jedis.
+
+        // STEP_END
+        
+        // HIDE_START
+    }
+}
+// HIDE_END


### PR DESCRIPTION
[DOC-4440](https://redislabs.atlassian.net/browse/DOC-4440)

Edit: added the [`AUTH`](https://redis.io/docs/latest/commands/auth/) examples using the `Jedis` class rather than `UnifiedJedis`.

[DOC-4440]: https://redislabs.atlassian.net/browse/DOC-4440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ