### PR TITLE
[automatic failover]  Add SSL configuration support to LagAwareStrategy 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,7 @@
 						<include>**/mcf/MultiCluster*</include>
 						<include>**/mcf/StatusTracker*</include>
 						<include>**/Health*.java</include>
+						<include>**/*IT.java</include>
 						<include>src/main/java/redis/clients/jedis/MultiClusterClientConfig.java</include>
 						<include>src/main/java/redis/clients/jedis/HostAndPort.java</include>
 					</includes>

--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,7 @@
 						<include>**/mcf/StatusTracker*</include>
 						<include>**/Health*.java</include>
 						<include>**/*IT.java</include>
+						<include>**/scenario/RestEndpointUtil.java</include>
 						<include>src/main/java/redis/clients/jedis/MultiClusterClientConfig.java</include>
 						<include>src/main/java/redis/clients/jedis/HostAndPort.java</include>
 					</includes>

--- a/src/main/java/redis/clients/jedis/SslOptions.java
+++ b/src/main/java/redis/clients/jedis/SslOptions.java
@@ -343,7 +343,7 @@ public class SslOptions {
 
         if (keystoreResource != null) {
 
-            KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+            KeyStore keyStore = KeyStore.getInstance(keyStoreType==null ? KeyStore.getDefaultType() : keyStoreType);
             try (InputStream keystoreStream = keystoreResource.get()) {
                 keyStore.load(keystoreStream, keystorePassword);
             }
@@ -355,7 +355,8 @@ public class SslOptions {
 
         if (trustManagers == null && truststoreResource != null) {
 
-            KeyStore trustStore = KeyStore.getInstance(trustStoreType);
+
+            KeyStore trustStore = KeyStore.getInstance(trustStoreType == null ? KeyStore.getDefaultType() : trustStoreType);
             try (InputStream truststoreStream = truststoreResource.get()) {
                 trustStore.load(truststoreStream, truststorePassword);
             }
@@ -377,6 +378,15 @@ public class SslOptions {
      */
     public SSLParameters getSslParameters() {
         return sslParameters;
+    }
+
+
+    /**
+     * Configured ssl verify mode.
+     * @return {@link SslVerifyMode}
+     */
+    public SslVerifyMode getSslVerifyMode() {
+        return sslVerifyMode;
     }
 
     private static char[] getPassword(char[] chars) {

--- a/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
@@ -22,8 +22,8 @@ public class LagAwareStrategy implements HealthCheckStrategy {
 
   public LagAwareStrategy(Config config) {
     this.config = config;
-    this.redisRestAPI = new RedisRestAPI(config.restEndpoint, config.credentialsSupplier,
-        config.timeout, config.sslOptions);
+    this.redisRestAPI = new RedisRestAPI(config.getRestEndpoint(), config.getCredentialsSupplier(),
+        config.getTimeout(), config.getSslOptions());
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.RedisCredentials;
+  import redis.clients.jedis.SslOptions;
 
 import redis.clients.jedis.Endpoint;
 
@@ -22,7 +23,7 @@ public class LagAwareStrategy implements HealthCheckStrategy {
   public LagAwareStrategy(Config config) {
     this.config = config;
     this.redisRestAPI = new RedisRestAPI(config.restEndpoint, config.credentialsSupplier,
-        config.timeout);
+        config.timeout, config.sslOptions);
   }
 
   @Override
@@ -86,6 +87,9 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     private final Endpoint restEndpoint;
     private final Supplier<RedisCredentials> credentialsSupplier;
 
+    // SSL configuration for HTTPS connections to Redis Enterprise REST API
+    private final SslOptions sslOptions;
+
     // Maximum acceptable lag in milliseconds (default: 100);
     private final Duration availability_lag_tolerance;
 
@@ -104,8 +108,9 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     private Config(ConfigBuilder builder) {
       super(builder.interval, builder.timeout, builder.minConsecutiveSuccessCount);
 
-      this.restEndpoint = builder.endpoint;
+      this.restEndpoint = builder.restEndpoint;
       this.credentialsSupplier = builder.credentialsSupplier;
+      this.sslOptions = builder.sslOptions;
       this.availability_lag_tolerance = builder.availabilityLagTolerance;
       this.extendedCheckEnabled = builder.extendedCheckEnabled;
     }
@@ -118,6 +123,10 @@ public class LagAwareStrategy implements HealthCheckStrategy {
       return credentialsSupplier;
     }
 
+    public SslOptions getSslOptions() {
+      return sslOptions;
+    }
+
     public Duration getAvailabilityLagTolerance() {
       return availability_lag_tolerance;
     }
@@ -128,13 +137,13 @@ public class LagAwareStrategy implements HealthCheckStrategy {
 
     /**
      * Create a new builder for LagAwareStrategy.Config.
-     * @param endpoint the Redis Enterprise endpoint
+     * @param restEndpoint the Redis Enterprise REST API endpoint
      * @param credentialsSupplier the credentials supplier
      * @return a new ConfigBuilder instance
      */
-    public static ConfigBuilder builder(Endpoint endpoint,
+    public static ConfigBuilder builder(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier) {
-      return new ConfigBuilder(endpoint, credentialsSupplier);
+      return new ConfigBuilder(restEndpoint, credentialsSupplier);
     }
 
     /**
@@ -146,8 +155,8 @@ public class LagAwareStrategy implements HealthCheckStrategy {
      * {@link #lagAwareWithTolerance(Endpoint, Supplier, Duration)}
      * </p>
      */
-    public static Config create(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier) {
-      return new ConfigBuilder(endpoint, credentialsSupplier).build();
+    public static Config create(Endpoint restEndpoint, Supplier<RedisCredentials> credentialsSupplier) {
+      return new ConfigBuilder(restEndpoint, credentialsSupplier).build();
     }
 
     /**
@@ -158,9 +167,9 @@ public class LagAwareStrategy implements HealthCheckStrategy {
      * {@link #lagAwareWithTolerance(Endpoint, Supplier, Duration)}
      * </p>
      */
-    public static Config databaseAvailability(Endpoint endpoint,
+    public static Config databaseAvailability(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier) {
-      return new ConfigBuilder(endpoint, credentialsSupplier).extendedCheckEnabled(false).build();
+      return new ConfigBuilder(restEndpoint, credentialsSupplier).extendedCheckEnabled(false).build();
     }
 
     /**
@@ -170,17 +179,17 @@ public class LagAwareStrategy implements HealthCheckStrategy {
      * {@link #lagAwareWithTolerance(Endpoint, Supplier, Duration)}
      * </p>
      */
-    public static Config lagAware(Endpoint endpoint,
+    public static Config lagAware(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier) {
-      return new ConfigBuilder(endpoint, credentialsSupplier).extendedCheckEnabled(true).build();
+      return new ConfigBuilder(restEndpoint, credentialsSupplier).extendedCheckEnabled(true).build();
     }
 
     /**
      * Perform standard datapath validation and lag validation using the specified lag tolerance.
      */
-    public static Config lagAwareWithTolerance(Endpoint endpoint,
+    public static Config lagAwareWithTolerance(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier, Duration availabilityLagTolerance) {
-      return new ConfigBuilder(endpoint, credentialsSupplier).extendedCheckEnabled(true)
+      return new ConfigBuilder(restEndpoint, credentialsSupplier).extendedCheckEnabled(true)
           .availabilityLagTolerance(availabilityLagTolerance).build();
     }
 
@@ -189,8 +198,11 @@ public class LagAwareStrategy implements HealthCheckStrategy {
      */
     public static class ConfigBuilder
         extends HealthCheckStrategy.Config.Builder<ConfigBuilder, Config> {
-      private final Endpoint endpoint;
+      private final Endpoint restEndpoint;
       private final Supplier<RedisCredentials> credentialsSupplier;
+
+      // SSL configuration for HTTPS connections
+      private SslOptions sslOptions;
 
       // Maximum acceptable lag in milliseconds (default: 100);
       private Duration availabilityLagTolerance = AVAILABILITY_LAG_TOLERANCE_DEFAULT;
@@ -198,9 +210,22 @@ public class LagAwareStrategy implements HealthCheckStrategy {
       // Enable extended lag checking
       private boolean extendedCheckEnabled = EXTENDED_CHECK_DEFAULT;
 
-      private ConfigBuilder(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier) {
-        this.endpoint = endpoint;
+      private ConfigBuilder(Endpoint restEndpoint, Supplier<RedisCredentials> credentialsSupplier) {
+        this.restEndpoint = restEndpoint;
         this.credentialsSupplier = credentialsSupplier;
+      }
+
+      /**
+       * Set SSL options for HTTPS connections to Redis Enterprise REST API.
+       * This allows configuration of custom truststore, keystore, and SSL parameters
+       * for secure connections to Redis Enterprise clusters.
+       *
+       * @param sslOptions the SSL configuration options
+       * @return this builder
+       */
+      public ConfigBuilder sslOptions(SslOptions sslOptions) {
+        this.sslOptions = sslOptions;
+        return this;
       }
 
       /**

--- a/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.RedisCredentials;
-  import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslOptions;
 
 import redis.clients.jedis.Endpoint;
 
@@ -155,7 +155,8 @@ public class LagAwareStrategy implements HealthCheckStrategy {
      * {@link #lagAwareWithTolerance(Endpoint, Supplier, Duration)}
      * </p>
      */
-    public static Config create(Endpoint restEndpoint, Supplier<RedisCredentials> credentialsSupplier) {
+    public static Config create(Endpoint restEndpoint,
+        Supplier<RedisCredentials> credentialsSupplier) {
       return new ConfigBuilder(restEndpoint, credentialsSupplier).build();
     }
 
@@ -169,7 +170,8 @@ public class LagAwareStrategy implements HealthCheckStrategy {
      */
     public static Config databaseAvailability(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier) {
-      return new ConfigBuilder(restEndpoint, credentialsSupplier).extendedCheckEnabled(false).build();
+      return new ConfigBuilder(restEndpoint, credentialsSupplier).extendedCheckEnabled(false)
+          .build();
     }
 
     /**
@@ -181,7 +183,8 @@ public class LagAwareStrategy implements HealthCheckStrategy {
      */
     public static Config lagAware(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier) {
-      return new ConfigBuilder(restEndpoint, credentialsSupplier).extendedCheckEnabled(true).build();
+      return new ConfigBuilder(restEndpoint, credentialsSupplier).extendedCheckEnabled(true)
+          .build();
     }
 
     /**
@@ -216,10 +219,8 @@ public class LagAwareStrategy implements HealthCheckStrategy {
       }
 
       /**
-       * Set SSL options for HTTPS connections to Redis Enterprise REST API.
-       * This allows configuration of custom truststore, keystore, and SSL parameters
-       * for secure connections to Redis Enterprise clusters.
-       *
+       * Set SSL options for HTTPS connections to Redis Enterprise REST API. This allows
+       * configuration of custom truststore, keystore, and SSL parameters for secure connections.
        * @param sslOptions the SSL configuration options
        * @return this builder
        */

--- a/src/main/java/redis/clients/jedis/mcf/RedisRestAPI.java
+++ b/src/main/java/redis/clients/jedis/mcf/RedisRestAPI.java
@@ -25,16 +25,20 @@ import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.RedisCredentials;
 import redis.clients.jedis.SslOptions;
 import redis.clients.jedis.SslVerifyMode;
+import redis.clients.jedis.annots.Internal;
 
 /**
  * Helper class to check the availability of a Redis database
  */
+@Internal
 class RedisRestAPI {
 
   private static final Logger log = LoggerFactory.getLogger(RedisRestAPI.class);
   private static final String BDBS_URL = "https://%s:%s/v1/bdbs?fields=uid,endpoints";
   private static final String AVAILABILITY_URL = "https://%s:%s/v1/bdbs/%s/availability";
   private static final String LAGAWARE_AVAILABILITY_URL = "https://%s:%s/v1/bdbs/%s/availability?extend_check=lag";
+
+  private static final int DEFAULT_TIMEOUT_MS = 1000;
 
   private final Endpoint endpoint;
   private final Supplier<RedisCredentials> credentialsSupplier;
@@ -43,7 +47,7 @@ class RedisRestAPI {
   private String bdbsUri;
 
   public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier) {
-    this(endpoint, credentialsSupplier, 1000);
+    this(endpoint, credentialsSupplier, DEFAULT_TIMEOUT_MS);
   }
 
   public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier,
@@ -130,7 +134,8 @@ class RedisRestAPI {
         SSLContext sslContext = sslOptions.createSslContext();
         httpsConnection.setSSLSocketFactory(sslContext.getSocketFactory());
 
-        if (sslOptions.getSslVerifyMode() == SslVerifyMode.CA || sslOptions.getSslVerifyMode() == SslVerifyMode.INSECURE) {
+        if (sslOptions.getSslVerifyMode() == SslVerifyMode.CA
+            || sslOptions.getSslVerifyMode() == SslVerifyMode.INSECURE) {
           httpsConnection.setHostnameVerifier((h, s) -> true); // skip hostname check
         }
       } catch (GeneralSecurityException e) {

--- a/src/main/java/redis/clients/jedis/mcf/RedisRestAPI.java
+++ b/src/main/java/redis/clients/jedis/mcf/RedisRestAPI.java
@@ -5,10 +5,13 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.function.Supplier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +23,8 @@ import com.google.gson.JsonParser;
 
 import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslVerifyMode;
 
 /**
  * Helper class to check the availability of a Redis database
@@ -31,9 +36,10 @@ class RedisRestAPI {
   private static final String AVAILABILITY_URL = "https://%s:%s/v1/bdbs/%s/availability";
   private static final String LAGAWARE_AVAILABILITY_URL = "https://%s:%s/v1/bdbs/%s/availability?extend_check=lag";
 
-  private Endpoint endpoint;
-  private Supplier<RedisCredentials> credentialsSupplier;
-  private int timeoutMs;
+  private final Endpoint endpoint;
+  private final Supplier<RedisCredentials> credentialsSupplier;
+  private final int timeoutMs;
+  private final SslOptions sslOptions;
   private String bdbsUri;
 
   public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier) {
@@ -42,9 +48,15 @@ class RedisRestAPI {
 
   public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier,
       int timeoutMs) {
+    this(endpoint, credentialsSupplier, timeoutMs, null);
+  }
+
+  public RedisRestAPI(Endpoint endpoint, Supplier<RedisCredentials> credentialsSupplier,
+      int timeoutMs, SslOptions sslOptions) {
     this.endpoint = endpoint;
     this.credentialsSupplier = credentialsSupplier;
     this.timeoutMs = timeoutMs;
+    this.sslOptions = sslOptions;
   }
 
   public List<RedisRestAPI.BdbInfo> getBdbs() throws IOException {
@@ -110,6 +122,22 @@ class RedisRestAPI {
       throws IOException {
     URL url = new URL(urlString);
     HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+    // Configure SSL if this is an HTTPS connection and SSL options are provided
+    if (connection instanceof HttpsURLConnection && sslOptions != null) {
+      HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
+      try {
+        SSLContext sslContext = sslOptions.createSslContext();
+        httpsConnection.setSSLSocketFactory(sslContext.getSocketFactory());
+
+        if (sslOptions.getSslVerifyMode() == SslVerifyMode.CA || sslOptions.getSslVerifyMode() == SslVerifyMode.INSECURE) {
+          httpsConnection.setHostnameVerifier((h, s) -> true); // skip hostname check
+        }
+      } catch (GeneralSecurityException e) {
+        throw new IOException("SSL configuration failed", e);
+      }
+    }
+
     connection.setRequestMethod(method);
     connection.setConnectTimeout(timeoutMs);
     connection.setReadTimeout(timeoutMs);

--- a/src/test/java/redis/clients/jedis/mcf/RedisRestAPIIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/RedisRestAPIIntegrationTest.java
@@ -27,6 +27,7 @@ import redis.clients.jedis.Endpoint;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.scenario.RestEndpointUtil;
 
 @Tags({ @Tag("failover"), @Tag("scenario") })
 public class RedisRestAPIIntegrationTest {
@@ -60,7 +61,7 @@ public class RedisRestAPIIntegrationTest {
         HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
 
       } catch (Exception e) {
-        e.printStackTrace();
+        log.error("Failed to disable SSL verification", e);
       }
     }
 
@@ -84,7 +85,7 @@ public class RedisRestAPIIntegrationTest {
   public static void beforeClass() {
     try {
       endpointConfig = HostAndPorts.getRedisEndpoint("re-active-active");
-      restAPIEndpoint = getRestAPIEndpoint(endpointConfig);
+      restAPIEndpoint = RestEndpointUtil.getRestAPIEndpoint(endpointConfig);
       credentialsSupplier = () -> new DefaultRedisCredentials("test@redis.com", "test123");
       SSLBypass.disableSSLVerification();
     } catch (IllegalArgumentException e) {
@@ -122,26 +123,6 @@ public class RedisRestAPIIntegrationTest {
     String firstBdbUid = bdbs.get(0).getUid();
     assertTrue(api.checkBdbAvailability(firstBdbUid, false));
     assertFalse(api.checkBdbAvailability(firstBdbUid, true));
-  }
-
-  private static Endpoint getRestAPIEndpoint(EndpointConfig config) {
-    return new Endpoint() {
-      @Override
-      public String getHost() {
-        // convert this to Redis FQDN by removing the node prefix
-        // "dns":"redis-10232.c1.taki-active-active-test-c114170a.cto.redislabs.com"
-        String host = config.getHost();
-        // trim until the first dot
-        String fqdn = host.substring(host.indexOf('.') + 1);
-        return fqdn;
-      }
-
-      @Override
-      public int getPort() {
-        // default port for REST API
-        return 9443;
-      }
-    };
   }
 
 }

--- a/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
@@ -1,0 +1,201 @@
+package redis.clients.jedis.scenario;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import redis.clients.jedis.DefaultRedisCredentials;
+import redis.clients.jedis.Endpoint;
+import redis.clients.jedis.EndpointConfig;
+import redis.clients.jedis.HostAndPorts;
+import redis.clients.jedis.RedisCredentials;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.SslVerifyMode;
+import redis.clients.jedis.mcf.HealthStatus;
+import redis.clients.jedis.mcf.LagAwareStrategy;
+import redis.clients.jedis.util.TlsUtil;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Test class demonstrating SSL configuration for LagAwareStrategy
+ */
+@Tag("scenario")
+public class LagAwareStrategySslIT {
+    private static EndpointConfig endpointConfig;
+    private static Endpoint restEndpoint;
+    private static Supplier<RedisCredentials> credentialsSupplier;
+    private static final String trustStoreName = LagAwareStrategySslIT.class.getSimpleName()+".jks";
+    private static final String certificateAlias = "redis-enterprise";
+    private static final char[] trustStorePassword = "changeit".toCharArray();
+
+    @BeforeAll
+    public static void beforeClass() {
+
+        endpointConfig = HostAndPorts.getRedisEndpoint("re-active-active");
+        restEndpoint = RestEndpointUtil.getRestAPIEndpoint(endpointConfig);
+        credentialsSupplier = () -> new DefaultRedisCredentials("test@redis.com", "test123");
+        try {
+            createTestTruststore(restEndpoint.getHost(), restEndpoint.getPort(),
+                    trustStoreName, certificateAlias, trustStorePassword);
+        } catch (Exception e) {
+            fail("Failed to create test truststore", e);
+        }
+    }
+
+    @ParameterizedTest(name = "SSL mode {0} should be HEALTHY")
+    @EnumSource(value = SslVerifyMode.class, names = {"FULL", "CA", "INSECURE"})
+    public void healthyWhenUsingCustomTruststore(SslVerifyMode sslVerifyMode) throws Exception {
+        // Create SSL options with custom truststore
+        SslOptions sslOptions = SslOptions.builder()
+            .truststore(new File(trustStoreName), trustStorePassword)
+            .sslVerifyMode(sslVerifyMode)
+            .build();
+
+        // Create LagAwareStrategy config with SSL support using builder
+        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
+            .sslOptions(sslOptions)
+            .build();
+
+        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+            assertEquals(HealthStatus.HEALTHY, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+        }
+    }
+
+    @ParameterizedTest(name = "SSL mode {0} should result in {1}")
+    @CsvSource({
+            "FULL, UNHEALTHY",
+            "CA, UNHEALTHY",
+            "INSECURE, HEALTHY"
+    })
+    void usingDefaultTruststoreWithUntrustedCertificate(SslVerifyMode sslVerifyMode, HealthStatus expected) {
+        // Create SSL options without specifying truststore
+        SslOptions sslOptions = SslOptions.builder()
+                .sslVerifyMode(sslVerifyMode)
+                .build();
+
+        // Create LagAwareStrategy config with SSL support using builder
+        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
+                .sslOptions(sslOptions)
+                .build();
+
+        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+            assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+        }
+    }
+
+    @ParameterizedTest(name = "SSL mode {0} should result in {1}")
+    @CsvSource({
+            "FULL, HEALTHY",
+            "CA, HEALTHY",
+            "INSECURE, HEALTHY"
+    })
+    void healthyWhenUsingDefaultTruststoreWithTrustedCertificate(SslVerifyMode sslVerifyMode, HealthStatus expected) {
+        // Create SSL options without specifying truststore
+        SslOptions sslOptions = SslOptions.builder()
+                .sslVerifyMode(sslVerifyMode)
+                .build();
+
+        // Create LagAwareStrategy config with SSL support using builder
+        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
+                .sslOptions(sslOptions)
+                .build();
+
+        // Verify configuration - trusted cert should pass
+        // Default SSL context is used if no user defined trust store is configured
+        // Configure default SSL context to trust our custom CA
+        // and reinitialize default SSL context for HttpsURLConnection
+        TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
+        SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
+        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+            HttpsURLConnection.setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+            assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+        } finally {
+            TlsUtil.restoreOriginalTrustStore();
+            HttpsURLConnection.setDefaultSSLSocketFactory(orig);
+        }
+    }
+
+    @Test
+    public void fallbackToDefaultSslContextWhenSslOptionsAreNull() {
+        // Test that SSL options can be null
+        // If SSL options are null, we should fallback to default SSL context
+        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
+                .build();
+
+        // Verify configuration - untrusted cert should fail
+        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+            assertEquals(HealthStatus.UNHEALTHY, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+        }
+
+        // Verify configuration - trusted cert should pass
+        // Default SSL context is used if no SSL options are provided
+        // Configure default SSL context to trust our custom CA
+        // and reinitialize default SSL context for HttpsURLConnection
+        TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
+        SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
+        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+            HttpsURLConnection.setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+            assertEquals(HealthStatus.HEALTHY, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+        } finally {
+            TlsUtil.restoreOriginalTrustStore();
+            HttpsURLConnection.setDefaultSSLSocketFactory(orig);
+        }
+    }
+
+     /**
+      * Downloads the server certificate from a host and stores it as a JKS file.
+      *
+      * @param host host to connect to (e.g., redis.example.com)
+      * @param port TLS port (e.g., 9443)
+      * @param jks path where the JKS file will be created
+      * @param alias alias to store the certificate under
+      * @param password password for the JKS
+      */
+     static void createTestTruststore(String host, int port, String jks, String alias, char[] password) throws Exception {
+         // Use SSL socket to fetch server cert
+         // Disable certificate verification
+         TrustManager[] trustAll = new TrustManager[] { new X509TrustManager() {
+             public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+             public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+             public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+         }};
+         SSLContext sslContext = SSLContext.getInstance("TLS");
+         sslContext.init(null, trustAll, new java.security.SecureRandom());
+         SSLSocketFactory factory = sslContext.getSocketFactory();
+
+         try (SSLSocket socket = (SSLSocket) factory.createSocket(host, port)) {
+             socket.startHandshake();
+             Certificate[] serverCerts = socket.getSession().getPeerCertificates();
+
+             // Create an empty KeyStore
+             KeyStore ks = KeyStore.getInstance("JKS");
+             ks.load(null, password);
+
+             // Add server certificate (first in chain)
+             ks.setCertificateEntry(alias, serverCerts[0]);
+
+             // Write KeyStore to disk
+             try (FileOutputStream fos = new FileOutputStream(jks)) {
+                 ks.store(fos, password);
+             }
+         }
+     }
+}

--- a/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
@@ -39,163 +39,160 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Tag("scenario")
 public class LagAwareStrategySslIT {
-    private static EndpointConfig endpointConfig;
-    private static Endpoint restEndpoint;
-    private static Supplier<RedisCredentials> credentialsSupplier;
-    private static final String trustStoreName = LagAwareStrategySslIT.class.getSimpleName()+".jks";
-    private static final String certificateAlias = "redis-enterprise";
-    private static final char[] trustStorePassword = "changeit".toCharArray();
+  private static EndpointConfig endpointConfig;
+  private static Endpoint restEndpoint;
+  private static Supplier<RedisCredentials> credentialsSupplier;
+  private static final String trustStoreName = LagAwareStrategySslIT.class.getSimpleName() + ".jks";
+  private static final String certificateAlias = "redis-enterprise";
+  private static final char[] trustStorePassword = "changeit".toCharArray();
 
-    @BeforeAll
-    public static void beforeClass() {
+  @BeforeAll
+  public static void beforeClass() {
 
-        endpointConfig = HostAndPorts.getRedisEndpoint("re-active-active");
-        restEndpoint = RestEndpointUtil.getRestAPIEndpoint(endpointConfig);
-        credentialsSupplier = () -> new DefaultRedisCredentials("test@redis.com", "test123");
-        try {
-            createTestTruststore(restEndpoint.getHost(), restEndpoint.getPort(),
-                    trustStoreName, certificateAlias, trustStorePassword);
-        } catch (Exception e) {
-            fail("Failed to create test truststore", e);
-        }
+    endpointConfig = HostAndPorts.getRedisEndpoint("re-active-active");
+    restEndpoint = RestEndpointUtil.getRestAPIEndpoint(endpointConfig);
+    credentialsSupplier = () -> new DefaultRedisCredentials("test@redis.com", "test123");
+    try {
+      createTestTruststore(restEndpoint.getHost(), restEndpoint.getPort(), trustStoreName,
+        certificateAlias, trustStorePassword);
+    } catch (Exception e) {
+      fail("Failed to create test truststore", e);
+    }
+  }
+
+  @ParameterizedTest(name = "SSL mode {0} should be HEALTHY")
+  @EnumSource(value = SslVerifyMode.class, names = { "FULL", "CA", "INSECURE" })
+  public void healthyWhenUsingCustomTruststore(SslVerifyMode sslVerifyMode) throws Exception {
+    // Create SSL options with custom truststore
+    SslOptions sslOptions = SslOptions.builder()
+        .truststore(new File(trustStoreName), trustStorePassword).sslVerifyMode(sslVerifyMode)
+        .build();
+
+    // Create LagAwareStrategy config with SSL support using builder
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).sslOptions(sslOptions).build();
+
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      assertEquals(HealthStatus.HEALTHY,
+        lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    }
+  }
+
+  @ParameterizedTest(name = "SSL mode {0} should result in {1}")
+  @CsvSource({ "FULL, UNHEALTHY", "CA, UNHEALTHY", "INSECURE, HEALTHY" })
+  void usingDefaultTruststoreWithUntrustedCertificate(SslVerifyMode sslVerifyMode,
+      HealthStatus expected) {
+    // Create SSL options without specifying truststore
+    SslOptions sslOptions = SslOptions.builder().sslVerifyMode(sslVerifyMode).build();
+
+    // Create LagAwareStrategy config with SSL support using builder
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).sslOptions(sslOptions).build();
+
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    }
+  }
+
+  @ParameterizedTest(name = "SSL mode {0} should result in {1}")
+  @CsvSource({ "FULL, HEALTHY", "CA, HEALTHY", "INSECURE, HEALTHY" })
+  void healthyWhenUsingDefaultTruststoreWithTrustedCertificate(SslVerifyMode sslVerifyMode,
+      HealthStatus expected) {
+    // Create SSL options without specifying truststore
+    SslOptions sslOptions = SslOptions.builder().sslVerifyMode(sslVerifyMode).build();
+
+    // Create LagAwareStrategy config with SSL support using builder
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).sslOptions(sslOptions).build();
+
+    // Verify configuration - trusted cert should pass
+    // Default SSL context is used if no user defined trust store is configured
+    // Configure default SSL context to trust our custom CA
+    // and reinitialize default SSL context for HttpsURLConnection
+    TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
+    SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      HttpsURLConnection
+          .setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+      assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    } finally {
+      TlsUtil.restoreOriginalTrustStore();
+      HttpsURLConnection.setDefaultSSLSocketFactory(orig);
+    }
+  }
+
+  @Test
+  public void fallbackToDefaultSslContextWhenSslOptionsAreNull() {
+    // Test that SSL options can be null
+    // If SSL options are null, we should fallback to default SSL context
+    LagAwareStrategy.Config config = LagAwareStrategy.Config
+        .builder(restEndpoint, credentialsSupplier).build();
+
+    // Verify configuration - untrusted cert should fail
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      assertEquals(HealthStatus.UNHEALTHY,
+        lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
     }
 
-    @ParameterizedTest(name = "SSL mode {0} should be HEALTHY")
-    @EnumSource(value = SslVerifyMode.class, names = {"FULL", "CA", "INSECURE"})
-    public void healthyWhenUsingCustomTruststore(SslVerifyMode sslVerifyMode) throws Exception {
-        // Create SSL options with custom truststore
-        SslOptions sslOptions = SslOptions.builder()
-            .truststore(new File(trustStoreName), trustStorePassword)
-            .sslVerifyMode(sslVerifyMode)
-            .build();
-
-        // Create LagAwareStrategy config with SSL support using builder
-        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
-            .sslOptions(sslOptions)
-            .build();
-
-        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
-            assertEquals(HealthStatus.HEALTHY, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
-        }
+    // Verify configuration - trusted cert should pass
+    // Default SSL context is used if no SSL options are provided
+    // Configure default SSL context to trust our custom CA
+    // and reinitialize default SSL context for HttpsURLConnection
+    TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
+    SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
+    try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
+      HttpsURLConnection
+          .setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
+      assertEquals(HealthStatus.HEALTHY,
+        lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
+    } finally {
+      TlsUtil.restoreOriginalTrustStore();
+      HttpsURLConnection.setDefaultSSLSocketFactory(orig);
     }
+  }
 
-    @ParameterizedTest(name = "SSL mode {0} should result in {1}")
-    @CsvSource({
-            "FULL, UNHEALTHY",
-            "CA, UNHEALTHY",
-            "INSECURE, HEALTHY"
-    })
-    void usingDefaultTruststoreWithUntrustedCertificate(SslVerifyMode sslVerifyMode, HealthStatus expected) {
-        // Create SSL options without specifying truststore
-        SslOptions sslOptions = SslOptions.builder()
-                .sslVerifyMode(sslVerifyMode)
-                .build();
+  /**
+   * Downloads the server certificate from a host and stores it as a JKS file.
+   * @param host host to connect to (e.g., redis.example.com)
+   * @param port TLS port (e.g., 9443)
+   * @param jks path where the JKS file will be created
+   * @param alias alias to store the certificate under
+   * @param password password for the JKS
+   */
+  static void createTestTruststore(String host, int port, String jks, String alias, char[] password)
+      throws Exception {
+    // Use SSL socket to fetch server cert
+    // Disable certificate verification
+    TrustManager[] trustAll = new TrustManager[] { new X509TrustManager() {
+      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+      }
 
-        // Create LagAwareStrategy config with SSL support using builder
-        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
-                .sslOptions(sslOptions)
-                .build();
+      public void checkServerTrusted(X509Certificate[] chain, String authType) {
+      }
 
-        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
-            assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
-        }
+      public X509Certificate[] getAcceptedIssuers() {
+        return new X509Certificate[0];
+      }
+    } };
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, trustAll, new java.security.SecureRandom());
+    SSLSocketFactory factory = sslContext.getSocketFactory();
+
+    try (SSLSocket socket = (SSLSocket) factory.createSocket(host, port)) {
+      socket.startHandshake();
+      Certificate[] serverCerts = socket.getSession().getPeerCertificates();
+
+      // Create an empty KeyStore
+      KeyStore ks = KeyStore.getInstance("JKS");
+      ks.load(null, password);
+
+      // Add server certificate (first in chain)
+      ks.setCertificateEntry(alias, serverCerts[0]);
+
+      // Write KeyStore to disk
+      try (FileOutputStream fos = new FileOutputStream(jks)) {
+        ks.store(fos, password);
+      }
     }
-
-    @ParameterizedTest(name = "SSL mode {0} should result in {1}")
-    @CsvSource({
-            "FULL, HEALTHY",
-            "CA, HEALTHY",
-            "INSECURE, HEALTHY"
-    })
-    void healthyWhenUsingDefaultTruststoreWithTrustedCertificate(SslVerifyMode sslVerifyMode, HealthStatus expected) {
-        // Create SSL options without specifying truststore
-        SslOptions sslOptions = SslOptions.builder()
-                .sslVerifyMode(sslVerifyMode)
-                .build();
-
-        // Create LagAwareStrategy config with SSL support using builder
-        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
-                .sslOptions(sslOptions)
-                .build();
-
-        // Verify configuration - trusted cert should pass
-        // Default SSL context is used if no user defined trust store is configured
-        // Configure default SSL context to trust our custom CA
-        // and reinitialize default SSL context for HttpsURLConnection
-        TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
-        SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
-        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
-            HttpsURLConnection.setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
-            assertEquals(expected, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
-        } finally {
-            TlsUtil.restoreOriginalTrustStore();
-            HttpsURLConnection.setDefaultSSLSocketFactory(orig);
-        }
-    }
-
-    @Test
-    public void fallbackToDefaultSslContextWhenSslOptionsAreNull() {
-        // Test that SSL options can be null
-        // If SSL options are null, we should fallback to default SSL context
-        LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(restEndpoint, credentialsSupplier)
-                .build();
-
-        // Verify configuration - untrusted cert should fail
-        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
-            assertEquals(HealthStatus.UNHEALTHY, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
-        }
-
-        // Verify configuration - trusted cert should pass
-        // Default SSL context is used if no SSL options are provided
-        // Configure default SSL context to trust our custom CA
-        // and reinitialize default SSL context for HttpsURLConnection
-        TlsUtil.setCustomTrustStore(new File(trustStoreName).toPath(), new String(trustStorePassword));
-        SSLSocketFactory orig = HttpsURLConnection.getDefaultSSLSocketFactory();
-        try (LagAwareStrategy lagAwareStrategy = new LagAwareStrategy(config)) {
-            HttpsURLConnection.setDefaultSSLSocketFactory((SSLSocketFactory) SSLSocketFactory.getDefault());
-            assertEquals(HealthStatus.HEALTHY, lagAwareStrategy.doHealthCheck(endpointConfig.getHostAndPort()));
-        } finally {
-            TlsUtil.restoreOriginalTrustStore();
-            HttpsURLConnection.setDefaultSSLSocketFactory(orig);
-        }
-    }
-
-     /**
-      * Downloads the server certificate from a host and stores it as a JKS file.
-      *
-      * @param host host to connect to (e.g., redis.example.com)
-      * @param port TLS port (e.g., 9443)
-      * @param jks path where the JKS file will be created
-      * @param alias alias to store the certificate under
-      * @param password password for the JKS
-      */
-     static void createTestTruststore(String host, int port, String jks, String alias, char[] password) throws Exception {
-         // Use SSL socket to fetch server cert
-         // Disable certificate verification
-         TrustManager[] trustAll = new TrustManager[] { new X509TrustManager() {
-             public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-             public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-             public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
-         }};
-         SSLContext sslContext = SSLContext.getInstance("TLS");
-         sslContext.init(null, trustAll, new java.security.SecureRandom());
-         SSLSocketFactory factory = sslContext.getSocketFactory();
-
-         try (SSLSocket socket = (SSLSocket) factory.createSocket(host, port)) {
-             socket.startHandshake();
-             Certificate[] serverCerts = socket.getSession().getPeerCertificates();
-
-             // Create an empty KeyStore
-             KeyStore ks = KeyStore.getInstance("JKS");
-             ks.load(null, password);
-
-             // Add server certificate (first in chain)
-             ks.setCertificateEntry(alias, serverCerts[0]);
-
-             // Write KeyStore to disk
-             try (FileOutputStream fos = new FileOutputStream(jks)) {
-                 ks.store(fos, password);
-             }
-         }
-     }
+  }
 }

--- a/src/test/java/redis/clients/jedis/scenario/RestEndpointUtil.java
+++ b/src/test/java/redis/clients/jedis/scenario/RestEndpointUtil.java
@@ -1,0 +1,26 @@
+package redis.clients.jedis.scenario;
+
+import redis.clients.jedis.Endpoint;
+import redis.clients.jedis.EndpointConfig;
+
+public class RestEndpointUtil {
+
+    public static Endpoint getRestAPIEndpoint(EndpointConfig config) {
+        return new Endpoint() {
+            @Override
+            public String getHost() {
+                // convert this to Redis FQDN by removing the node prefix
+                // "dns":"redis-10232.c1.taki-active-active-test-c114170a.cto.redislabs.com"
+                String host = config.getHost();
+                // trim until the first dot
+                return host.substring(host.indexOf('.') + 1);
+            }
+
+            @Override
+            public int getPort() {
+                // default port for REST API
+                return 9443;
+            }
+        };
+    }
+}

--- a/src/test/java/redis/clients/jedis/scenario/RestEndpointUtil.java
+++ b/src/test/java/redis/clients/jedis/scenario/RestEndpointUtil.java
@@ -5,22 +5,22 @@ import redis.clients.jedis.EndpointConfig;
 
 public class RestEndpointUtil {
 
-    public static Endpoint getRestAPIEndpoint(EndpointConfig config) {
-        return new Endpoint() {
-            @Override
-            public String getHost() {
-                // convert this to Redis FQDN by removing the node prefix
-                // "dns":"redis-10232.c1.taki-active-active-test-c114170a.cto.redislabs.com"
-                String host = config.getHost();
-                // trim until the first dot
-                return host.substring(host.indexOf('.') + 1);
-            }
+  public static Endpoint getRestAPIEndpoint(EndpointConfig config) {
+    return new Endpoint() {
+      @Override
+      public String getHost() {
+        // convert this to Redis FQDN by removing the node prefix
+        // "dns":"redis-10232.c1.taki-active-active-test-c114170a.cto.redislabs.com"
+        String host = config.getHost();
+        // trim until the first dot
+        return host.substring(host.indexOf('.') + 1);
+      }
 
-            @Override
-            public int getPort() {
-                // default port for REST API
-                return 9443;
-            }
-        };
-    }
+      @Override
+      public int getPort() {
+        // default port for REST API
+        return 9443;
+      }
+    };
+  }
 }


### PR DESCRIPTION
**Problem:**
LagAwareStrategy health checks to Redis Enterprise REST API (port 9443) required adding certificates to the default Java truststore for custom certificates, self-signed certificates. This approach is not ideal for application-specific SSL configuration.

**Solution:**
- Added SSL configuration support to `LagAwareStrategy.Config` builder
- SSL options include truststore, keystore, and verification modes (FULL, CA, INSECURE)

**Usage:**
```java
SslOptions sslOptions = SslOptions.builder()
    .truststore(new File("truststore.jks"), "password".toCharArray())
    .sslVerifyMode(SslVerifyMode.FULL)
    .build();

LagAwareStrategy.Config config = LagAwareStrategy.Config.builder(endpoint, credentials)
    .sslOptions(sslOptions)
    .build();
    
  Closes #4292 