### PR TITLE
Support INFO command in UnifiedJedis

### DIFF
--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -42,6 +42,7 @@ import redis.clients.jedis.search.aggr.FtAggregateIteration;
 import redis.clients.jedis.search.schemafields.SchemaField;
 import redis.clients.jedis.timeseries.*;
 import redis.clients.jedis.util.IOUtils;
+import redis.clients.jedis.util.JedisBroadcastReplies;
 import redis.clients.jedis.util.JedisURIHelper;
 import redis.clients.jedis.util.KeyValue;
 
@@ -333,6 +334,10 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
     this.commandObjects.setBroadcastAndRoundRobinConfig(this.broadcastAndRoundRobinConfig);
   }
 
+  public final JedisBroadcastReplies broadcastCommandDifferingReplies(CommandObject commandObject) {
+    return executor.broadcastCommandDifferingReplies(commandObject);
+  }
+
   public Cache getCache() {
     return cache;
   }
@@ -351,6 +356,16 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
 
   public String configSet(String parameter, String value) {
     return checkAndBroadcastCommand(commandObjects.configSet(parameter, value));
+  }
+
+  public final JedisBroadcastReplies info() {
+    return executor.broadcastCommandDifferingReplies(new CommandObject(
+        new CommandArguments(Protocol.Command.INFO), BuilderFactory.STRING));
+  }
+
+  public final JedisBroadcastReplies info(String section) {
+    return executor.broadcastCommandDifferingReplies(new CommandObject(
+        new CommandArguments(Protocol.Command.INFO).add(section), BuilderFactory.STRING));
   }
 
   // Key commands

--- a/src/main/java/redis/clients/jedis/executors/CommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/executors/CommandExecutor.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis.executors;
 
 import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.util.JedisBroadcastReplies;
 
 public interface CommandExecutor extends AutoCloseable {
 
@@ -8,5 +9,9 @@ public interface CommandExecutor extends AutoCloseable {
 
   default <T> T broadcastCommand(CommandObject<T> commandObject) {
     return executeCommand(commandObject);
+  }
+
+  default JedisBroadcastReplies broadcastCommandDifferingReplies(CommandObject commandObject) {
+    return JedisBroadcastReplies.singleton(executeCommand(commandObject));
   }
 }

--- a/src/main/java/redis/clients/jedis/util/JedisBroadcastReplies.java
+++ b/src/main/java/redis/clients/jedis/util/JedisBroadcastReplies.java
@@ -1,0 +1,40 @@
+package redis.clients.jedis.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The collection of replies where a command is broadcasted to multiple nodes, but the replies are expected to differ
+ * even in ideal situation.
+ */
+public class JedisBroadcastReplies {
+
+  private static final Object DUMMY_OBJECT = new Object();
+
+  private final Map<Object, Object> replies;
+
+  public JedisBroadcastReplies() {
+    this(new HashMap<>());
+  }
+
+  public JedisBroadcastReplies(int size) {
+    this(new HashMap<>(size));
+  }
+
+  private JedisBroadcastReplies(Map<Object, Object> replies) {
+    this.replies = replies;
+  }
+
+  public void addReply(Object node, Object reply) {
+    replies.put(node, reply);
+  }
+
+  public Map<Object, Object> getReplies() {
+    return Collections.unmodifiableMap(replies);
+  }
+
+  public static JedisBroadcastReplies singleton(Object reply) {
+    return new JedisBroadcastReplies(Collections.singletonMap(DUMMY_OBJECT, reply));
+  }
+}

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClusterValuesCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClusterValuesCommandsTest.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.commands.jedis;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -10,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import redis.clients.jedis.BuilderFactory;
@@ -23,6 +25,7 @@ import redis.clients.jedis.args.GeoUnit;
 import redis.clients.jedis.params.GeoRadiusParam;
 import redis.clients.jedis.params.GeoRadiusStoreParam;
 import redis.clients.jedis.resps.ScanResult;
+import redis.clients.jedis.util.JedisBroadcastReplies;
 
 public class ClusterValuesCommandsTest extends ClusterJedisCommandsTestBase {
 
@@ -126,6 +129,21 @@ public class ClusterValuesCommandsTest extends ClusterJedisCommandsTestBase {
   @Test
   public void pingBroadcast() {
     assertEquals("PONG", cluster.ping());
+  }
+
+  @Test
+  public void broadcastDifferentReplies() {
+    JedisBroadcastReplies infoReplies = cluster.info();
+    assertThat(infoReplies.getReplies(), Matchers.aMapWithSize(3));
+    infoReplies.getReplies().values().forEach(infoValue -> {
+      assertThat((String) infoValue, Matchers.notNullValue());
+    });
+
+    infoReplies = cluster.info("server");
+    assertThat(infoReplies.getReplies(), Matchers.aMapWithSize(3));
+    infoReplies.getReplies().values().forEach(infoValue -> {
+      assertThat((String) infoValue, Matchers.notNullValue());
+    });
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/pooled/PooledMiscellaneousTest.java
@@ -1,5 +1,6 @@
 package redis.clients.jedis.commands.unified.pooled;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -9,6 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import io.redis.test.annotations.SinceRedisVersion;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -23,6 +25,7 @@ import redis.clients.jedis.Response;
 import redis.clients.jedis.commands.unified.UnifiedJedisCommandsTestBase;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.util.EnabledOnCommandRule;
+import redis.clients.jedis.util.JedisBroadcastReplies;
 import redis.clients.jedis.util.RedisVersionRule;
 
 @RunWith(Parameterized.class)
@@ -163,5 +166,18 @@ public class PooledMiscellaneousTest extends UnifiedJedisCommandsTestBase {
     JedisDataException error = assertThrows(JedisDataException.class,
         () -> jedis.functionDelete("xyz"));
     assertEquals("ERR Library not found", error.getMessage());
+  }
+
+  @Test
+  public void broadcastDifferentReplies() {
+    JedisBroadcastReplies infoReplies = jedis.info();
+    assertThat(infoReplies.getReplies(), Matchers.aMapWithSize(1));
+    Object infoValue = infoReplies.getReplies().values().stream().findFirst().get();
+    assertThat((String) infoValue, Matchers.notNullValue());
+
+    infoReplies = jedis.info("server");
+    assertThat(infoReplies.getReplies(), Matchers.aMapWithSize(1));
+    infoValue = infoReplies.getReplies().values().stream().findFirst().get();
+    assertThat((String) infoValue, Matchers.notNullValue());
   }
 }


### PR DESCRIPTION
This PR target's  to resolve https://github.com/redis/jedis/issues/4094

In PR [4079](https://github.com/redis/jedis/pull/4079 ) is suggested simplified approach were in case of cluster, INFO` `command is send to arbitrary node.

This PR suggests broadcasting the command to all node's from the cluster and return's aggregated response in complex object

