### PR TITLE
Speed up cluster tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ protected-mode no
 requirepass cluster
 port 7379
 tls-port 8379
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_cluster_node1.pid
 logfile /tmp/redis_cluster_node1.log
 save ""
@@ -274,7 +274,7 @@ protected-mode no
 requirepass cluster
 port 7380
 tls-port 8380
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_cluster_node2.pid
 logfile /tmp/redis_cluster_node2.log
 save ""
@@ -293,7 +293,7 @@ protected-mode no
 requirepass cluster
 port 7381
 tls-port 8381
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_cluster_node3.pid
 logfile /tmp/redis_cluster_node3.log
 save ""
@@ -312,7 +312,7 @@ protected-mode no
 requirepass cluster
 port 7382
 tls-port 8382
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_cluster_node4.pid
 logfile /tmp/redis_cluster_node4.log
 save ""
@@ -331,7 +331,7 @@ protected-mode no
 requirepass cluster
 port 7383
 tls-port 8383
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_cluster_node5.pid
 logfile /tmp/redis_cluster_node5.log
 save ""
@@ -351,7 +351,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7479
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_stable_cluster_node1.pid
 logfile /tmp/redis_stable_cluster_node1.log
 save ""
@@ -365,7 +365,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7480
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_stable_cluster_node2.pid
 logfile /tmp/redis_stable_cluster_node2.log
 save ""
@@ -379,7 +379,7 @@ daemonize yes
 protected-mode no
 requirepass cluster
 port 7481
-cluster-node-timeout 15000
+cluster-node-timeout 150
 pidfile /tmp/redis_stable_cluster_node3.pid
 logfile /tmp/redis_stable_cluster_node3.log
 save ""

--- a/src/test/resources/env/cluster-unbound/config/node-7379-8379/redis.conf
+++ b/src/test/resources/env/cluster-unbound/config/node-7379-8379/redis.conf
@@ -3,7 +3,7 @@ port 7379
 tls-port 8379
 requirepass cluster
 tls-auth-clients no
-cluster-node-timeout 15000
+cluster-node-timeout 150
 save ""
 appendonly no
 cluster-enabled yes

--- a/src/test/resources/env/cluster-unbound/config/node-7380-8380/redis.conf
+++ b/src/test/resources/env/cluster-unbound/config/node-7380-8380/redis.conf
@@ -1,8 +1,9 @@
 bind 0.0.0.0
-requirepass cluster
 port 7380
 tls-port 8380
+requirepass cluster
 tls-auth-clients no
+cluster-node-timeout 150
 save ""
 appendonly no
 cluster-enabled yes

--- a/src/test/resources/env/cluster-unbound/config/node-7381-8381/redis.conf
+++ b/src/test/resources/env/cluster-unbound/config/node-7381-8381/redis.conf
@@ -3,7 +3,7 @@ port 7381
 tls-port 8381
 requirepass cluster
 tls-auth-clients no
-cluster-node-timeout 15000
+cluster-node-timeout 150
 save ""
 appendonly no
 cluster-enabled yes

--- a/src/test/resources/env/cluster-unbound/config/node-7382-8382/redis.conf
+++ b/src/test/resources/env/cluster-unbound/config/node-7382-8382/redis.conf
@@ -3,7 +3,7 @@ requirepass cluster
 port 7382
 tls-port 8382
 tls-auth-clients no
-cluster-node-timeout 15000
+cluster-node-timeout 150
 save ""
 appendonly no
 cluster-enabled yes

--- a/src/test/resources/env/cluster-unbound/config/node-7383-8383/redis.conf
+++ b/src/test/resources/env/cluster-unbound/config/node-7383-8383/redis.conf
@@ -3,7 +3,7 @@ port 7383
 tls-port 8383
 requirepass cluster
 tls-auth-clients no
-cluster-node-timeout 15000
+cluster-node-timeout 150
 save ""
 appendonly no
 cluster-enabled yes


### PR DESCRIPTION
Reduced total test time from ~18m to ~10m

Example run 
```
Warning:  Tests run: 8688, Failures: 0, Errors: 0, Skipped: 4
[INFO] 
[INFO] 
[INFO] --- jacoco:0.8.12:report (report) @ jedis ---
[INFO] Skipping JaCoCo execution due to missing execution data file.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  09:42 min
[INFO] Finished at: 2025-04-24T10:54:27Z
[INFO] ------------------------------------------------------------------------
```