### PR TITLE
[automatic failover] Set and test default values for failover config&components

### DIFF
--- a/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
+++ b/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
@@ -130,16 +130,16 @@ public final class MultiClusterClientConfig {
       .asList(JedisConnectionException.class);
 
   /** Default failure rate threshold percentage for circuit breaker activation. */
-  private static final float CIRCUIT_BREAKER_FAILURE_RATE_THRESHOLD_DEFAULT = 50.0f;
+  private static final float CIRCUIT_BREAKER_FAILURE_RATE_THRESHOLD_DEFAULT = 10.0f;
 
   /** Default minimum number of calls required before circuit breaker can calculate failure rate. */
-  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_MIN_CALLS_DEFAULT = 100;
+  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_MIN_CALLS_DEFAULT = 1000;
 
   /** Default sliding window type for circuit breaker failure tracking. */
   private static final SlidingWindowType CIRCUIT_BREAKER_SLIDING_WINDOW_TYPE_DEFAULT = SlidingWindowType.COUNT_BASED;
 
   /** Default sliding window size for circuit breaker failure tracking. */
-  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_SIZE_DEFAULT = 100;
+  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_SIZE_DEFAULT = 2;
 
   /** Default slow call duration threshold in milliseconds. */
   private static final int CIRCUIT_BREAKER_SLOW_CALL_DURATION_THRESHOLD_DEFAULT = 60000;
@@ -156,10 +156,10 @@ public final class MultiClusterClientConfig {
       .asList(CallNotPermittedException.class, ConnectionFailoverException.class);
 
   /** Default interval in milliseconds for checking if failed clusters have recovered. */
-  private static final long FAILBACK_CHECK_INTERVAL_DEFAULT = 5000;
+  private static final long FAILBACK_CHECK_INTERVAL_DEFAULT = 120000;
 
   /** Default grace period in milliseconds to keep clusters disabled after they become unhealthy. */
-  private static final long GRACE_PERIOD_DEFAULT = 10000;
+  private static final long GRACE_PERIOD_DEFAULT = 60000;
 
   /** Default maximum number of failover attempts. */
   private static final int MAX_NUM_FAILOVER_ATTEMPTS_DEFAULT = 10;

--- a/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
@@ -11,18 +11,19 @@ import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
 
 public class EchoStrategy implements HealthCheckStrategy {
+  private static final int MAX_HEALTH_CHECK_POOL_SIZE = 2;
 
   private final UnifiedJedis jedis;
   private final HealthCheckStrategy.Config config;
 
   public EchoStrategy(HostAndPort hostAndPort, JedisClientConfig jedisClientConfig) {
-    this(hostAndPort, jedisClientConfig, HealthCheckStrategy.Config.builder().build());
+    this(hostAndPort, jedisClientConfig, HealthCheckStrategy.Config.create());
   }
 
   public EchoStrategy(HostAndPort hostAndPort, JedisClientConfig jedisClientConfig,
       HealthCheckStrategy.Config config) {
     GenericObjectPoolConfig<Connection> poolConfig = new GenericObjectPoolConfig<>();
-    poolConfig.setMaxTotal(2);
+    poolConfig.setMaxTotal(MAX_HEALTH_CHECK_POOL_SIZE);
     this.jedis = new JedisPooled(hostAndPort, jedisClientConfig, poolConfig);
     this.config = config;
   }

--- a/src/main/java/redis/clients/jedis/mcf/HealthCheckStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/HealthCheckStrategy.java
@@ -49,6 +49,11 @@ public interface HealthCheckStrategy extends Closeable {
   int getDelayInBetweenProbes();
 
   public static class Config {
+    private static final int INTERVAL_DEFAULT = 5000;
+    private static final int TIMEOUT_DEFAULT = 1000;
+    private static final int NUM_PROBES_DEFAULT = 3;
+    private static final int DELAY_IN_BETWEEN_PROBES_DEFAULT = 500;
+    
     protected final int interval;
     protected final int timeout;
     protected final int numProbes;
@@ -97,14 +102,14 @@ public interface HealthCheckStrategy extends Closeable {
      * @return a new Config instance
      */
     public static Config create() {
-      return new Builder<>().build();
+      return builder().build();
     }
 
     /**
      * Create a new builder for HealthCheckStrategy.Config.
      * @return a new Builder instance
      */
-    public static Builder<?, Config> builder() {
+    public static Builder<?, ? extends Config> builder() {
       return new Builder<>();
     }
 
@@ -114,11 +119,11 @@ public interface HealthCheckStrategy extends Closeable {
      * @param <C> the config type being built
      */
     public static class Builder<T extends Builder<T, C>, C extends Config> {
-      protected int interval = 1000;
-      protected int timeout = 1000;
-      protected int numProbes = 3;
+      protected int interval = INTERVAL_DEFAULT;
+      protected int timeout = TIMEOUT_DEFAULT;
+      protected int numProbes = NUM_PROBES_DEFAULT;
       protected ProbingPolicy policy = ProbingPolicy.BuiltIn.ALL_SUCCESS;
-      protected int delayInBetweenProbes = 100;
+      protected int delayInBetweenProbes = DELAY_IN_BETWEEN_PROBES_DEFAULT;
 
       /**
        * Set the interval between health checks in milliseconds.

--- a/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
@@ -94,7 +94,7 @@ public class LagAwareStrategy implements HealthCheckStrategy {
   public static class Config extends HealthCheckStrategy.Config {
 
     public static final boolean EXTENDED_CHECK_DEFAULT = true;
-    public static final Duration AVAILABILITY_LAG_TOLERANCE_DEFAULT = Duration.ofMillis(100);
+    public static final Duration AVAILABILITY_LAG_TOLERANCE_DEFAULT = Duration.ofMillis(5000);
 
     private final Endpoint restEndpoint;
     private final Supplier<RedisCredentials> credentialsSupplier;
@@ -102,7 +102,7 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     // SSL configuration for HTTPS connections to Redis Enterprise REST API
     private final SslOptions sslOptions;
 
-    // Maximum acceptable lag in milliseconds (default: 100);
+    // Maximum acceptable lag in milliseconds (default: 5000);
     private final Duration availability_lag_tolerance;
 
     // Enable extended lag checking (default: true - performs lag validation in addition to standard
@@ -111,7 +111,7 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     private final boolean extendedCheckEnabled;
 
     public Config(Endpoint restEndpoint, Supplier<RedisCredentials> credentialsSupplier) {
-      this(builder(restEndpoint, credentialsSupplier).interval(1000).timeout(1000).numProbes(3)
+      this(builder(restEndpoint, credentialsSupplier)
           .availabilityLagTolerance(AVAILABILITY_LAG_TOLERANCE_DEFAULT)
           .extendedCheckEnabled(EXTENDED_CHECK_DEFAULT));
     }
@@ -155,6 +155,15 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     public static ConfigBuilder builder(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier) {
       return new ConfigBuilder(restEndpoint, credentialsSupplier);
+    }
+
+    /**
+     * Use {@link LagAwareStrategy.Config#builder(Endpoint, Supplier)} instead.
+     * @return a new Builder instance
+     */
+    public static ConfigBuilder builder() {
+      throw new UnsupportedOperationException(
+          "Endpoint and credentials are required to build LagAwareStrategy.Config.");
     }
 
     /**

--- a/src/test/java/redis/clients/jedis/mcf/DefaultValuesTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/DefaultValuesTest.java
@@ -1,0 +1,79 @@
+package redis.clients.jedis.mcf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.MultiClusterClientConfig;
+
+public class DefaultValuesTest {
+
+        HostAndPort fakeEndpoint = new HostAndPort("fake", 6379);
+        JedisClientConfig config = DefaultJedisClientConfig.builder().build();
+
+        @Test
+        void testDefaultValuesInConfig() {
+
+                MultiClusterClientConfig.ClusterConfig clusterConfig = MultiClusterClientConfig.ClusterConfig
+                                .builder(fakeEndpoint, config).build();
+                MultiClusterClientConfig multiConfig = new MultiClusterClientConfig.Builder(
+                                new MultiClusterClientConfig.ClusterConfig[] { clusterConfig })
+                                                .build();
+
+                // check for grace period
+                assertEquals(60000, multiConfig.getGracePeriod());
+
+                // check for cluster config
+                assertEquals(clusterConfig, multiConfig.getClusterConfigs()[0]);
+
+                // check healthchecks enabled
+                assertNotNull(clusterConfig.getHealthCheckStrategySupplier());
+
+                // check default healthcheck strategy is echo
+                assertEquals(EchoStrategy.DEFAULT, clusterConfig.getHealthCheckStrategySupplier());
+
+                // check number of probes
+                assertEquals(3, clusterConfig.getHealthCheckStrategySupplier()
+                                .get(fakeEndpoint, config).getNumProbes());
+
+                assertEquals(500, clusterConfig.getHealthCheckStrategySupplier()
+                                .get(fakeEndpoint, config).getDelayInBetweenProbes());
+
+                assertEquals(ProbingPolicy.BuiltIn.ALL_SUCCESS,
+                        clusterConfig.getHealthCheckStrategySupplier().get(fakeEndpoint, config)
+                                        .getPolicy());
+
+                // check health check interval
+                assertEquals(5000, clusterConfig.getHealthCheckStrategySupplier()
+                                .get(fakeEndpoint, config).getInterval());
+
+                // check lag aware tolerance
+                LagAwareStrategy.Config lagAwareConfig = LagAwareStrategy.Config
+                                .builder(fakeEndpoint, config.getCredentialsProvider()).build();
+                assertEquals(Duration.ofMillis(5000), lagAwareConfig.getAvailabilityLagTolerance());
+
+                // TODO: check CB number of failures threshold -- 1000
+                // assertEquals(1000, multiConfig.circuitBreakerMinNumOfFailures());
+
+                // check CB failure rate threshold
+                assertEquals(10, multiConfig.getCircuitBreakerFailureRateThreshold());
+
+                // check CB sliding window size
+                assertEquals(2, multiConfig.getCircuitBreakerSlidingWindowSize());
+
+                // check failback check interval
+                assertEquals(120000, multiConfig.getFailbackCheckInterval());
+
+                // check failover max attempts before give up
+                assertEquals(10, multiConfig.getMaxNumFailoverAttempts());
+
+                // check delay between failover attempts
+                assertEquals(12000, multiConfig.getDelayInBetweenFailoverAttempts());
+
+        }
+}

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
@@ -531,7 +531,7 @@ public class HealthCheckTest {
     // Test without config
     HealthCheckStrategy strategyWithoutConfig = supplier.get(testEndpoint, null);
     assertNotNull(strategyWithoutConfig);
-    assertEquals(1000, strategyWithoutConfig.getInterval()); // Default values
+    assertEquals(5000, strategyWithoutConfig.getInterval()); // Default values
     assertEquals(1000, strategyWithoutConfig.getTimeout());
   }
 


### PR DESCRIPTION
Simply sets default values in builders and configuration objects and adds unit tests for.