### PR TITLE
Fix NPE when maxAttempts = 0 in RetryableCommandExecutor

### DIFF
--- a/src/main/java/redis/clients/jedis/executors/RetryableCommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/executors/RetryableCommandExecutor.java
@@ -68,7 +68,9 @@ public class RetryableCommandExecutor implements CommandExecutor {
     }
 
     JedisException maxAttemptsException = new JedisException("No more attempts left.");
-    maxAttemptsException.addSuppressed(lastException);
+    if (lastException != null) {
+      maxAttemptsException.addSuppressed(lastException);
+    }
     throw maxAttemptsException;
   }
 


### PR DESCRIPTION
Fixes a `NullPointerException` when `maxAttempts = 0` in `RetryableCommandExecutor`. When no retries are allowed, `lastException` remains `null`, and calling `addSuppressed(lastException)` throws: `java.lang.NullPointerException: Cannot suppress a null exception`

This fix checks for null before suppressing.
Reproducible with:
`JedisCluster jedis = new JedisCluster(
    new HostAndPort("localhost", 6379),
    2000,       // connection timeout
    2000,       // soTimeout
    0,          // maxAttempts
    null,       // password
    new JedisPoolConfig()
);
jedis.set("key", "value");  // NPE thrown
`

Confirmed on: Jedis 3.9.0
master branch (RetryableCommandExecutor.java#L71