### PR TITLE
Add getPasswordAsChars and deprecate getPassword

### DIFF
--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -84,6 +84,11 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   }
 
   @Override
+  public char[] getPasswordAsChars() {
+    return credentialsProvider.get().getPassword().clone();
+  }
+
+  @Override
   public Supplier<RedisCredentials> getCredentialsProvider() {
     return credentialsProvider;
   }
@@ -157,6 +162,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
 
     private String user = null;
     private String password = null;
+    private char[] passwordAsChars = null;
     private Supplier<RedisCredentials> credentialsProvider;
     private int database = Protocol.DEFAULT_DATABASE;
     private String clientName = null;
@@ -227,8 +233,18 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
       return this;
     }
 
+    /**
+     * @deprecated This method is deprecated in favor of {@link #passwordAsChars(char[])} due to security concerns.
+     * Storing passwords as Strings can lead to security risks since Strings are immutable and stay in memory
+     * until garbage collected. Use {@link #passwordAsChars(char[])} instead to handle passwords more securely.
+     */
     public Builder password(String password) {
       this.password = password;
+      return this;
+    }
+
+    public Builder passwordAsChars(char[] password) {
+      this.passwordAsChars = password;
       return this;
     }
 
@@ -357,6 +373,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     } else {
       builder.user(copy.getUser());
       builder.password(copy.getPassword());
+      builder.passwordAsChars(copy.getPasswordAsChars());
     }
 
     builder.database(copy.getDatabase());

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -42,9 +42,17 @@ public interface JedisClientConfig {
     return null;
   }
 
+  /**
+   * @deprecated This method is deprecated in favor of {@link #getPasswordAsChars()} due to security concerns.
+   * Storing passwords as Strings can lead to security risks since Strings are immutable and stay in memory
+   * until garbage collected. Use {@link #getPasswordAsChars()} instead to handle passwords more securely.
+   */
+  @Deprecated
   default String getPassword() {
     return null;
   }
+
+  default char[] getPasswordAsChars() { return null; }
 
   // TODO: return null
   default Supplier<RedisCredentials> getCredentialsProvider() {


### PR DESCRIPTION
feat: Add getPasswordAsChars() method to interface and class  

- Introduced `getPasswordAsChars()` method in the relevant interface and Java class.  
- This method provides a char[] alternative to the existing password retrieval mechanism.  
- The goal is to progressively upgrade client classes to use this method for better security and memory management as discussed in #4021. 

Further comments are appreciated! :)
