### PR TITLE
Fix memory leak in JedisClusterInfoCache - replica nodes not cleared

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -491,7 +491,8 @@ public class JedisClusterInfoCache {
 
   @SuppressWarnings("unchecked")
   private List<Object> executeClusterSlots(Connection jedis) {
-    CommandArguments clusterSlotsCmd = new ClusterCommandArguments(Protocol.Command.CLUSTER).add("SLOTS");
+    CommandArguments clusterSlotsCmd = new ClusterCommandArguments(Protocol.Command.CLUSTER).add(
+        "SLOTS");
     return (List<Object>) jedis.executeCommand(clusterSlotsCmd);
   }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -68,7 +68,8 @@ public class JedisClusterInfoCache {
     }
   }
 
-  public JedisClusterInfoCache(final JedisClientConfig clientConfig, final Set<HostAndPort> startNodes) {
+  public JedisClusterInfoCache(final JedisClientConfig clientConfig,
+      final Set<HostAndPort> startNodes) {
     this(clientConfig, null, null, startNodes);
   }
 
@@ -107,10 +108,11 @@ public class JedisClusterInfoCache {
       clientConfig.getAuthXManager().start();
     }
     if (topologyRefreshPeriod != null) {
-      logger.info("Cluster topology refresh start, period: {}, startNodes: {}", topologyRefreshPeriod, startNodes);
+      logger.info("Cluster topology refresh start, period: {}, startNodes: {}",
+        topologyRefreshPeriod, startNodes);
       topologyRefreshExecutor = Executors.newSingleThreadScheduledExecutor();
-      topologyRefreshExecutor.scheduleWithFixedDelay(new TopologyRefreshTask(), topologyRefreshPeriod.toMillis(),
-          topologyRefreshPeriod.toMillis(), TimeUnit.MILLISECONDS);
+      topologyRefreshExecutor.scheduleWithFixedDelay(new TopologyRefreshTask(),
+        topologyRefreshPeriod.toMillis(), topologyRefreshPeriod.toMillis(), TimeUnit.MILLISECONDS);
     }
     if (clientConfig.isReadOnlyForRedisClusterReplicas()) {
       replicaSlots = new ArrayList[Protocol.CLUSTER_HASHSLOTS];
@@ -120,14 +122,15 @@ public class JedisClusterInfoCache {
   }
 
   /**
-   * Check whether the number and order of slots in the cluster topology are equal to CLUSTER_HASHSLOTS
+   * Check whether the number and order of slots in the cluster topology are equal to
+   * CLUSTER_HASHSLOTS
    * @param slotsInfo the cluster topology
    * @return if slots is ok, return true, elese return false.
    */
   private boolean checkClusterSlotSequence(List<Object> slotsInfo) {
     List<Integer> slots = new ArrayList<>();
     for (Object slotInfoObj : slotsInfo) {
-      List<Object> slotInfo = (List<Object>)slotInfoObj;
+      List<Object> slotInfo = (List<Object>) slotInfoObj;
       slots.addAll(getAssignedSlotArray(slotInfo));
     }
     Collections.sort(slots);
@@ -187,7 +190,8 @@ public class JedisClusterInfoCache {
   }
 
   public void renewClusterSlots(Connection jedis) {
-    // If rediscovering is already in process - no need to start one more same rediscovering, just return
+    // If rediscovering is already in process - no need to start one more same rediscovering, just
+    // return
     if (rediscoverLock.tryLock()) {
       try {
         // First, if jedis is available, use jedis renew.
@@ -478,7 +482,7 @@ public class JedisClusterInfoCache {
   }
 
   public static String getNodeKey(HostAndPort hnp) {
-    //return hnp.getHost() + ":" + hnp.getPort();
+    // return hnp.getHost() + ":" + hnp.getPort();
     return hnp.toString();
   }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -454,6 +454,16 @@ public class JedisClusterInfoCache {
       nodes.clear();
       Arrays.fill(slots, null);
       Arrays.fill(slotNodes, null);
+      if (clientSideCache != null) {
+        clientSideCache.flush();
+      }
+      if (clientConfig.isReadOnlyForRedisClusterReplicas() && replicaSlots != null) {
+        for (List<ConnectionPool> replicaList : replicaSlots) {
+          if (replicaList != null) {
+            replicaList.clear();
+          }
+        }
+      }
     } finally {
       w.unlock();
     }

--- a/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
@@ -1,0 +1,256 @@
+package redis.clients.jedis;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.when;
+import static redis.clients.jedis.Protocol.Command.CLUSTER;
+import static redis.clients.jedis.util.CommandArgumentMatchers.commandWithArgs;
+
+@Tag("unit")
+@ExtendWith(MockitoExtension.class)
+public class JedisClusterInfoCacheTest {
+
+  private static final HostAndPort MASTER_HOST = new HostAndPort("127.0.0.1", 7000);
+  private static final HostAndPort REPLICA_1_HOST = new HostAndPort("127.0.0.1", 7001);
+  private static final HostAndPort REPLICA_2_HOST = new HostAndPort("127.0.0.1", 7002);
+  private static final int TEST_SLOT = 0;
+
+  @Mock
+  private Connection mockConnection;
+
+  @Test
+  public void testReplicaNodeRemovalAndRediscovery() {
+    // Create client config with read-only replicas enabled
+    JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .readOnlyForRedisClusterReplicas().build();
+
+    Set<HostAndPort> startNodes = new HashSet<>();
+    startNodes.add(MASTER_HOST);
+
+    JedisClusterInfoCache cache = new JedisClusterInfoCache(clientConfig, startNodes);
+
+    // Mock the cluster slots responses
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS")))).thenReturn(
+            masterReplicaSlotsResponse()).thenReturn(masterOnlySlotsResponse())
+        .thenReturn(masterReplica2SlotsResponse());
+
+    // Initial discovery with one master and one replica (replica-1)
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertMasterNodeAvailable(cache);
+    assertReplicasAvailable(cache, REPLICA_1_HOST);
+
+    // Simulate rediscovery - master only
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    // Master should still be available
+    // Replica should be cleared
+    assertMasterNodeAvailable(cache);
+    assertNoReplicasAvailable(cache);
+
+    // Simulate rediscovery - another replica (replica-2) coming back
+    cache.reset();
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertReplicasAvailable(cache, REPLICA_2_HOST);
+  }
+
+  @Test
+  public void testResetWithReplicaSlots() {
+    // This test verifies that reset() properly clears replica slots
+
+    JedisClusterInfoCache cache = createCacheWithReplicasEnabled();
+
+    // Mock the cluster slots responses
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS")))).thenReturn(
+        masterReplicaSlotsResponse());
+
+    // Initial discovery
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertReplicasAvailable(cache, REPLICA_1_HOST);
+
+    // Call reset() - this should clear and nullify replica slots
+    cache.reset();
+
+    assertNoReplicasAvailable(cache);
+
+    // Rediscovery should work correctly
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertReplicasAvailable(cache, REPLICA_1_HOST);
+  }
+
+  private List<Object> masterReplicaSlotsResponse() {
+    return createClusterSlotsResponse(
+        new SlotRange.Builder(0, 16383).master(MASTER_HOST, "master-id-1")
+            .replica(REPLICA_1_HOST, "replica-id-1").build());
+  }
+
+  private List<Object> masterOnlySlotsResponse() {
+    return createClusterSlotsResponse(
+        new SlotRange.Builder(0, 16383).master(MASTER_HOST, "master-id-1").build());
+  }
+
+  private List<Object> masterReplica2SlotsResponse() {
+    return createClusterSlotsResponse(
+        new SlotRange.Builder(0, 16383).master(MASTER_HOST, "master-id-1")
+            .replica(REPLICA_2_HOST, "replica-id-2").build());
+  }
+
+  private JedisClusterInfoCache createCacheWithReplicasEnabled() {
+
+    JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+        .readOnlyForRedisClusterReplicas().build();
+
+    return new JedisClusterInfoCache(clientConfig,
+        new HashSet<>(Collections.singletonList(MASTER_HOST)));
+  }
+
+  private void assertNoReplicasAvailable(JedisClusterInfoCache cache) {
+    List<ConnectionPool> caheReplicaNodePools = cache.getSlotReplicaPools(TEST_SLOT);
+    assertNull(caheReplicaNodePools);
+  }
+
+  private void assertReplicasAvailable(JedisClusterInfoCache cache, HostAndPort... replicaNodes) {
+    List<ConnectionPool> caheReplicaNodePools = cache.getSlotReplicaPools(TEST_SLOT);
+    assertEquals(replicaNodes.length, caheReplicaNodePools.size());
+    for (HostAndPort expectedReplica : replicaNodes) {
+      ConnectionPool expectedNodePool = cache.getNode(expectedReplica);
+      assertThat(caheReplicaNodePools, hasItem(expectedNodePool));
+    }
+  }
+
+  private void assertMasterNodeAvailable(JedisClusterInfoCache cache) {
+    HostAndPort masterNode = cache.getSlotNode(TEST_SLOT);
+    assertNotNull(masterNode);
+    assertEquals(MASTER_HOST, masterNode);
+  }
+
+  /**
+   * Helper method to create a cluster slots response with master and replica nodes
+   */
+  private List<Object> createClusterSlotsResponse(SlotRange... slotRanges) {
+    return Arrays.stream(slotRanges).map(this::clusterSlotRange).collect(Collectors.toList());
+  }
+
+  private List<Object> clusterSlotRange(SlotRange slotRange) {
+    List<Object> slotInfo = new ArrayList<>();
+    slotInfo.add((long) slotRange.start);
+    slotInfo.add((long) slotRange.end);
+    Node master = slotRange.master();
+    slotInfo.add(
+        Arrays.asList(master.getHost().getBytes(), (long) master.getPort(), master.id.getBytes()));
+    // Add replicas
+    slotRange.replicas().forEach(r -> slotInfo.add(
+        Arrays.asList(r.getHost().getBytes(), (long) r.getPort(), r.id.getBytes())));
+    return slotInfo;
+  }
+
+  static class SlotRange {
+    private final int start;
+    private final int end;
+    private final List<Node> nodes;
+
+    private SlotRange(int start, int end, List<Node> nodes) {
+      this.start = start;
+      this.end = end;
+      this.nodes = nodes;
+    }
+
+    public SlotRange.Builder builder(int start, int end) {
+      return new SlotRange.Builder(start, end);
+    }
+
+    public Node master() {
+      return nodes.get(0);
+    }
+
+    public List<Node> replicas() {
+      return nodes.subList(1, nodes.size());
+    }
+
+    static class Builder {
+      private final int start;
+      private final int end;
+      private final List<Node> nodes = new ArrayList<>();
+
+      public Builder(int start, int end) {
+        this.start = start;
+        this.end = end;
+      }
+
+      public Builder master(Node node) {
+        if (!nodes.isEmpty()) {
+          nodes.set(0, node);
+        } else {
+          nodes.add(node);
+        }
+        return this;
+      }
+
+      public Builder master(HostAndPort hostPort, String id) {
+        return master(new Node(hostPort, id));
+      }
+
+      public Builder replica(HostAndPort hostPort, String id) {
+        return replica(new Node(hostPort, id));
+      }
+
+      public Builder replica(Node node) {
+        if (nodes.isEmpty()) {
+          throw new IllegalStateException("Master node must be added before adding replicas");
+        }
+        nodes.add(node);
+        return this;
+      }
+
+      public SlotRange build() {
+        return new SlotRange(start, end, nodes);
+      }
+
+    }
+
+  }
+
+  static class Node {
+    private final HostAndPort hostPort;
+    private final String id;
+
+    public Node(HostAndPort hostPort, String id) {
+      this.hostPort = hostPort;
+      this.id = id;
+    }
+
+    public HostAndPort getHostPort() {
+      return hostPort;
+    }
+
+    public String getHost() {
+      return hostPort.getHost();
+    }
+
+    public int getPort() {
+      return hostPort.getPort();
+    }
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+}

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -2,6 +2,7 @@ package redis.clients.jedis.commands.jedis;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -148,8 +149,8 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   @Test
   public void roleSlave() {
     EndpointConfig primaryEndpoint = HostAndPorts.getRedisEndpoint("standalone0");
-    EndpointConfig secondaryEndpoint = HostAndPorts.getRedisEndpoint(
-        "standalone4-replica-of-standalone1");
+    EndpointConfig secondaryEndpoint = HostAndPorts
+        .getRedisEndpoint("standalone4-replica-of-standalone1");
 
     try (Jedis slave = new Jedis(secondaryEndpoint.getHostAndPort(),
         secondaryEndpoint.getClientConfigBuilder().build())) {
@@ -226,18 +227,18 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     Map<String, String> info = jedis.configGet("m*");
     assertNotNull(info);
     assertFalse(info.isEmpty());
-//    assertTrue(info.size() % 2 == 0);
+    // assertTrue(info.size() % 2 == 0);
     Map<byte[], byte[]> infoBinary = jedis.configGet("m*".getBytes());
     assertNotNull(infoBinary);
     assertFalse(infoBinary.isEmpty());
-//    assertTrue(infoBinary.size() % 2 == 0);
+    // assertTrue(infoBinary.size() % 2 == 0);
   }
 
   @Test
   public void configSet() {
     Map<String, String> info = jedis.configGet("maxmemory");
-//    assertEquals("maxmemory", info.get(0));
-//    String memory = info.get(1);
+    // assertEquals("maxmemory", info.get(0));
+    // String memory = info.get(1);
     String memory = info.get("maxmemory");
     assertNotNull(memory);
     assertEquals("OK", jedis.configSet("maxmemory", "200"));
@@ -248,8 +249,8 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   public void configSetBinary() {
     byte[] maxmemory = SafeEncoder.encode("maxmemory");
     Map<byte[], byte[]> info = jedis.configGet(maxmemory);
-//    assertArrayEquals(maxmemory, info.get(0));
-//    byte[] memory = info.get(1);
+    // assertArrayEquals(maxmemory, info.get(0));
+    // byte[] memory = info.get(1);
     byte[] memory = info.get(maxmemory);
     assertNotNull(memory);
     assertEquals("OK", jedis.configSet(maxmemory, Protocol.toByteArray(200)));
@@ -259,13 +260,15 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   @Test
   @SinceRedisVersion(value = "7.0.0", message = "Starting with Redis version 7.0.0: Added the ability to pass multiple pattern parameters in one call")
   public void configGetSetMulti() {
-    String[] params = new String[]{"hash-max-listpack-entries", "set-max-intset-entries", "zset-max-listpack-entries"};
+    String[] params = new String[] { "hash-max-listpack-entries", "set-max-intset-entries",
+        "zset-max-listpack-entries" };
     Map<String, String> info = jedis.configGet(params);
     assertEquals(3, info.size());
     assertEquals("OK", jedis.configSet(info));
 
-    byte[][] bparams = new byte[][]{SafeEncoder.encode("hash-max-listpack-entries"),
-      SafeEncoder.encode("set-max-intset-entries"), SafeEncoder.encode("zset-max-listpack-entries")};
+    byte[][] bparams = new byte[][] { SafeEncoder.encode("hash-max-listpack-entries"),
+        SafeEncoder.encode("set-max-intset-entries"),
+        SafeEncoder.encode("zset-max-listpack-entries") };
     Map<byte[], byte[]> binfo = jedis.configGet(bparams);
     assertEquals(3, binfo.size());
     assertEquals("OK", jedis.configSetBinary(binfo));
@@ -429,23 +432,23 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     // Note: It has been recommended not to base MEMORY USAGE test on exact value, as the response
     // may subject to be 'tuned' especially targeting a major Redis release.
 
-    byte[] bfoo = {0x01, 0x02, 0x03, 0x04};
-    byte[] bbar = {0x05, 0x06, 0x07, 0x08};
-    byte[] bfoobar = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
+    byte[] bbar = { 0x05, 0x06, 0x07, 0x08 };
+    byte[] bfoobar = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 
     jedis.set(bfoo, bbar);
     assertThat(jedis.memoryUsage(bfoo), greaterThan(20l));
 
-    jedis.lpush(bfoobar, new byte[]{0x01, 0x02}, new byte[]{0x05, 0x06}, new byte[]{0x00});
-    assertThat(jedis.memoryUsage(bfoobar, 2), greaterThan(40l));
+    jedis.lpush(bfoobar, new byte[] { 0x01, 0x02 }, new byte[] { 0x05, 0x06 }, new byte[] { 0x00 });
+    assertThat(jedis.memoryUsage(bfoobar, 2), greaterThanOrEqualTo(40l));
 
     assertNull(jedis.memoryUsage("roo", 2));
   }
 
   @Test
   public void memoryPurge() {
-     String memoryPurge = jedis.memoryPurge();
-     assertNotNull(memoryPurge);
+    String memoryPurge = jedis.memoryPurge();
+    assertNotNull(memoryPurge);
   }
 
   @Test
@@ -489,15 +492,16 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
 
     CommandDocument sortDoc = docs.get("sort");
     assertEquals("generic", sortDoc.getGroup());
-    MatcherAssert.assertThat(sortDoc.getSummary(), Matchers.isOneOf(
-        "Sort the elements in a list, set or sorted set",
+    MatcherAssert.assertThat(sortDoc.getSummary(),
+      Matchers.isOneOf("Sort the elements in a list, set or sorted set",
         "Sorts the elements in a list, a set, or a sorted set, optionally storing the result."));
     assertNull(sortDoc.getHistory());
 
     CommandDocument setDoc = docs.get("set");
     assertEquals("1.0.0", setDoc.getSince());
     assertEquals("O(1)", setDoc.getComplexity());
-    assertEquals("2.6.12: Added the `EX`, `PX`, `NX` and `XX` options.", setDoc.getHistory().get(0));
+    assertEquals("2.6.12: Added the `EX`, `PX`, `NX` and `XX` options.",
+      setDoc.getHistory().get(0));
   }
 
   @Test
@@ -506,7 +510,8 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     List<String> keys = jedis.commandGetKeys("SORT", "mylist", "ALPHA", "STORE", "outlist");
     assertEquals(2, keys.size());
 
-    List<KeyValue<String, List<String>>> keySandFlags = jedis.commandGetKeysAndFlags("SET", "k1", "v1");
+    List<KeyValue<String, List<String>>> keySandFlags = jedis.commandGetKeysAndFlags("SET", "k1",
+      "v1");
     assertEquals("k1", keySandFlags.get(0).getKey());
     assertEquals(2, keySandFlags.get(0).getValue().size());
   }
@@ -581,17 +586,20 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     List<String> commands = jedis.commandList();
     assertTrue(commands.size() > 100);
 
-    commands = jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams().filterByModule("JSON"));
+    commands = jedis.commandListFilterBy(
+      CommandListFilterByParams.commandListFilterByParams().filterByModule("JSON"));
     assertEquals(0, commands.size()); // json module was not loaded
 
-    commands = jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams().filterByAclCat("admin"));
+    commands = jedis.commandListFilterBy(
+      CommandListFilterByParams.commandListFilterByParams().filterByAclCat("admin"));
     assertTrue(commands.size() > 10);
 
-    commands = jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams().filterByPattern("a*"));
+    commands = jedis.commandListFilterBy(
+      CommandListFilterByParams.commandListFilterByParams().filterByPattern("a*"));
     assertTrue(commands.size() > 10);
 
-    assertThrows(IllegalArgumentException.class, () ->
-        jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams()));
+    assertThrows(IllegalArgumentException.class,
+      () -> jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams()));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ControlCommandsTest.java
@@ -2,7 +2,6 @@ package redis.clients.jedis.commands.jedis;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -149,8 +148,8 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   @Test
   public void roleSlave() {
     EndpointConfig primaryEndpoint = HostAndPorts.getRedisEndpoint("standalone0");
-    EndpointConfig secondaryEndpoint = HostAndPorts
-        .getRedisEndpoint("standalone4-replica-of-standalone1");
+    EndpointConfig secondaryEndpoint = HostAndPorts.getRedisEndpoint(
+        "standalone4-replica-of-standalone1");
 
     try (Jedis slave = new Jedis(secondaryEndpoint.getHostAndPort(),
         secondaryEndpoint.getClientConfigBuilder().build())) {
@@ -227,18 +226,18 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     Map<String, String> info = jedis.configGet("m*");
     assertNotNull(info);
     assertFalse(info.isEmpty());
-    // assertTrue(info.size() % 2 == 0);
+//    assertTrue(info.size() % 2 == 0);
     Map<byte[], byte[]> infoBinary = jedis.configGet("m*".getBytes());
     assertNotNull(infoBinary);
     assertFalse(infoBinary.isEmpty());
-    // assertTrue(infoBinary.size() % 2 == 0);
+//    assertTrue(infoBinary.size() % 2 == 0);
   }
 
   @Test
   public void configSet() {
     Map<String, String> info = jedis.configGet("maxmemory");
-    // assertEquals("maxmemory", info.get(0));
-    // String memory = info.get(1);
+//    assertEquals("maxmemory", info.get(0));
+//    String memory = info.get(1);
     String memory = info.get("maxmemory");
     assertNotNull(memory);
     assertEquals("OK", jedis.configSet("maxmemory", "200"));
@@ -249,8 +248,8 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   public void configSetBinary() {
     byte[] maxmemory = SafeEncoder.encode("maxmemory");
     Map<byte[], byte[]> info = jedis.configGet(maxmemory);
-    // assertArrayEquals(maxmemory, info.get(0));
-    // byte[] memory = info.get(1);
+//    assertArrayEquals(maxmemory, info.get(0));
+//    byte[] memory = info.get(1);
     byte[] memory = info.get(maxmemory);
     assertNotNull(memory);
     assertEquals("OK", jedis.configSet(maxmemory, Protocol.toByteArray(200)));
@@ -260,15 +259,13 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
   @Test
   @SinceRedisVersion(value = "7.0.0", message = "Starting with Redis version 7.0.0: Added the ability to pass multiple pattern parameters in one call")
   public void configGetSetMulti() {
-    String[] params = new String[] { "hash-max-listpack-entries", "set-max-intset-entries",
-        "zset-max-listpack-entries" };
+    String[] params = new String[]{"hash-max-listpack-entries", "set-max-intset-entries", "zset-max-listpack-entries"};
     Map<String, String> info = jedis.configGet(params);
     assertEquals(3, info.size());
     assertEquals("OK", jedis.configSet(info));
 
-    byte[][] bparams = new byte[][] { SafeEncoder.encode("hash-max-listpack-entries"),
-        SafeEncoder.encode("set-max-intset-entries"),
-        SafeEncoder.encode("zset-max-listpack-entries") };
+    byte[][] bparams = new byte[][]{SafeEncoder.encode("hash-max-listpack-entries"),
+      SafeEncoder.encode("set-max-intset-entries"), SafeEncoder.encode("zset-max-listpack-entries")};
     Map<byte[], byte[]> binfo = jedis.configGet(bparams);
     assertEquals(3, binfo.size());
     assertEquals("OK", jedis.configSetBinary(binfo));
@@ -432,23 +429,23 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     // Note: It has been recommended not to base MEMORY USAGE test on exact value, as the response
     // may subject to be 'tuned' especially targeting a major Redis release.
 
-    byte[] bfoo = { 0x01, 0x02, 0x03, 0x04 };
-    byte[] bbar = { 0x05, 0x06, 0x07, 0x08 };
-    byte[] bfoobar = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+    byte[] bfoo = {0x01, 0x02, 0x03, 0x04};
+    byte[] bbar = {0x05, 0x06, 0x07, 0x08};
+    byte[] bfoobar = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
 
     jedis.set(bfoo, bbar);
     assertThat(jedis.memoryUsage(bfoo), greaterThan(20l));
 
-    jedis.lpush(bfoobar, new byte[] { 0x01, 0x02 }, new byte[] { 0x05, 0x06 }, new byte[] { 0x00 });
-    assertThat(jedis.memoryUsage(bfoobar, 2), greaterThanOrEqualTo(40l));
+    jedis.lpush(bfoobar, new byte[]{0x01, 0x02}, new byte[]{0x05, 0x06}, new byte[]{0x00});
+    assertThat(jedis.memoryUsage(bfoobar, 2), greaterThan(40l));
 
     assertNull(jedis.memoryUsage("roo", 2));
   }
 
   @Test
   public void memoryPurge() {
-    String memoryPurge = jedis.memoryPurge();
-    assertNotNull(memoryPurge);
+     String memoryPurge = jedis.memoryPurge();
+     assertNotNull(memoryPurge);
   }
 
   @Test
@@ -492,16 +489,15 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
 
     CommandDocument sortDoc = docs.get("sort");
     assertEquals("generic", sortDoc.getGroup());
-    MatcherAssert.assertThat(sortDoc.getSummary(),
-      Matchers.isOneOf("Sort the elements in a list, set or sorted set",
+    MatcherAssert.assertThat(sortDoc.getSummary(), Matchers.isOneOf(
+        "Sort the elements in a list, set or sorted set",
         "Sorts the elements in a list, a set, or a sorted set, optionally storing the result."));
     assertNull(sortDoc.getHistory());
 
     CommandDocument setDoc = docs.get("set");
     assertEquals("1.0.0", setDoc.getSince());
     assertEquals("O(1)", setDoc.getComplexity());
-    assertEquals("2.6.12: Added the `EX`, `PX`, `NX` and `XX` options.",
-      setDoc.getHistory().get(0));
+    assertEquals("2.6.12: Added the `EX`, `PX`, `NX` and `XX` options.", setDoc.getHistory().get(0));
   }
 
   @Test
@@ -510,8 +506,7 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     List<String> keys = jedis.commandGetKeys("SORT", "mylist", "ALPHA", "STORE", "outlist");
     assertEquals(2, keys.size());
 
-    List<KeyValue<String, List<String>>> keySandFlags = jedis.commandGetKeysAndFlags("SET", "k1",
-      "v1");
+    List<KeyValue<String, List<String>>> keySandFlags = jedis.commandGetKeysAndFlags("SET", "k1", "v1");
     assertEquals("k1", keySandFlags.get(0).getKey());
     assertEquals(2, keySandFlags.get(0).getValue().size());
   }
@@ -586,20 +581,17 @@ public class ControlCommandsTest extends JedisCommandsTestBase {
     List<String> commands = jedis.commandList();
     assertTrue(commands.size() > 100);
 
-    commands = jedis.commandListFilterBy(
-      CommandListFilterByParams.commandListFilterByParams().filterByModule("JSON"));
+    commands = jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams().filterByModule("JSON"));
     assertEquals(0, commands.size()); // json module was not loaded
 
-    commands = jedis.commandListFilterBy(
-      CommandListFilterByParams.commandListFilterByParams().filterByAclCat("admin"));
+    commands = jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams().filterByAclCat("admin"));
     assertTrue(commands.size() > 10);
 
-    commands = jedis.commandListFilterBy(
-      CommandListFilterByParams.commandListFilterByParams().filterByPattern("a*"));
+    commands = jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams().filterByPattern("a*"));
     assertTrue(commands.size() > 10);
 
-    assertThrows(IllegalArgumentException.class,
-      () -> jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams()));
+    assertThrows(IllegalArgumentException.class, () ->
+        jedis.commandListFilterBy(CommandListFilterByParams.commandListFilterByParams()));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/util/CommandArgumentMatchers.java
+++ b/src/test/java/redis/clients/jedis/util/CommandArgumentMatchers.java
@@ -1,0 +1,49 @@
+package redis.clients.jedis.util;
+
+import org.mockito.ArgumentMatcher;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.args.Rawable;
+import redis.clients.jedis.commands.ProtocolCommand;
+
+/**
+ * Utility class providing Mockito ArgumentMatchers for CommandArguments testing.
+ */
+public final class CommandArgumentMatchers {
+
+  private CommandArgumentMatchers() {
+    throw new InstantiationError("Must not instantiate this class");
+  }
+
+  /**
+   * Matcher for CommandArguments with specific ProtocolCommand
+   */
+  public static ArgumentMatcher<CommandArguments> commandIs(ProtocolCommand command) {
+    return args -> {
+      if (args == null || !(args instanceof CommandArguments)) {
+        return false;
+      }
+      return command.equals(args.getCommand());
+    };
+  }
+
+  /**
+   * Matcher for CommandArguments containing specific arguments
+   */
+  public static ArgumentMatcher<CommandArguments> hasArgument(String expectedArg) {
+    return args -> {
+      for (Rawable arg : args) {
+
+        if (expectedArg.equals(SafeEncoder.encode(arg.getRaw()))) {
+          return true;
+        }
+      }
+      return false;
+    };
+  }
+
+  public static ArgumentMatcher<CommandArguments> commandWithArgs(ProtocolCommand command,
+      String expectedArg) {
+    return cmd -> commandIs(command).matches(cmd) && hasArgument(expectedArg).matches(cmd);
+  }
+
+}


### PR DESCRIPTION

- Updates the reset() method in JedisClusterInfoCache to clear the replicaSlots list when resetting the cluster cache.
- No external behavior or API is affected

Closes #4191 