### PR TITLE
Add binary stream support for XREAD and XREADGROUP (#3566)

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -2892,6 +2892,30 @@ public class CommandObjects {
     return new CommandObject<>(args, BuilderFactory.RAW_OBJECT_LIST);
   }
 
+  public final CommandObject<List<Map.Entry<byte[], List<StreamEntryBinary>>>> xreadBinary(
+      XReadParams xReadParams, Map.Entry<byte[], byte[]>... streams) {
+    CommandArguments args = commandArguments(XREAD).addParams(xReadParams).add(STREAMS);
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.key(entry.getKey());
+    }
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.add(entry.getValue());
+    }
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_BINARY_RESPONSE);
+  }
+
+  public final CommandObject<Map<byte[], List<StreamEntryBinary>>> xreadBinaryAsMap(
+      XReadParams xReadParams, Map.Entry<byte[], byte[]>... streams) {
+    CommandArguments args = commandArguments(XREAD).addParams(xReadParams).add(STREAMS);
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.key(entry.getKey());
+    }
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.add(entry.getValue());
+    }
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_BINARY_MAP_RESPONSE);
+  }
+
   public final CommandObject<List<Object>> xreadGroup(byte[] groupName, byte[] consumer,
       XReadGroupParams xReadGroupParams, Map.Entry<byte[], byte[]>... streams) {
     CommandArguments args = commandArguments(XREADGROUP)
@@ -2904,6 +2928,36 @@ public class CommandObjects {
       args.add(entry.getValue());
     }
     return new CommandObject<>(args, BuilderFactory.RAW_OBJECT_LIST);
+  }
+
+  public final CommandObject<List<Map.Entry<byte[], List<StreamEntryBinary>>>> xreadGroupBinary(
+      byte[] groupName, byte[] consumer, XReadGroupParams xReadGroupParams, 
+      Map.Entry<byte[], byte[]>... streams) {
+    CommandArguments args = commandArguments(XREADGROUP)
+        .add(GROUP).add(groupName).add(consumer)
+        .addParams(xReadGroupParams).add(STREAMS);
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.key(entry.getKey());
+    }
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.add(entry.getValue());
+    }
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_BINARY_RESPONSE);
+  }
+
+  public final CommandObject<Map<byte[], List<StreamEntryBinary>>> xreadGroupBinaryAsMap(
+      byte[] groupName, byte[] consumer, XReadGroupParams xReadGroupParams, 
+      Map.Entry<byte[], byte[]>... streams) {
+    CommandArguments args = commandArguments(XREADGROUP)
+        .add(GROUP).add(groupName).add(consumer)
+        .addParams(xReadGroupParams).add(STREAMS);
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.key(entry.getKey());
+    }
+    for (Map.Entry<byte[], byte[]> entry : streams) {
+      args.add(entry.getValue());
+    }
+    return new CommandObject<>(args, BuilderFactory.STREAM_READ_BINARY_MAP_RESPONSE);
   }
   // Stream commands
 

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -1172,7 +1172,7 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.hsetex(key, params, field, value));
   }
-  
+
   @Override
   public long hsetex(byte[] key, HSetExParams params, Map<byte[], byte[]> hash){
     checkIsInMultiOrPipeline();
@@ -1200,13 +1200,13 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.hgetex(key, params, fields));
   }
-  
+
   @Override
   public List<byte[]> hgetdel(byte[] key, byte[]... fields){
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.hgetdel(key, fields));
   }
