### PR TITLE
Fix test coverage generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven.surefire.version}</version>
 				<configuration>
-					<argLine>${JVM_OPTS}</argLine>
+					<argLine>@{argLine}</argLine>
 					<systemPropertyVariables>
 						<redis-hosts>${redis-hosts}</redis-hosts>
 					</systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
 		<jackson.version>2.19.2</jackson.version>
 		<maven.surefire.version>3.5.3</maven.surefire.version>
 		<junit.version>5.13.3</junit.version>
+		<!-- Default JVM options for tests -->
+		<JVM_OPTS></JVM_OPTS>
 	</properties>
 
 	<dependencyManagement>
@@ -270,7 +272,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven.surefire.version}</version>
 				<configuration>
-					<argLine>@{argLine}</argLine>
+					<argLine>@{argLine} ${JVM_OPTS}</argLine>
 					<systemPropertyVariables>
 						<redis-hosts>${redis-hosts}</redis-hosts>
 					</systemPropertyVariables>


### PR DESCRIPTION
We need to use special surefire syntax `@{...}` to include JaCoCo config options