### PR TITLE
[automatic failover] Improve failover resilience by evaluating circuit breaker before retries

### DIFF
--- a/formatter-pom.xml
+++ b/formatter-pom.xml
@@ -20,7 +20,7 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.23.0</version>
+				<version>2.16.0</version>
 				<configuration>
 					<configFile>${project.basedir}/hbase-formatter.xml</configFile>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
 					<directories>
 						<directory>${project.basedir}/src/main/java/redis/clients/jedis/annots</directory>
 						<directory>${project.basedir}/src/main/java/redis/clients/jedis/mcf</directory>
+						<directory>${project.basedir}/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java</directory>
 						<directory>${project.basedir}/src/test/java/redis/clients/jedis/failover</directory>
 					</directories>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.23.0</version>
+				<version>2.16.0</version>
 				<configuration>
 					<configFile>${project.basedir}/hbase-formatter.xml</configFile>
 					<directories>

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
 			<plugin>
 				<groupId>net.revelc.code.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<version>2.16.0</version>
+				<version>2.23.0</version>
 				<configuration>
 					<configFile>${project.basedir}/hbase-formatter.xml</configFile>
 					<directories>

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerCommandExecutor.java
@@ -35,8 +35,8 @@ public class CircuitBreakerCommandExecutor extends CircuitBreakerFailoverBase
     DecorateSupplier<T> supplier = Decorators
         .ofSupplier(() -> this.handleExecuteCommand(commandObject, cluster));
 
-    supplier.withRetry(cluster.getRetry());
     supplier.withCircuitBreaker(cluster.getCircuitBreaker());
+    supplier.withRetry(cluster.getRetry());
     supplier.withFallback(provider.getFallbackExceptionList(),
       e -> this.handleClusterFailover(commandObject, cluster.getCircuitBreaker()));
 

--- a/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
@@ -273,27 +273,25 @@ public class FailoverIntegrationTest {
   }
 
   /**
-   * Tests that the CircuitBreaker counts each command error separately, and not just after
-   * all retries are exhausted. This ensures that the circuit breaker opens based on the
-   * actual number of send commands with failures, and not based on the number of logical operations.
+   * Tests that the CircuitBreaker counts each command error separately, and not just after all
+   * retries are exhausted. This ensures that the circuit breaker opens based on the actual number
+   * of send commands with failures, and not based on the number of logical operations.
    */
   @Test
   public void testCircuitBreakerCountsEachConnectionErrorSeparately() throws IOException {
     MultiClusterClientConfig failoverConfig = new MultiClusterClientConfig.Builder(
-        getClusterConfigs(DefaultJedisClientConfig.builder()
-            .socketTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS)
-            .connectionTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS).build(),
-            endpoint1, endpoint2))
-        .retryMaxAttempts(2)
-        .retryWaitDuration(1)
-        .circuitBreakerSlidingWindowType(COUNT_BASED)
-        .circuitBreakerSlidingWindowSize(3)
-        .circuitBreakerFailureRateThreshold(50) // 50% failure rate threshold
-        .circuitBreakerSlidingWindowMinCalls(3)
-        .build();
+        getClusterConfigs(
+          DefaultJedisClientConfig.builder()
+              .socketTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS)
+              .connectionTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS).build(),
+          endpoint1, endpoint2)).retryMaxAttempts(2).retryWaitDuration(1)
+              .circuitBreakerSlidingWindowType(COUNT_BASED).circuitBreakerSlidingWindowSize(3)
+              .circuitBreakerFailureRateThreshold(50) // 50% failure rate threshold
+              .circuitBreakerSlidingWindowMinCalls(3).build();
 
-    MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(failoverConfig);
-    try ( UnifiedJedis client = new UnifiedJedis(provider)){
+    MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
+        failoverConfig);
+    try (UnifiedJedis client = new UnifiedJedis(provider)) {
       // Verify initial connection to first endpoint
       assertThat(getNodeId(client.info("server")), equalTo(JEDIS1_ID));
 
@@ -301,24 +299,31 @@ public class FailoverIntegrationTest {
       redisProxy1.disable();
 
       // First command should fail and OPEN the circuit breaker immediately
-      //   If CB is applied after retries, it would take :
-      //      2 commands to OPEN CB (error is propagated for both commands)
-      //      Failover to the next Endpoint happens on the 3rd command
-      //   If CB is applied before retries, it should open after just 1 command
-      //      CB is OPEN after the 2nd retry of the first command, and error is propagated
-      //      Failover to the next Endpoint happens on the 2nd command
+      //
+      // If CB is applied after retries:
+      // - It would take 2 commands to OPEN CB (error is propagated for both commands)
+      // - Failover to the next Endpoint happens on the 3rd command
+      //
+      // If CB is applied before retries:
+      // - It should open after just 1 command with retries
+      // - CB is OPEN after the 2nd retry of the first command
+      // - Failover to the next Endpoint happens on the 2nd command
+      //
+      // This test verifies the second case by checking that:
+      // 1. CB opens after the first command (with retries)
+      // 2. The second command is routed to the second endpoint
       // Command 1
       assertThrows(JedisConnectionException.class, () -> client.info("server"));
 
       // Circuit breaker should be open after just one command with retries
       assertThat(provider.getCluster(1).getCircuitBreaker().getState(),
-          equalTo(CircuitBreaker.State.OPEN));
+        equalTo(CircuitBreaker.State.OPEN));
 
       // Next command should be routed to the second endpoint
-      //Command 2
+      // Command 2
       assertThat(getNodeId(client.info("server")), equalTo(JEDIS2_ID));
 
-      //Command 3
+      // Command 3
       assertThat(getNodeId(client.info("server")), equalTo(JEDIS2_ID));
 
     }

