### PR TITLE
#2320: Unit Tests for ACL Credential Propagation in JedisPool/UnifiedJedis

### DIFF
--- a/src/test/java/redis/clients/jedis/JedisPoolTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPoolTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import redis.clients.jedis.exceptions.InvalidURIException;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.providers.PooledConnectionProvider;
 
 public class JedisPoolTest {
 
@@ -456,6 +457,78 @@ public class JedisPoolTest {
         obj2.set("foo", "bar");
         assertEquals("bar", obj2.get("foo"));
       }
+    }
+  }
+
+  @Test
+  public void testCompareUsernamePasswordWithConfig() {
+
+    class TestJedisFactory extends JedisFactory {
+      private final JedisClientConfig testClientConfig;
+
+      public TestJedisFactory(final String host, final int port, final int connectionTimeout,
+                              final int soTimeout, final String user, final String password,
+                              final int database, final String clientName) {
+
+        super(host, port, connectionTimeout, soTimeout, 0, user, password, database, clientName);
+
+        this.testClientConfig = DefaultJedisClientConfig.builder()
+                .connectionTimeoutMillis(connectionTimeout)
+                .socketTimeoutMillis(soTimeout)
+                .blockingSocketTimeoutMillis(0)
+                .user(user).password(password)
+                .database(database).clientName(clientName)
+                .ssl(false).sslSocketFactory(null)
+                .sslParameters(null).hostnameVerifier(null).build();
+      }
+
+      public JedisClientConfig getTestClientConfig() {
+        return testClientConfig;
+      }
+    }
+
+    try (JedisPool pool = new JedisPool(new JedisPoolConfig(),
+            new TestJedisFactory(endpointStandalone1.getHost(), endpointStandalone1.getPort(),
+            Protocol.DEFAULT_TIMEOUT, Protocol.DEFAULT_TIMEOUT,
+            endpointStandalone1.getUsername(), endpointStandalone1.getPassword(),
+            Protocol.DEFAULT_DATABASE, null))) {
+
+      TestJedisFactory factory = (TestJedisFactory) pool.getFactory();
+      JedisClientConfig clientConfig = factory.getTestClientConfig();
+
+      assertEquals(endpointStandalone1.getUsername(), clientConfig.getUser());
+      assertEquals(endpointStandalone1.getPassword(), clientConfig.getPassword());
+    }
+  }
+
+  @Test
+  public void testCompareUsernamePasswordWithConfigForUnifiedJedis() {
+
+    class TestConnectionFactory extends ConnectionFactory {
+      private final JedisClientConfig testClientConfig;
+
+      public TestConnectionFactory(HostAndPort hostAndPort, JedisClientConfig clientConfig) {
+        super(hostAndPort, clientConfig);
+        this.testClientConfig = clientConfig;
+      }
+
+      public JedisClientConfig getClientConfig() {
+        return testClientConfig;
+      }
+    }
+
+    // UnifiedJedis -> PooledConnectionProvider -> factory
+    DefaultJedisClientConfig jedisClientConfig = DefaultJedisClientConfig.builder()
+            .user(endpointStandalone1.getUsername()).password(endpointStandalone1.getPassword()).build();
+    TestConnectionFactory testConnectionFactory = new TestConnectionFactory(endpointStandalone1.getHostAndPort(), jedisClientConfig);
+
+    try (UnifiedJedis unifiedJedis = new UnifiedJedis(new PooledConnectionProvider(testConnectionFactory))) {
+
+      PooledConnectionProvider provider = (PooledConnectionProvider) unifiedJedis.provider;
+      TestConnectionFactory factory = (TestConnectionFactory) provider.getPool().getFactory();
+
+      assertEquals(endpointStandalone1.getUsername(), factory.getClientConfig().getUser());
+      assertEquals(endpointStandalone1.getPassword(), factory.getClientConfig().getPassword());
     }
   }
 }


### PR DESCRIPTION
- #2320 Unit test for constructors of JedisPool/UnifeidJedis which verifies that the provided username/password reaches ConnectionFactory. Without the need of explicit test env

### Questions
- In your previous feedback, you mentioned, "I would start with reviewing submitted tests and check if there are other places where we configure username/password with missing tests." Does this mean that username/password should be passed in every test, or are you referring to specific tests (e.g., JedisPoolTest or JedisPooledTest)?

- Regarding the approach of using a test-specific subclass (TestJedisFactory) to verify, without using Reflection, that the ACL credentials provided to the constructor are correctly reflected in the internal JedisClientConfig—is this approach acceptable? Are there any additional aspects we should check?

- Additionally, we would like to confirm if the placement of these tests is appropriate.