### PR TITLE
Update "Pipelines and transactions" doc example to include pipeline.close()

### DIFF
--- a/src/test/java/io/redis/examples/PipeTransExample.java
+++ b/src/test/java/io/redis/examples/PipeTransExample.java
@@ -27,9 +27,8 @@ public class PipeTransExample {
         // REMOVE_END
 
         // STEP_START basic_pipe
-        // Pipeline is a way to send multiple commands to Redis in a single request.
-        // It can be used to improve performance by reducing the number of round trips to the server.
-        // Make sure to close the pipeline after use to release resources and return the connection to the pool.
+        // Make sure you close the pipeline after use to release resources
+        // and return the connection to the pool.
         try (AbstractPipeline pipe = jedis.pipelined()) {
 
             for (int i = 0; i < 5; i++) {


### PR DESCRIPTION
The example PipeTransExample.java  is updated to use a try-with-resources block to ensure the pipeline is properly closed after use.

Failing to close pipelines can lead to resource leaks. Specifically, if pipelines are repeatedly created without being closed, and the number of open connections exceeds the maximum allowed by the connection pool, the application will block.

closes #4132