### PR TITLE
Fix the Java example code for Lists using RPUSH

### DIFF
--- a/src/test/java/io/redis/examples/ListExample.java
+++ b/src/test/java/io/redis/examples/ListExample.java
@@ -176,7 +176,7 @@ public class ListExample {
         // REMOVE_START
         assertEquals(5, res27);
         assertEquals("OK", res28);
-        assertEquals("[bike:5, bike:4, bike:3]", res29.toString());
+        assertEquals("[bike:1, bike:2, bike:3]", res29.toString());
         jedis.del("bikes:repairs");
         // REMOVE_END
 

--- a/src/test/java/io/redis/examples/ListExample.java
+++ b/src/test/java/io/redis/examples/ListExample.java
@@ -163,14 +163,14 @@ public class ListExample {
         // REMOVE_END
 
         // STEP_START ltrim
-        long res27 = jedis.lpush("bikes:repairs", "bike:1", "bike:2", "bike:3", "bike:4", "bike:5");
+        long res27 = jedis.rpush("bikes:repairs", "bike:1", "bike:2", "bike:3", "bike:4", "bike:5");
         System.out.println(res27);  // >>> 5
 
         String res28 = jedis.ltrim("bikes:repairs", 0, 2);
         System.out.println(res28);  // >>> OK
 
         List<String> res29 = jedis.lrange("bikes:repairs", 0, -1);
-        System.out.println(res29);  // >>> [bike:5, bike:4, bike:3]
+        System.out.println(res29);  // >>> [bike:1, bike:2, bike:3]
         // STEP_END
 
         // REMOVE_START


### PR DESCRIPTION
In the example under Capped List on the documentation page: https://redis.io/docs/latest/develop/data-types/lists/
The Java-Sync library code example is not matching the one given in Redis CLI and also not matching the problem statement: "For example, if you're adding bikes on the end of a list of repairs, but only want to worry about the 3 that have been on the list the longest:" 

The right solution is to use `rpush` and `ltrim` the first X elements. 

This PR fixes the code to match the Redis CLI example.