### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The most recent version of this library supports redis version
 [7.2](https://github.com/redis/redis/blob/7.2/00-RELEASENOTES) and 
 [7.4](https://github.com/redis/redis/blob/7.4/00-RELEASENOTES).
 
-The table below highlights version compatibility of the most-recent library versions and Redis versions. Compatibility means communication features, and Redis command capabilities.
+The table below highlights the version compatibility of the most-recent library versions with Redis versions and JDK versions. Compatibility means communication features, and Redis command capabilities.
 
 
 | Jedis version | Supported Redis versions              | JDK Compatibility |


### PR DESCRIPTION
Original Text:
"The table below highlights version compatibility of the most-recent library versions and Redis versions."
Proposed Change:
"The table below highlights the version compatibility of the most-recent library versions with Redis versions and JDK versions."
Explanation:
This change provides a more comprehensive description of the table's content by explicitly mentioning JDK version compatibility.
