### PR TITLE
Update stale issue workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -18,7 +18,7 @@ jobs:
         stale-issue-message: 'This issue is marked stale. It will be closed in 30 days if it is not updated.'
         stale-pr-message: 'This pull request is marked stale. It will be closed in 30 days if it is not updated.'
         days-before-stale: 30
-        days-before-close: 14
+        days-before-close: 30
         stale-issue-label: "stale"
         stale-pr-label: "stale"
         operations-per-run: 10

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -17,12 +17,12 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is marked stale. It will be closed in 30 days if it is not updated.'
         stale-pr-message: 'This pull request is marked stale. It will be closed in 30 days if it is not updated.'
-        days-before-stale: 365
-        days-before-close: 30
+        days-before-stale: 30
+        days-before-close: 14
         stale-issue-label: "stale"
         stale-pr-label: "stale"
         operations-per-run: 10
-        remove-stale-when-updated: false
+        remove-stale-when-updated: true
         only-labels: 'waiting-for-feedback'
         exempt-issue-labels: 'feedback-provided'
         exempt-pr-labels: 'feedback-provided'

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -23,3 +23,7 @@ jobs:
         stale-pr-label: "stale"
         operations-per-run: 10
         remove-stale-when-updated: false
+        only-labels: 'waiting-for-feedback'
+        exempt-issue-labels: 'feedback-provided'
+        exempt-pr-labels: 'feedback-provided'
+        exempt-all-milestones: true


### PR DESCRIPTION
  - Mark the Issue as stale only if marked with waiting-for-feedback
  - Do not mark Issue/PR as stale if marked with feedback-provided
  - Do not mark the Issue/PR as stale if assigned to a milestone