### PR TITLE
Fix flaky test ClientCommandsTest.killSkipmeYesNo

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -2,6 +2,7 @@ package redis.clients.jedis.commands.jedis;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -182,7 +183,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
     assertDisconnected(client);
 
     ClientKillParams skipmeNo = new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.NO);
-    assertThat(jedis.clientKill(skipmeNo), greaterThan(1L));
+    assertThat(jedis.clientKill(skipmeNo), greaterThanOrEqualTo(1L));
     assertDisconnected(jedis);
   }
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -1,5 +1,7 @@
 package redis.clients.jedis.commands.jedis;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -178,8 +180,9 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   public void killSkipmeYesNo() {
     jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.YES));
     assertDisconnected(client);
-    assertTrue(
-      jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.NO)) >= 1);
+
+    ClientKillParams skipmeNo = new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.NO);
+    assertThat(jedis.clientKill(skipmeNo), greaterThan(1L));
     assertDisconnected(jedis);
   }
 

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -40,6 +40,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
 
   private Jedis client;
 
+
   public ClientCommandsTest(RedisProtocol protocol) {
     super(protocol);
   }
@@ -123,8 +124,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   public void clientUnblock() throws InterruptedException, TimeoutException {
     long clientId = client.clientId();
     assertEquals(0, jedis.clientUnblock(clientId, UnblockType.ERROR));
-    Future<?> future = Executors.newSingleThreadExecutor()
-        .submit(() -> client.brpop(100000, "foo"));
+    Future<?> future = Executors.newSingleThreadExecutor().submit(() -> client.brpop(100000, "foo"));
 
     try {
       // to make true command already executed
@@ -132,9 +132,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
       assertEquals(1, jedis.clientUnblock(clientId, UnblockType.ERROR));
       future.get(1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      assertEquals(
-        "redis.clients.jedis.exceptions.JedisDataException: UNBLOCKED client unblocked via CLIENT UNBLOCK",
-        e.getMessage());
+      assertEquals("redis.clients.jedis.exceptions.JedisDataException: UNBLOCKED client unblocked via CLIENT UNBLOCK", e.getMessage());
     }
   }
 
@@ -229,7 +227,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
     matcher.find();
     String addr = matcher.group(1);
     int lastColon = addr.lastIndexOf(":");
-    String[] hp = new String[] { addr.substring(0, lastColon), addr.substring(lastColon + 1) };
+    String[] hp = new String[]{addr.substring(0, lastColon), addr.substring(lastColon + 1)};
 
     assertEquals(1, jedis.clientKill(new ClientKillParams().addr(hp[0], Integer.parseInt(hp[1]))));
 
@@ -307,8 +305,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void trackingInfoResp3() {
-    Jedis clientResp3 = new Jedis(endpoint.getHostAndPort(),
-        endpoint.getClientConfigBuilder().protocol(RedisProtocol.RESP3).build());
+    Jedis clientResp3 = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
+            .protocol(RedisProtocol.RESP3).build());
     TrackingInfo trackingInfo = clientResp3.clientTrackingInfo();
 
     assertEquals(1, trackingInfo.getFlags().size());

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -40,7 +40,6 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
 
   private Jedis client;
 
-
   public ClientCommandsTest(RedisProtocol protocol) {
     super(protocol);
   }
@@ -124,7 +123,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   public void clientUnblock() throws InterruptedException, TimeoutException {
     long clientId = client.clientId();
     assertEquals(0, jedis.clientUnblock(clientId, UnblockType.ERROR));
-    Future<?> future = Executors.newSingleThreadExecutor().submit(() -> client.brpop(100000, "foo"));
+    Future<?> future = Executors.newSingleThreadExecutor()
+        .submit(() -> client.brpop(100000, "foo"));
 
     try {
       // to make true command already executed
@@ -132,7 +132,9 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
       assertEquals(1, jedis.clientUnblock(clientId, UnblockType.ERROR));
       future.get(1, TimeUnit.SECONDS);
     } catch (ExecutionException e) {
-      assertEquals("redis.clients.jedis.exceptions.JedisDataException: UNBLOCKED client unblocked via CLIENT UNBLOCK", e.getMessage());
+      assertEquals(
+        "redis.clients.jedis.exceptions.JedisDataException: UNBLOCKED client unblocked via CLIENT UNBLOCK",
+        e.getMessage());
     }
   }
 
@@ -178,7 +180,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   public void killSkipmeYesNo() {
     jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.YES));
     assertDisconnected(client);
-    assertTrue(jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.NO)) >= 1);
+    assertTrue(
+      jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.NO)) >= 1);
     assertDisconnected(jedis);
   }
 
@@ -226,7 +229,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
     matcher.find();
     String addr = matcher.group(1);
     int lastColon = addr.lastIndexOf(":");
-    String[] hp = new String[]{addr.substring(0, lastColon), addr.substring(lastColon + 1)};
+    String[] hp = new String[] { addr.substring(0, lastColon), addr.substring(lastColon + 1) };
 
     assertEquals(1, jedis.clientKill(new ClientKillParams().addr(hp[0], Integer.parseInt(hp[1]))));
 
@@ -304,8 +307,8 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
 
   @Test
   public void trackingInfoResp3() {
-    Jedis clientResp3 = new Jedis(endpoint.getHostAndPort(), endpoint.getClientConfigBuilder()
-            .protocol(RedisProtocol.RESP3).build());
+    Jedis clientResp3 = new Jedis(endpoint.getHostAndPort(),
+        endpoint.getClientConfigBuilder().protocol(RedisProtocol.RESP3).build());
     TrackingInfo trackingInfo = clientResp3.clientTrackingInfo();
 
     assertEquals(1, trackingInfo.getFlags().size());

--- a/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/jedis/ClientCommandsTest.java
@@ -178,7 +178,7 @@ public class ClientCommandsTest extends JedisCommandsTestBase {
   public void killSkipmeYesNo() {
     jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.YES));
     assertDisconnected(client);
-    assertEquals(1, jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.NO)));
+    assertTrue(jedis.clientKill(new ClientKillParams().type(ClientType.NORMAL).skipMe(SkipMe.NO)) >= 1);
     assertDisconnected(jedis);
   }
 


### PR DESCRIPTION
Fixes random failures in the killSkipmeYesNo test by asserting that at least one client is killed, instead of exactly one.

Closes #4165 