--- a/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
@@ -139,9 +139,9 @@ public class FailoverIntegrationTest {
 
     MultiClusterClientConfig failoverConfig = new MultiClusterClientConfig.Builder(
         getClusterConfigs(clientConfig, endpoint1, endpoint2)).retryMaxAttempts(1)
-            .retryWaitDuration(1).circuitBreakerSlidingWindowType(COUNT_BASED)
-            .circuitBreakerSlidingWindowSize(1).circuitBreakerFailureRateThreshold(100)
-            .circuitBreakerSlidingWindowMinCalls(1).build();
+        .retryWaitDuration(1).circuitBreakerSlidingWindowType(COUNT_BASED)
+        .circuitBreakerSlidingWindowSize(1).circuitBreakerFailureRateThreshold(100)
+        .circuitBreakerSlidingWindowMinCalls(1).build();
 
     provider = new MultiClusterPooledConnectionProvider(failoverConfig);
     failoverClient = new UnifiedJedis(provider);
@@ -284,10 +284,11 @@ public class FailoverIntegrationTest {
           DefaultJedisClientConfig.builder()
               .socketTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS)
               .connectionTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS).build(),
-          endpoint1, endpoint2)).retryMaxAttempts(2).retryWaitDuration(1)
-              .circuitBreakerSlidingWindowType(COUNT_BASED).circuitBreakerSlidingWindowSize(3)
-              .circuitBreakerFailureRateThreshold(50) // 50% failure rate threshold
-              .circuitBreakerSlidingWindowMinCalls(3).build();
+          endpoint1, endpoint2))
+        .retryMaxAttempts(2).retryWaitDuration(1).circuitBreakerSlidingWindowType(COUNT_BASED)
+        .circuitBreakerSlidingWindowSize(3).circuitBreakerFailureRateThreshold(50) // 50% failure
+                                                                                   // rate threshold
+        .circuitBreakerSlidingWindowMinCalls(3).build();
 
     MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
         failoverConfig);

--- a/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/failover/FailoverIntegrationTest.java
@@ -139,9 +139,9 @@ public class FailoverIntegrationTest {
 
     MultiClusterClientConfig failoverConfig = new MultiClusterClientConfig.Builder(
         getClusterConfigs(clientConfig, endpoint1, endpoint2)).retryMaxAttempts(1)
-        .retryWaitDuration(1).circuitBreakerSlidingWindowType(COUNT_BASED)
-        .circuitBreakerSlidingWindowSize(1).circuitBreakerFailureRateThreshold(100)
-        .circuitBreakerSlidingWindowMinCalls(1).build();
+            .retryWaitDuration(1).circuitBreakerSlidingWindowType(COUNT_BASED)
+            .circuitBreakerSlidingWindowSize(1).circuitBreakerFailureRateThreshold(100)
+            .circuitBreakerSlidingWindowMinCalls(1).build();
 
     provider = new MultiClusterPooledConnectionProvider(failoverConfig);
     failoverClient = new UnifiedJedis(provider);
@@ -284,11 +284,11 @@ public class FailoverIntegrationTest {
           DefaultJedisClientConfig.builder()
               .socketTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS)
               .connectionTimeoutMillis(RecommendedSettings.DEFAULT_TIMEOUT_MS).build(),
-          endpoint1, endpoint2))
-        .retryMaxAttempts(2).retryWaitDuration(1).circuitBreakerSlidingWindowType(COUNT_BASED)
-        .circuitBreakerSlidingWindowSize(3).circuitBreakerFailureRateThreshold(50) // 50% failure
-                                                                                   // rate threshold
-        .circuitBreakerSlidingWindowMinCalls(3).build();
+          endpoint1, endpoint2)).retryMaxAttempts(2).retryWaitDuration(1)
+              .circuitBreakerSlidingWindowType(COUNT_BASED).circuitBreakerSlidingWindowSize(3)
+              .circuitBreakerFailureRateThreshold(50) // 50% failure
+                                                      // rate threshold
+              .circuitBreakerSlidingWindowMinCalls(3).build();
 
     MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
         failoverConfig);


### PR DESCRIPTION
## Problem
Currently, the circuit breaker is evaluated only after all retry attempts are exhausted. This delays failover to healthy endpoints in unstable network conditions, as the system must wait for all retries to complete before marking an endpoint as unhealthy.

## Solution
This PR changes the evaluation order so that the circuit breaker counts each connection error separately, even during retry attempts. This allows the circuit breaker to open more quickly when an endpoint is experiencing issues, enabling faster failover to healthy endpoints.

## Changes
- Modified the order of evaluation between circuit breaker and retry mechanisms
- Added integration test to verify the new behavior