-  
+
   /**
    * Set the specified hash field to the specified value if the field not exists. <b>Time
    * complexity:</b> O(1)
@@ -4781,6 +4781,34 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
       XReadGroupParams xReadGroupParams, Entry<byte[], byte[]>... streams) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.xreadGroup(groupName, consumer, xReadGroupParams, streams));
+  }
+
+  @Override
+  public List<Map.Entry<byte[], List<StreamEntryBinary>>> xreadBinary(XReadParams xReadParams, 
+      Entry<byte[], byte[]>... streams) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.xreadBinary(xReadParams, streams));
+  }
+
+  @Override
+  public Map<byte[], List<StreamEntryBinary>> xreadBinaryAsMap(XReadParams xReadParams, 
+      Entry<byte[], byte[]>... streams) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.xreadBinaryAsMap(xReadParams, streams));
+  }
+
+  @Override
+  public List<Map.Entry<byte[], List<StreamEntryBinary>>> xreadGroupBinary(byte[] groupName, byte[] consumer, 
+      XReadGroupParams xReadGroupParams, Entry<byte[], byte[]>... streams) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.xreadGroupBinary(groupName, consumer, xReadGroupParams, streams));
+  }
+
+  @Override
+  public Map<byte[], List<StreamEntryBinary>> xreadGroupBinaryAsMap(byte[] groupName, byte[] consumer, 
+      XReadGroupParams xReadGroupParams, Entry<byte[], byte[]>... streams) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.xreadGroupBinaryAsMap(groupName, consumer, xReadGroupParams, streams));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -1548,7 +1548,7 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   public List<byte[]> hgetex(byte[] key, HGetExParams params, byte[]... fields) {
     return executeCommand(commandObjects.hgetex(key, params, fields));
   }
-  
+
   @Override
   public List<byte[]> hgetdel(byte[] key, byte[]... fields) {
     return executeCommand(commandObjects.hgetdel(key, fields));
@@ -3459,6 +3459,30 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   @Override
   public List<Object> xreadGroup(byte[] groupName, byte[] consumer, XReadGroupParams xReadGroupParams, Map.Entry<byte[], byte[]>... streams) {
     return executeCommand(commandObjects.xreadGroup(groupName, consumer, xReadGroupParams, streams));
+  }
+
+  @Override
+  public List<Map.Entry<byte[], List<StreamEntryBinary>>> xreadBinary(XReadParams xReadParams, 
+      Map.Entry<byte[], byte[]>... streams) {
+    return executeCommand(commandObjects.xreadBinary(xReadParams, streams));
+  }
+
+  @Override
+  public Map<byte[], List<StreamEntryBinary>> xreadBinaryAsMap(XReadParams xReadParams, 
+      Map.Entry<byte[], byte[]>... streams) {
+    return executeCommand(commandObjects.xreadBinaryAsMap(xReadParams, streams));
+  }
+
+  @Override
+  public List<Map.Entry<byte[], List<StreamEntryBinary>>> xreadGroupBinary(byte[] groupName, byte[] consumer, 
+      XReadGroupParams xReadGroupParams, Map.Entry<byte[], byte[]>... streams) {
+    return executeCommand(commandObjects.xreadGroupBinary(groupName, consumer, xReadGroupParams, streams));
+  }
+
+  @Override
+  public Map<byte[], List<StreamEntryBinary>> xreadGroupBinaryAsMap(byte[] groupName, byte[] consumer, 
+      XReadGroupParams xReadGroupParams, Map.Entry<byte[], byte[]>... streams) {
+    return executeCommand(commandObjects.xreadGroupBinaryAsMap(groupName, consumer, xReadGroupParams, streams));
   }
   // Stream commands
 

--- a/src/main/java/redis/clients/jedis/commands/StreamBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/StreamBinaryCommands.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import redis.clients.jedis.params.*;
+import redis.clients.jedis.resps.StreamEntryBinary;
 
 public interface StreamBinaryCommands {
 
@@ -79,4 +80,15 @@ public interface StreamBinaryCommands {
   List<Object> xreadGroup(byte[] groupName, byte[] consumer, XReadGroupParams xReadGroupParams,
       Map.Entry<byte[], byte[]>... streams);
 
+  List<Map.Entry<byte[], List<StreamEntryBinary>>> xreadBinary(XReadParams xReadParams,
+      Map.Entry<byte[], byte[]>... streams);
+
+  Map<byte[], List<StreamEntryBinary>> xreadBinaryAsMap(XReadParams xReadParams,
+      Map.Entry<byte[], byte[]>... streams);
+
+  List<Map.Entry<byte[], List<StreamEntryBinary>>> xreadGroupBinary(byte[] groupName, byte[] consumer,
+      XReadGroupParams xReadGroupParams, Map.Entry<byte[], byte[]>... streams);
+
+  Map<byte[], List<StreamEntryBinary>> xreadGroupBinaryAsMap(byte[] groupName, byte[] consumer,
+      XReadGroupParams xReadGroupParams, Map.Entry<byte[], byte[]>... streams);
 }

--- a/src/main/java/redis/clients/jedis/resps/StreamEntryBinary.java
+++ b/src/main/java/redis/clients/jedis/resps/StreamEntryBinary.java
@@ -1,0 +1,42 @@
+package redis.clients.jedis.resps;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Map;
+import redis.clients.jedis.StreamEntryID;
+
+public class StreamEntryBinary implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private StreamEntryID id;
+  private Map<byte[], byte[]> fields;
+
+  public StreamEntryBinary(StreamEntryID id, Map<byte[], byte[]> fields) {
+    this.id = id;
+    this.fields = fields;
+  }
+
+  public StreamEntryID getID() {
+    return id;
+  }
+
+  public Map<byte[], byte[]> getFields() {
+    return fields;
+  }
+
+  @Override
+  public String toString() {
+    return id + " " + fields;
+  }
+
+  private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    out.writeUnshared(this.id);
+    out.writeUnshared(this.fields);
+  }
+
+  private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+    this.id = (StreamEntryID) in.readUnshared();
+    this.fields = (Map<byte[], byte[]>) in.readUnshared();
+  }
+}

--- a/src/test/java/redis/clients/jedis/commands/binary/BinaryStreamEntryTest.java
+++ b/src/test/java/redis/clients/jedis/commands/binary/BinaryStreamEntryTest.java
@@ -1,0 +1,160 @@
+package redis.clients.jedis.commands.binary;
+
+import io.redis.test.annotations.SinceRedisVersion;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.*;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.params.XAddParams;
+import redis.clients.jedis.params.XReadGroupParams;
+import redis.clients.jedis.params.XReadParams;
+import redis.clients.jedis.resps.StreamEntryBinary;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SinceRedisVersion("6.0.0")
+public class BinaryStreamEntryTest {
+
+  private static final byte[] STREAM_KEY = "test-binary-stream".getBytes();
+  private static final byte[] GROUP_NAME = "test-group".getBytes();
+  private static final byte[] CONSUMER_NAME = "test-consumer".getBytes();
+  private static final byte[] FIELD_KEY = "binary-field".getBytes();
+  private static final byte[] BINARY_VALUE = new byte[] { 0x00, 0x01, 0x02, 0x03, (byte) 0xFF };
+
+  private static final EndpointConfig endpoint = HostAndPorts.getRedisEndpoint("standalone0");
+
+  @Test
+  public void testBinaryStreamEntry() {
+    // Add binary data to stream
+    try (JedisPooled jedis = new JedisPooled(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
+            .protocol(RedisProtocol.RESP3).timeoutMillis(5000).password(endpoint.getPassword()).build())) {
+
+      Map<byte[], byte[]> hash = new HashMap<>();
+      hash.put(FIELD_KEY, BINARY_VALUE);
+
+      byte[] idBytes = jedis.xadd(STREAM_KEY, new XAddParams(), hash);
+      StreamEntryID id = new StreamEntryID(new String(idBytes));
+      assertNotNull(id);
+
+      // Read the data back using xreadBinary
+      Map.Entry<byte[], byte[]> streamEntry = new AbstractMap.SimpleImmutableEntry<>(STREAM_KEY, "0-0".getBytes());
+      List<Map.Entry<byte[], List<StreamEntryBinary>>> result = jedis.xreadBinary(
+          XReadParams.xReadParams().count(1), streamEntry);
+
+      assertNotNull(result);
+      assertEquals(1, result.size());
+
+      Map.Entry<byte[], List<StreamEntryBinary>> streamData = result.get(0);
+      assertArrayEquals(STREAM_KEY, streamData.getKey());
+
+      List<StreamEntryBinary> entries = streamData.getValue();
+      assertNotNull(entries);
+      assertEquals(1, entries.size());
+
+      StreamEntryBinary entry = entries.get(0);
+      verifyBinaryFields(entry.getFields());
+
+      // Test xreadBinaryAsMap
+      Map<byte[], List<StreamEntryBinary>> mapResult = jedis.xreadBinaryAsMap(
+          XReadParams.xReadParams().count(1), streamEntry);
+
+      assertNotNull(mapResult);
+      assertEquals(1, mapResult.size());
+
+      boolean keyFound = false;
+      for (byte[] key : mapResult.keySet()) {
+        if (Arrays.equals(key, STREAM_KEY)) {
+          keyFound = true;
+          List<StreamEntryBinary> mapEntries = mapResult.get(key);
+          assertNotNull(mapEntries);
+          assertEquals(1, mapEntries.size());
+          verifyBinaryFields(mapEntries.get(0).getFields());
+          break;
+        }
+      }
+      assertTrue(keyFound);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testBinaryStreamEntryWithGroup() {
+    // Add binary data to stream
+    try (JedisPooled jedis = new JedisPooled(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
+            .protocol(RedisProtocol.RESP3).timeoutMillis(5000).password(endpoint.getPassword()).build())) {
+
+      Map<byte[], byte[]> hash = new HashMap<>();
+      hash.put(FIELD_KEY, BINARY_VALUE);
+
+      byte[] idBytes = jedis.xadd(STREAM_KEY, new XAddParams(), hash);
+      StreamEntryID id = new StreamEntryID(new String(idBytes));
+      assertNotNull(id);
+
+      // Create a consumer group
+      try {
+        jedis.xgroupCreate(STREAM_KEY, GROUP_NAME, "0-0".getBytes(), true);
+      } catch (JedisDataException e) {
+        // Ignore BUSYGROUP error
+        if (!e.getMessage().contains("BUSYGROUP")) {
+          throw e;
+        }
+      }
+
+      // Read the data back using xreadGroupBinary
+      Map.Entry<byte[], byte[]> streamEntry = new AbstractMap.SimpleImmutableEntry<>(STREAM_KEY, ">".getBytes());
+
+      List<Map.Entry<byte[], List<StreamEntryBinary>>> result = jedis.xreadGroupBinary(
+              GROUP_NAME, CONSUMER_NAME, XReadGroupParams.xReadGroupParams().count(1), streamEntry);
+
+      assertNotNull(result);
+      assertEquals(1, result.size());
+
+      Map.Entry<byte[], List<StreamEntryBinary>> streamData = result.get(0);
+      assertArrayEquals(STREAM_KEY, streamData.getKey());
+
+      List<StreamEntryBinary> entries = streamData.getValue();
+      assertNotNull(entries);
+      assertEquals(1, entries.size());
+      StreamEntryBinary entry = entries.get(0);
+
+      verifyBinaryFields(entry.getFields());
+
+    } catch (Exception e) {
+      fail("failed to read binary data from stream: " + e.getMessage());
+    }
+  }
+
+  private void verifyBinaryFields(Map<byte[], byte[]> fields) {
+    assertNotNull(fields);
+
+    // Check if the field exists using Arrays.equals since byte[] equality is based on reference
+    boolean fieldExists = false;
+    for (byte[] key : fields.keySet()) {
+      if (Arrays.equals(key, FIELD_KEY)) {
+        fieldExists = true;
+        break;
+      }
+    }
+    assertTrue(fieldExists);
+
+    // Get the value using the field key
+    byte[] value = null;
+    for (Map.Entry<byte[], byte[]> field : fields.entrySet()) {
+      if (Arrays.equals(field.getKey(), FIELD_KEY)) {
+        value = field.getValue();
+        break;
+      }
+    }
+
+    assertNotNull(value);
+    assertEquals(BINARY_VALUE.length, value.length);
+
+    // Verify the binary data is preserved correctly
+    for (int i = 0; i < BINARY_VALUE.length; i++) {
+      assertEquals(BINARY_VALUE[i], value[i]);
+    }
+  }
+}


### PR DESCRIPTION
- Created StreamEntryBinary class to support binary data with Map<byte[], byte[]>
- Added xreadBinary, xreadBinaryAsMap, xreadGroupBinary, and xreadGroupBinaryAsMap methods to StreamBinaryCommands
- Implemented binary stream builders in BuilderFactory
- Added implementation in Jedis and UnifiedJedis classes
- Created BinaryStreamEntryTest to verify binary stream functionality