### PR TITLE
Extend EXECABORT with "previous errors" #4084

### DIFF
--- a/src/main/java/redis/clients/jedis/Transaction.java
+++ b/src/main/java/redis/clients/jedis/Transaction.java
@@ -169,11 +169,25 @@ public class Transaction extends TransactionBase {
     try {
       // ignore QUEUED (or ERROR)
       // processPipelinedResponses(pipelinedResponses.size());
-      connection.getMany(1 + pipelinedResponses.size());
+      List<Object> queuedCmdResponses = connection.getMany(1 + pipelinedResponses.size());
+
 
       connection.sendCommand(EXEC);
 
-      List<Object> unformatted = connection.getObjectMultiBulkReply();
+      List<Object> unformatted;
+      try {
+        unformatted = connection.getObjectMultiBulkReply();
+      } catch (JedisDataException jce) {
+        // A command may fail to be queued, so there may be an error before EXEC is called
+        // In this case, the server will discard all commands in the transaction and return the EXECABORT error.
+        // Enhance the final error with suppressed errors.
+        queuedCmdResponses.stream()
+            .filter(o -> o instanceof Exception)
+            .map(o -> (Exception) o)
+            .forEach(jce::addSuppressed);
+        throw jce;
+      }
+
       if (unformatted == null) {
         pipelinedResponses.clear();
         return null;

--- a/src/test/java/redis/clients/jedis/TransactionV2Test.java
+++ b/src/test/java/redis/clients/jedis/TransactionV2Test.java
@@ -1,6 +1,8 @@
 package redis.clients.jedis;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 import static redis.clients.jedis.Protocol.Command.INCR;
 import static redis.clients.jedis.Protocol.Command.GET;
 import static redis.clients.jedis.Protocol.Command.SET;
@@ -9,6 +11,8 @@ import static redis.clients.jedis.util.AssertUtil.assertByteArrayListEquals;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -211,6 +215,23 @@ public class TransactionV2Test {
       // that is fine we should be here
     }
     assertEquals("bar", r.get());
+  }
+
+  @Test
+  public void transactionPropagatesErrorsBeforeExec() {
+    // A command may fail to be queued, so there may be an error before EXEC is called.
+    // For instance the command may be syntactically wrong (wrong number of arguments, wrong command name, ...)
+    CommandObject<String> invalidCommand =
+        new CommandObject<>(new CommandObjects().commandArguments(SET), BuilderFactory.STRING);
+
+    Transaction t = new Transaction(conn);
+    t.appendCommand(invalidCommand);
+    t.set("foo","bar");
+    JedisDataException exception = assertThrows(JedisDataException.class, t::exec);
+    Throwable[] suppressed = exception.getSuppressed();
+    assertNotNull("Suppressed exceptions should not be null", suppressed);
+    assertTrue("There should be at least one suppressed exception", suppressed.length > 0);
+    MatcherAssert.assertThat(suppressed[0].getMessage(), containsString("ERR wrong number of arguments"));
   }
 
   @Test


### PR DESCRIPTION
Addresses #4084

[see : Transactions](https://redis.io/docs/latest/develop/interact/transactions/)
A command may fail to be queued, so there may be an error before EXEC is called. For instance the command may be syntactically wrong (wrong number of arguments, wrong command name, ...), 

Fix:  Errors were already collected but not reported. With this change, they are added to the final exception as suppressed.
 
closes #4084