### PR TITLE
[automatic failover] Automatic failover client improvements (part 3)

### DIFF
--- a/docs/failover.md
+++ b/docs/failover.md
@@ -69,9 +69,8 @@ Then build a `MultiClusterPooledConnectionProvider`.
 
 ```java
 MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(clientConfigs);
-builder.circuitBreakerSlidingWindowSize(10); // Sliding window size in number of calls
-builder.circuitBreakerSlidingWindowMinCalls(1);
-builder.circuitBreakerFailureRateThreshold(50.0f); // percentage of failures to trigger circuit breaker
+builder.circuitBreakerSlidingWindowSize(2); // Sliding window size in number of calls
+builder.circuitBreakerFailureRateThreshold(10.0f); // percentage of failures to trigger circuit breaker
 
 builder.failbackSupported(true); // Enable failback
 builder.failbackCheckInterval(1000); // Check every second the unhealthy cluster to see if it has recovered
@@ -140,12 +139,9 @@ Jedis uses the following circuit breaker settings:
 
 | Setting                                 | Default value              | Description                                                                                                                                                                   |
 |-----------------------------------------|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Sliding window type                     | `COUNT_BASED`              | The type of sliding window used to record the outcome of calls. Options are `COUNT_BASED` and `TIME_BASED`.                                                                   |
-| Sliding window size                     | 100                        | The size of the sliding window. Units depend on sliding window type. When `COUNT_BASED`, the size represents number of calls. When `TIME_BASED`, the size represents seconds. |
-| Sliding window min calls                | 100                        | Minimum number of calls required (per sliding window period) before the CircuitBreaker will start calculating the error rate or slow call rate.                               |
-| Failure rate threshold                  | `50.0f`                    | Percentage of calls within the sliding window that must fail before the circuit breaker transitions to the `OPEN` state.                                                      |
-| Slow call duration threshold            | 60000 ms                   | Duration threshold above which calls are classified as slow and added to the sliding window.                                                                                  |
-| Slow call rate threshold                | `100.0f`                   | Percentage of calls within the sliding window that exceed the slow call duration threshold before circuit breaker transitions to the `OPEN` state.                            |
+| Sliding window size                     | 2                          | The size of the sliding window. Units depend on sliding window type. The size represents seconds. |
+| Threshold min number of failures        | 1000                       | Minimum number of failures before circuit breaker is tripped.                                                                                                                 |
+| Failure rate threshold                  | `10.0f`                    | Percentage of calls within the sliding window that must fail before the circuit breaker transitions to the `OPEN` state.                                                      |
 | Circuit breaker included exception list | [JedisConnectionException] | A list of Throwable classes that count as failures and add to the failure rate.                                                                                               |
 | Circuit breaker ignored exception list  | null                       | A list of Throwable classes to explicitly ignore for failure rate calculations.                                                                                               |                                                                                                               |
 

--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,9 @@
 						<include>src/main/java/redis/clients/jedis/MultiClusterClientConfig.java</include>
 						<include>src/main/java/redis/clients/jedis/HostAndPort.java</include>
 						<include>**/builders/*.java</include>
+						<include>**/MultiDb*.java</include>
+						<include>**/ClientTestUtil.java</include>
+						<include>**/ReflectionTestUtil.java</include>
 					</includes>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -482,15 +482,7 @@
 						<include>**/Endpoint.java</include>
 						<include>src/main/java/redis/clients/jedis/mcf/*.java</include>
 						<include>src/test/java/redis/clients/jedis/failover/*.java</include>
-						<include>**/mcf/EchoStrategyIntegrationTest.java</include>
-						<include>**/mcf/LagAwareStrategyUnitTest.java</include>
-						<include>**/mcf/RedisRestAPI*.java</include>
-						<include>**/mcf/ActiveActiveLocalFailoverTest*</include>
-						<include>**/mcf/FailbackMechanism*.java</include>
-						<include>**/mcf/PeriodicFailbackTest*.java</include>
-						<include>**/mcf/AutomaticFailoverTest*.java</include>
-						<include>**/mcf/MultiCluster*.java</include>
-						<include>**/mcf/StatusTracker*.java</include>
+						<include>src/test/java/redis/clients/jedis/mcf/*.java</include>
 						<include>**/Health*.java</include>
 						<include>**/*IT.java</include>
 						<include>**/scenario/RestEndpointUtil.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
 		<junit.version>5.13.4</junit.version>
 		<!-- Default JVM options for tests -->
 		<JVM_OPTS></JVM_OPTS>
+		<!-- Default excluded groups for tests - can be overridden from command line -->
+		<excludedGroupsForUnitTests>integration,scenario</excludedGroupsForUnitTests>
 	</properties>
 
 	<dependencyManagement>
@@ -335,7 +337,7 @@
 					<systemPropertyVariables>
 						<redis-hosts>${redis-hosts}</redis-hosts>
 					</systemPropertyVariables>
-					<excludedGroups>integration,scenario</excludedGroups>
+					<excludedGroups>${excludedGroupsForUnitTests}</excludedGroups>
 					<excludes>
 						<exclude>**/examples/*.java</exclude>
 						<exclude>**/scenario/*Test.java</exclude>

--- a/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
+++ b/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
@@ -279,7 +279,6 @@ public final class MultiClusterClientConfig {
    * <strong>Default:</strong> {@value #CIRCUIT_BREAKER_SLIDING_WINDOW_SIZE_DEFAULT}
    * </p>
    * @see #getCircuitBreakerSlidingWindowSize()
-   * @see #circuitBreakerSlidingWindowType
    */
   private int circuitBreakerSlidingWindowSize;
 
@@ -687,10 +686,10 @@ public final class MultiClusterClientConfig {
   public static class ClusterConfig {
 
     /** The Redis endpoint (host and port) for this cluster. */
-    private HostAndPort hostAndPort;
+    private final Endpoint endpoint;
 
     /** Jedis client configuration containing connection settings and authentication. */
-    private JedisClientConfig jedisClientConfig;
+    private final JedisClientConfig jedisClientConfig;
 
     /** Optional connection pool configuration for managing connections to this cluster. */
     private GenericObjectPoolConfig<Connection> connectionPoolConfig;
@@ -714,12 +713,12 @@ public final class MultiClusterClientConfig {
      * EchoStrategy for health checks. Use the {@link Builder} for more advanced configuration
      * options.
      * </p>
-     * @param hostAndPort the Redis endpoint (host and port)
+     * @param endpoint the Redis endpoint (host and port)
      * @param clientConfig the Jedis client configuration
-     * @throws IllegalArgumentException if hostAndPort or clientConfig is null
+     * @throws IllegalArgumentException if endpoint or clientConfig is null
      */
-    public ClusterConfig(HostAndPort hostAndPort, JedisClientConfig clientConfig) {
-      this.hostAndPort = hostAndPort;
+    public ClusterConfig(Endpoint endpoint, JedisClientConfig clientConfig) {
+      this.endpoint = endpoint;
       this.jedisClientConfig = clientConfig;
     }
 
@@ -729,14 +728,14 @@ public final class MultiClusterClientConfig {
      * This constructor allows specification of connection pool settings in addition to basic
      * endpoint configuration. Default weight of 1.0f and EchoStrategy for health checks are used.
      * </p>
-     * @param hostAndPort the Redis endpoint (host and port)
+     * @param endpoint the Redis endpoint (host and port)
      * @param clientConfig the Jedis client configuration
      * @param connectionPoolConfig the connection pool configuration
-     * @throws IllegalArgumentException if hostAndPort or clientConfig is null
+     * @throws IllegalArgumentException if endpoint or clientConfig is null
      */
-    public ClusterConfig(HostAndPort hostAndPort, JedisClientConfig clientConfig,
+    public ClusterConfig(Endpoint endpoint, JedisClientConfig clientConfig,
         GenericObjectPoolConfig<Connection> connectionPoolConfig) {
-      this.hostAndPort = hostAndPort;
+      this.endpoint = endpoint;
       this.jedisClientConfig = clientConfig;
       this.connectionPoolConfig = connectionPoolConfig;
     }
@@ -746,7 +745,7 @@ public final class MultiClusterClientConfig {
      * @param builder the builder containing configuration values
      */
     private ClusterConfig(Builder builder) {
-      this.hostAndPort = builder.hostAndPort;
+      this.endpoint = builder.endpoint;
       this.jedisClientConfig = builder.jedisClientConfig;
       this.connectionPoolConfig = builder.connectionPoolConfig;
       this.weight = builder.weight;
@@ -757,20 +756,20 @@ public final class MultiClusterClientConfig {
      * Returns the Redis endpoint (host and port) for this cluster.
      * @return the host and port information
      */
-    public HostAndPort getHostAndPort() {
-      return hostAndPort;
+    public Endpoint getEndpoint() {
+      return endpoint;
     }
 
     /**
      * Creates a new Builder instance for configuring a ClusterConfig.
-     * @param hostAndPort the Redis endpoint (host and port)
+     * @param endpoint the Redis endpoint (host and port)
      * @param clientConfig the Jedis client configuration
      * @return new Builder instance
-     * @throws IllegalArgumentException if hostAndPort or clientConfig is null
+     * @throws IllegalArgumentException if endpoint or clientConfig is null
      */
-    // TODO : Replace HostAndPort with Endpoint
-    public static Builder builder(HostAndPort hostAndPort, JedisClientConfig clientConfig) {
-      return new Builder(hostAndPort, clientConfig);
+
+    public static Builder builder(Endpoint endpoint, JedisClientConfig clientConfig) {
+      return new Builder(endpoint, clientConfig);
     }
 
     /**
@@ -833,7 +832,7 @@ public final class MultiClusterClientConfig {
      */
     public static class Builder {
       /** The Redis endpoint for this cluster configuration. */
-      private HostAndPort hostAndPort;
+      private Endpoint endpoint;
 
       /** The Jedis client configuration. */
       private JedisClientConfig jedisClientConfig;
@@ -849,12 +848,12 @@ public final class MultiClusterClientConfig {
 
       /**
        * Constructs a new Builder with required endpoint and client configuration.
-       * @param hostAndPort the Redis endpoint (host and port)
+       * @param endpoint the Redis endpoint (host and port)
        * @param clientConfig the Jedis client configuration
-       * @throws IllegalArgumentException if hostAndPort or clientConfig is null
+       * @throws IllegalArgumentException if endpoint or clientConfig is null
        */
-      public Builder(HostAndPort hostAndPort, JedisClientConfig clientConfig) {
-        this.hostAndPort = hostAndPort;
+      public Builder(Endpoint endpoint, JedisClientConfig clientConfig) {
+        this.endpoint = endpoint;
         this.jedisClientConfig = clientConfig;
       }
 
@@ -1104,12 +1103,8 @@ public final class MultiClusterClientConfig {
      * @return this builder
      */
     public Builder endpoint(Endpoint endpoint, float weight, JedisClientConfig clientConfig) {
-      // Convert Endpoint to HostAndPort for ClusterConfig
-      // TODO : Refactor ClusterConfig to accept Endpoint directly
-      HostAndPort hostAndPort = (endpoint instanceof HostAndPort) ? (HostAndPort) endpoint
-          : new HostAndPort(endpoint.getHost(), endpoint.getPort());
 
-      ClusterConfig clusterConfig = ClusterConfig.builder(hostAndPort, clientConfig).weight(weight)
+      ClusterConfig clusterConfig = ClusterConfig.builder(endpoint, clientConfig).weight(weight)
           .build();
 
       this.clusterConfigs.add(clusterConfig);

--- a/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
+++ b/src/main/java/redis/clients/jedis/MultiClusterClientConfig.java
@@ -130,16 +130,16 @@ public final class MultiClusterClientConfig {
       .asList(JedisConnectionException.class);
 
   /** Default failure rate threshold percentage for circuit breaker activation. */
-  private static final float CIRCUIT_BREAKER_FAILURE_RATE_THRESHOLD_DEFAULT = 50.0f;
+  private static final float CIRCUIT_BREAKER_FAILURE_RATE_THRESHOLD_DEFAULT = 10.0f;
 
   /** Default minimum number of calls required before circuit breaker can calculate failure rate. */
-  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_MIN_CALLS_DEFAULT = 100;
+  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_MIN_CALLS_DEFAULT = 1000;
 
   /** Default sliding window type for circuit breaker failure tracking. */
   private static final SlidingWindowType CIRCUIT_BREAKER_SLIDING_WINDOW_TYPE_DEFAULT = SlidingWindowType.COUNT_BASED;
 
   /** Default sliding window size for circuit breaker failure tracking. */
-  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_SIZE_DEFAULT = 100;
+  private static final int CIRCUIT_BREAKER_SLIDING_WINDOW_SIZE_DEFAULT = 2;
 
   /** Default slow call duration threshold in milliseconds. */
   private static final int CIRCUIT_BREAKER_SLOW_CALL_DURATION_THRESHOLD_DEFAULT = 60000;
@@ -156,10 +156,10 @@ public final class MultiClusterClientConfig {
       .asList(CallNotPermittedException.class, ConnectionFailoverException.class);
 
   /** Default interval in milliseconds for checking if failed clusters have recovered. */
-  private static final long FAILBACK_CHECK_INTERVAL_DEFAULT = 5000;
+  private static final long FAILBACK_CHECK_INTERVAL_DEFAULT = 120000;
 
   /** Default grace period in milliseconds to keep clusters disabled after they become unhealthy. */
-  private static final long GRACE_PERIOD_DEFAULT = 10000;
+  private static final long GRACE_PERIOD_DEFAULT = 60000;
 
   /** Default maximum number of failover attempts. */
   private static final int MAX_NUM_FAILOVER_ATTEMPTS_DEFAULT = 10;

--- a/src/main/java/redis/clients/jedis/MultiDbClient.java
+++ b/src/main/java/redis/clients/jedis/MultiDbClient.java
@@ -1,0 +1,288 @@
+package redis.clients.jedis;
+
+import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
+import redis.clients.jedis.annots.Experimental;
+import redis.clients.jedis.builders.MultiDbClientBuilder;
+import redis.clients.jedis.csc.Cache;
+import redis.clients.jedis.executors.CommandExecutor;
+import redis.clients.jedis.mcf.CircuitBreakerCommandExecutor;
+import redis.clients.jedis.mcf.MultiClusterPipeline;
+import redis.clients.jedis.mcf.MultiClusterTransaction;
+import redis.clients.jedis.providers.ConnectionProvider;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
+
+import java.util.Set;
+
+/**
+ * MultiDbClient provides high-availability Redis connectivity with automatic failover and failback
+ * capabilities across multiple weighted endpoints.
+ * <p>
+ * This client extends UnifiedJedis to support resilient operations with:
+ * <ul>
+ * <li><strong>Multi-Endpoint Support:</strong> Configure multiple Redis endpoints with individual
+ * weights</li>
+ * <li><strong>Automatic Failover:</strong> Seamless switching to backup endpoints when primary
+ * becomes unavailable</li>
+ * <li><strong>Circuit Breaker Pattern:</strong> Built-in circuit breaker to prevent cascading
+ * failures</li>
+ * <li><strong>Weight-Based Selection:</strong> Intelligent endpoint selection based on configured
+ * weights</li>
+ * <li><strong>Health Monitoring:</strong> Continuous health checks with automatic failback to
+ * recovered endpoints</li>
+ * <li><strong>Retry Logic:</strong> Configurable retry mechanisms with exponential backoff</li>
+ * </ul>
+ * <p>
+ * <strong>Usage Example:</strong>
+ * </p>
+ * 
+ * <pre>
+ * // Create multi-db client with multiple endpoints
+ * HostAndPort primary = new HostAndPort("localhost", 29379);
+ * HostAndPort secondary = new HostAndPort("localhost", 29380);
+ *
+ *
+ * MultiDbClient client = MultiDbClient.builder()
+ *                 .multiDbConfig(
+ *                         MultiClusterClientConfig.builder()
+ *                                 .endpoint(
+ *                                         ClusterConfig.builder(
+ *                                                         primary,
+ *                                                         DefaultJedisClientConfig.builder().build())
+ *                                                 .weight(100.0f)
+ *                                                 .build())
+ *                                 .endpoint(ClusterConfig.builder(
+ *                                                 secondary,
+ *                                                 DefaultJedisClientConfig.builder().build())
+ *                                         .weight(50.0f).build())
+ *                                 .circuitBreakerFailureRateThreshold(50.0f)
+ *                                 .retryMaxAttempts(3)
+ *                                 .build()
+ *                 )
+ *                 .databaseSwitchListener(event -&gt;
+ *                    System.out.println("Switched to: " + event.getEndpoint()))
+ *                 .build();
+ * 
+ * // Use like any other Jedis client
+ * client.set("key", "value");
+ * String value = client.get("key");
+ * 
+ * // Automatic failover happens transparently
+ * client.close();
+ * </pre>
+ * <p>
+ * The client automatically handles endpoint failures and recoveries, providing transparent high
+ * availability for Redis operations. All standard Jedis operations are supported with the added
+ * resilience features.
+ * </p>
+ * @author Ivo Gaydazhiev
+ * @since 5.2.0
+ * @see MultiClusterPooledConnectionProvider
+ * @see CircuitBreakerCommandExecutor
+ * @see MultiClusterClientConfig
+ */
+@Experimental
+public class MultiDbClient extends UnifiedJedis {
+
+  /**
+   * Creates a MultiDbClient with custom components.
+   * <p>
+   * This constructor allows full customization of the client components and is primarily used by
+   * the builder pattern for advanced configurations. For most use cases, prefer using
+   * {@link #builder()} to create instances.
+   * </p>
+   * @param commandExecutor the command executor (typically CircuitBreakerCommandExecutor)
+   * @param connectionProvider the connection provider (typically
+   *          MultiClusterPooledConnectionProvider)
+   * @param commandObjects the command objects
+   * @param redisProtocol the Redis protocol version
+   * @param cache the client-side cache (may be null)
+   */
+  MultiDbClient(CommandExecutor commandExecutor, ConnectionProvider connectionProvider,
+      CommandObjects commandObjects, RedisProtocol redisProtocol, Cache cache) {
+    super(commandExecutor, connectionProvider, commandObjects, redisProtocol, cache);
+  }
+
+  /**
+   * Returns the underlying MultiClusterPooledConnectionProvider.
+   * <p>
+   * This provides access to multi-cluster specific operations like manual failover, health status
+   * monitoring, and cluster switch event handling.
+   * </p>
+   * @return the multi-cluster connection provider
+   * @throws ClassCastException if the provider is not a MultiClusterPooledConnectionProvider
+   */
+  private MultiClusterPooledConnectionProvider getMultiClusterProvider() {
+    return (MultiClusterPooledConnectionProvider) this.provider;
+  }
+
+  /**
+   * Manually switches to the specified endpoint.
+   * <p>
+   * This method allows manual failover to a specific endpoint, bypassing the automatic weight-based
+   * selection. The switch will only succeed if the target endpoint is healthy.
+   * </p>
+   * @param endpoint the endpoint to switch to
+   */
+  public void setActiveDatabase(Endpoint endpoint) {
+    getMultiClusterProvider().setActiveCluster(endpoint);
+  }
+
+  /**
+   * Adds a pre-configured cluster configuration.
+   * <p>
+   * This method allows adding a fully configured ClusterConfig instance, providing maximum
+   * flexibility for advanced configurations including custom health check strategies, connection
+   * pool settings, etc.
+   * </p>
+   * @param clusterConfig the pre-configured cluster configuration
+   */
+  public void addEndpoint(ClusterConfig clusterConfig) {
+    getMultiClusterProvider().add(clusterConfig);
+  }
+
+  /**
+   * Dynamically adds a new cluster endpoint to the resilient client.
+   * <p>
+   * This allows adding new endpoints at runtime without recreating the client. The new endpoint
+   * will be available for failover operations immediately after being added and passing health
+   * checks (if configured).
+   * </p>
+   * @param endpoint the Redis server endpoint
+   * @param weight the weight for this endpoint (higher values = higher priority)
+   * @param clientConfig the client configuration for this endpoint
+   * @throws redis.clients.jedis.exceptions.JedisValidationException if the endpoint already exists
+   */
+  public void addEndpoint(Endpoint endpoint, float weight, JedisClientConfig clientConfig) {
+    // Convert Endpoint to HostAndPort for ClusterConfig
+    HostAndPort hostAndPort = (endpoint instanceof HostAndPort) ? (HostAndPort) endpoint
+        : new HostAndPort(endpoint.getHost(), endpoint.getPort());
+
+    ClusterConfig clusterConfig = ClusterConfig.builder(hostAndPort, clientConfig).weight(weight)
+        .build();
+
+    getMultiClusterProvider().add(clusterConfig);
+  }
+
+  /**
+   * Returns the set of all configured endpoints.
+   * <p>
+   * This method provides a view of all endpoints currently configured in the resilient client.
+   * </p>
+   * @return the set of all configured endpoints
+   */
+  public Set<Endpoint> getEndpoints() {
+    return getMultiClusterProvider().getEndpoints();
+  }
+
+  /**
+   * Returns the health status of the specified endpoint.
+   * <p>
+   * This method provides the current health status of a specific endpoint.
+   * </p>
+   * @param endpoint the endpoint to check
+   * @return the health status of the endpoint
+   */
+  public boolean isHealthy(Endpoint endpoint) {
+    return getMultiClusterProvider().isHealthy(endpoint);
+  }
+
+  /**
+   * Dynamically removes a cluster endpoint from the resilient client.
+   * <p>
+   * This allows removing endpoints at runtime. If the removed endpoint is currently active, the
+   * client will automatically failover to the next available healthy endpoint based on weight
+   * priority.
+   * </p>
+   * @param endpoint the endpoint to remove
+   * @throws redis.clients.jedis.exceptions.JedisValidationException if the endpoint doesn't exist
+   * @throws redis.clients.jedis.exceptions.JedisException if removing the endpoint would leave no
+   *           healthy clusters available
+   */
+  public void removeEndpoint(Endpoint endpoint) {
+    getMultiClusterProvider().remove(endpoint);
+  }
+
+  /**
+   * Forces the client to switch to a specific endpoint for a duration.
+   * <p>
+   * This method forces the client to use the specified endpoint and puts all other endpoints in a
+   * grace period, preventing automatic failover for the specified duration. This is useful for
+   * maintenance scenarios or testing specific endpoints.
+   * </p>
+   * @param endpoint the endpoint to force as active
+   * @param forcedActiveDurationMs the duration in milliseconds to keep this endpoint forced
+   * @throws redis.clients.jedis.exceptions.JedisValidationException if the endpoint is not healthy
+   *           or doesn't exist
+   */
+  public void forceActiveEndpoint(Endpoint endpoint, long forcedActiveDurationMs) {
+    getMultiClusterProvider().forceActiveCluster(endpoint, forcedActiveDurationMs);
+  }
+
+  /**
+   * Creates a new pipeline for batch operations with multi-cluster support.
+   * <p>
+   * The returned pipeline supports the same resilience features as the main client, including
+   * automatic failover during batch execution.
+   * </p>
+   * @return a new MultiClusterPipeline instance
+   */
+  @Override
+  public MultiClusterPipeline pipelined() {
+    return new MultiClusterPipeline(getMultiClusterProvider(), commandObjects);
+  }
+
+  /**
+   * Creates a new transaction with multi-cluster support.
+   * <p>
+   * The returned transaction supports the same resilience features as the main client, including
+   * automatic failover during transaction execution.
+   * </p>
+   * @return a new MultiClusterTransaction instance
+   */
+  @Override
+  public MultiClusterTransaction multi() {
+    return new MultiClusterTransaction((MultiClusterPooledConnectionProvider) provider, true,
+        commandObjects);
+  }
+
+  /**
+   * @param doMulti {@code false} should be set to enable manual WATCH, UNWATCH and MULTI
+   * @return transaction object
+   */
+  @Override
+  public MultiClusterTransaction transaction(boolean doMulti) {
+    if (provider == null) {
+      throw new IllegalStateException(
+          "It is not allowed to create Transaction from this " + getClass());
+    }
+
+    return new MultiClusterTransaction(getMultiClusterProvider(), doMulti, commandObjects);
+  }
+
+  public Endpoint getActiveEndpoint() {
+    return getMultiClusterProvider().getCluster().getEndpoint();
+  }
+
+  /**
+   * Fluent builder for {@link MultiDbClient}.
+   * <p>
+   * Obtain an instance via {@link #builder()}.
+   * </p>
+   */
+  public static class Builder extends MultiDbClientBuilder<MultiDbClient> {
+
+    @Override
+    protected MultiDbClient createClient() {
+      return new MultiDbClient(commandExecutor, connectionProvider, commandObjects,
+          clientConfig.getRedisProtocol(), cache);
+    }
+  }
+
+  /**
+   * Create a new builder for configuring MultiDbClient instances.
+   * @return a new {@link MultiDbClient.Builder} instance
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+}

--- a/src/main/java/redis/clients/jedis/MultiDbClient.java
+++ b/src/main/java/redis/clients/jedis/MultiDbClient.java
@@ -153,11 +153,7 @@ public class MultiDbClient extends UnifiedJedis {
    * @throws redis.clients.jedis.exceptions.JedisValidationException if the endpoint already exists
    */
   public void addEndpoint(Endpoint endpoint, float weight, JedisClientConfig clientConfig) {
-    // Convert Endpoint to HostAndPort for ClusterConfig
-    HostAndPort hostAndPort = (endpoint instanceof HostAndPort) ? (HostAndPort) endpoint
-        : new HostAndPort(endpoint.getHost(), endpoint.getPort());
-
-    ClusterConfig clusterConfig = ClusterConfig.builder(hostAndPort, clientConfig).weight(weight)
+    ClusterConfig clusterConfig = ClusterConfig.builder(endpoint, clientConfig).weight(weight)
         .build();
 
     getMultiClusterProvider().add(clusterConfig);

--- a/src/main/java/redis/clients/jedis/builders/MultiDbClientBuilder.java
+++ b/src/main/java/redis/clients/jedis/builders/MultiDbClientBuilder.java
@@ -1,0 +1,139 @@
+package redis.clients.jedis.builders;
+
+import java.util.function.Consumer;
+
+import redis.clients.jedis.MultiClusterClientConfig;
+import redis.clients.jedis.annots.Experimental;
+import redis.clients.jedis.executors.CommandExecutor;
+import redis.clients.jedis.mcf.CircuitBreakerCommandExecutor;
+import redis.clients.jedis.mcf.ClusterSwitchEventArgs;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
+import redis.clients.jedis.providers.ConnectionProvider;
+
+/**
+ * Builder for creating multi-db Redis clients with multi-endpoint support.
+ * <p>
+ * This builder provides methods specific to multi-db Redis deployments, including multiple weighted
+ * endpoints, circuit breaker configuration, health checks, and automatic failover/failback
+ * capabilities.
+ * </p>
+ * <p>
+ * <strong>Key Features:</strong>
+ * </p>
+ * <ul>
+ * <li><strong>Multi-Endpoint Configuration:</strong> Add multiple Redis endpoints with individual
+ * weights</li>
+ * <li><strong>Circuit Breaker Integration:</strong> Built-in circuit breaker with configurable
+ * thresholds</li>
+ * <li><strong>Health Monitoring:</strong> Automatic health checks with configurable strategies</li>
+ * <li><strong>Event Handling:</strong> Listen to cluster switch events for monitoring and
+ * alerting</li>
+ * <li><strong>Flexible Configuration:</strong> Support for both simple and advanced multi-cluster
+ * configurations</li>
+ * </ul>
+ * <p>
+ * <strong>Usage Examples:</strong>
+ * </p>
+ *
+ * <pre>
+ * MultiDbClient client = MultiDbClient.builder()
+ *                 .multiDbConfig(
+ *                         MultiClusterClientConfig.builder()
+ *                                 .endpoint(
+ *                                         ClusterConfig.builder(
+ *                                                         east,
+ *                                                         DefaultJedisClientConfig.builder().credentials(credentialsEast).build())
+ *                                                 .weight(100.0f)
+ *                                                 .build())
+ *                                 .endpoint(ClusterConfig.builder(
+ *                                                 west,
+ *                                                 DefaultJedisClientConfig.builder().credentials(credentialsWest).build())
+ *                                         .weight(50.0f).build())
+ *                                 .circuitBreakerFailureRateThreshold(50.0f)
+ *                                 .retryMaxAttempts(3)
+ *                                 .build()
+ *                 )
+ *                 .databaseSwitchListener(event -&gt;
+ *                     System.out.println("Switched to: " + event.getEndpoint()))
+ *                 .build();
+ * </pre>
+ * 
+ * @param <C> the client type that this builder creates
+ * @author Ivo Gaydazhiev
+ * @since 5.2.0
+ */
+@Experimental
+public abstract class MultiDbClientBuilder<C>
+    extends AbstractClientBuilder<MultiDbClientBuilder<C>, C> {
+
+  // Multi-db specific configuration fields
+  private MultiClusterClientConfig multiDbConfig = null;
+  private Consumer<ClusterSwitchEventArgs> databaseSwitchListener = null;
+
+  /**
+   * Sets the multi-database configuration.
+   * <p>
+   * This configuration controls circuit breaker behavior, retry logic, health checks, failback
+   * settings, and other resilience features. If not provided, default configuration will be used.
+   * </p>
+   * @param config the multi-database configuration
+   * @return this builder
+   */
+  public MultiDbClientBuilder<C> multiDbConfig(MultiClusterClientConfig config) {
+    this.multiDbConfig = config;
+    return this;
+  }
+
+  /**
+   * Sets a listener for database switch events.
+   * <p>
+   * The listener will be called whenever the client switches from one endpoint to another,
+   * providing information about the switch reason and the new active endpoint. This is useful for
+   * monitoring, alerting, and logging purposes.
+   * </p>
+   * @param listener the database switch event listener
+   * @return this builder
+   */
+  public MultiDbClientBuilder<C> databaseSwitchListener(Consumer<ClusterSwitchEventArgs> listener) {
+    this.databaseSwitchListener = listener;
+    return this;
+  }
+
+  @Override
+  protected MultiDbClientBuilder<C> self() {
+    return this;
+  }
+
+  @Override
+  protected ConnectionProvider createDefaultConnectionProvider() {
+
+    if (this.multiDbConfig == null || this.multiDbConfig.getClusterConfigs() == null
+        || this.multiDbConfig.getClusterConfigs().length < 1) {
+      throw new IllegalArgumentException("At least one endpoint must be specified");
+    }
+
+    // Create the multi-cluster connection provider
+    MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(
+        multiDbConfig);
+
+    // Set database switch listener if provided
+    if (this.databaseSwitchListener != null) {
+      provider.setClusterSwitchListener(this.databaseSwitchListener);
+    }
+
+    return provider;
+  }
+
+  @Override
+  protected CommandExecutor createDefaultCommandExecutor() {
+    // For multi-db clients, we always use CircuitBreakerCommandExecutor
+    return new CircuitBreakerCommandExecutor(
+        (MultiClusterPooledConnectionProvider) this.connectionProvider);
+  }
+
+  @Override
+  protected void validateSpecificConfiguration() {
+
+  }
+
+}

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerFailoverBase.java
@@ -1,8 +1,10 @@
 package redis.clients.jedis.mcf;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
 import redis.clients.jedis.util.IOUtils;
@@ -79,4 +81,13 @@ public class CircuitBreakerFailoverBase implements AutoCloseable {
     }
   }
 
+  boolean isActiveCluster(Cluster cluster) {
+    Cluster activeCluster = provider.getCluster();
+    return activeCluster != null && activeCluster.equals(cluster);
+  }
+
+  static boolean isCircuitBreakerTrackedException(Exception e, Cluster cluster) {
+    return cluster.getCircuitBreaker().getCircuitBreakerConfig().getRecordExceptionPredicate()
+        .test(e);
+  }
 }

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsAdapter.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsAdapter.java
@@ -1,0 +1,84 @@
+package redis.clients.jedis.mcf;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
+import redis.clients.jedis.MultiClusterClientConfig;
+
+/**
+ * Adapter that disables Resilience4j's built-in circuit breaker evaluation and help delegate
+ * threshold decisions to Jedis's custom dual-threshold logic.
+ * <p>
+ * This adapter sets maximum values for failure rate (100%) and minimum calls (Integer.MAX_VALUE) to
+ * effectively disable Resilience4j's automatic circuit breaker transitions, allowing
+ * {@link MultiClusterPooledConnectionProvider.Cluster#evaluateThresholds(boolean)} to control when
+ * the circuit breaker opens based on both minimum failure count AND failure rate.
+ * </p>
+ * @see MultiClusterPooledConnectionProvider.Cluster#evaluateThresholds(boolean)
+ */
+class CircuitBreakerThresholdsAdapter {
+  /** Maximum failure rate threshold (100%) to disable Resilience4j evaluation */
+  private static final float FAILURE_RATE_TRESHOLD_MAX = 100.0f;
+
+  /** Always set to 100% to disable Resilience4j's rate-based evaluation */
+  private float failureRateThreshold;
+
+  /** Always set to Integer.MAX_VALUE to disable Resilience4j's call-count evaluation */
+  private int minimumNumberOfCalls;
+
+  /** Sliding window size from configuration for metrics collection */
+  private int slidingWindowSize;
+
+  /**
+   * Returns Integer.MAX_VALUE to disable Resilience4j's minimum call evaluation.
+   * @return Integer.MAX_VALUE to prevent automatic circuit breaker evaluation
+   */
+  int getMinimumNumberOfCalls() {
+    return minimumNumberOfCalls;
+  }
+
+  /**
+   * Returns 100% to disable Resilience4j's failure rate evaluation.
+   * @return 100.0f to prevent automatic circuit breaker evaluation
+   */
+  float getFailureRateThreshold() {
+    return failureRateThreshold;
+  }
+
+  /**
+   * Returns TIME_BASED sliding window type for metrics collection.
+   * @return SlidingWindowType.TIME_BASED
+   */
+  SlidingWindowType getSlidingWindowType() {
+    return SlidingWindowType.TIME_BASED;
+  }
+
+  /**
+   * Returns the sliding window size for metrics collection.
+   * @return sliding window size in seconds
+   */
+  int getSlidingWindowSize() {
+    return slidingWindowSize;
+  }
+
+  /**
+   * Creates an adapter that disables Resilience4j's circuit breaker evaluation.
+   * <p>
+   * Sets failure rate to 100% and minimum calls to Integer.MAX_VALUE to ensure Resilience4j never
+   * automatically opens the circuit breaker. Instead, Jedis's custom {@code evaluateThresholds()}
+   * method controls circuit breaker state based on the original configuration's dual-threshold
+   * logic.
+   * </p>
+   * @param multiClusterClientConfig configuration containing sliding window size
+   */
+  CircuitBreakerThresholdsAdapter(MultiClusterClientConfig multiClusterClientConfig) {
+
+    // IMPORTANT: failureRateThreshold is set to max theoretically disable Resilience4j's evaluation
+    // and rely on our custom evaluateThresholds() logic.
+    failureRateThreshold = FAILURE_RATE_TRESHOLD_MAX;
+
+    // IMPORTANT: minimumNumberOfCalls is set to max theoretically disable Resilience4j's evaluation
+    // and rely on our custom evaluateThresholds() logic.
+    minimumNumberOfCalls = Integer.MAX_VALUE;
+
+    slidingWindowSize = multiClusterClientConfig.getCircuitBreakerSlidingWindowSize();
+  }
+}

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsAdapter.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsAdapter.java
@@ -73,7 +73,7 @@ class CircuitBreakerThresholdsAdapter {
 
     // IMPORTANT: failureRateThreshold is set to max theoretically disable Resilience4j's evaluation
     // and rely on our custom evaluateThresholds() logic.
-    failureRateThreshold = FAILURE_RATE_TRESHOLD_MAX;
+    failureRateThreshold = FAILURE_RATE_THRESHOLD_MAX;
 
     // IMPORTANT: minimumNumberOfCalls is set to max theoretically disable Resilience4j's evaluation
     // and rely on our custom evaluateThresholds() logic.

--- a/src/main/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsAdapter.java
+++ b/src/main/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsAdapter.java
@@ -16,7 +16,7 @@ import redis.clients.jedis.MultiClusterClientConfig;
  */
 class CircuitBreakerThresholdsAdapter {
   /** Maximum failure rate threshold (100%) to disable Resilience4j evaluation */
-  private static final float FAILURE_RATE_TRESHOLD_MAX = 100.0f;
+  private static final float FAILURE_RATE_THRESHOLD_MAX = 100.0f;
 
   /** Always set to 100% to disable Resilience4j's rate-based evaluation */
   private float failureRateThreshold;

--- a/src/main/java/redis/clients/jedis/mcf/ClusterSwitchEventArgs.java
+++ b/src/main/java/redis/clients/jedis/mcf/ClusterSwitchEventArgs.java
@@ -11,6 +11,7 @@ public class ClusterSwitchEventArgs {
 
   public ClusterSwitchEventArgs(SwitchReason reason, Endpoint endpoint, Cluster cluster) {
     this.reason = reason;
+    // TODO: @ggivo do we need cluster name?
     this.ClusterName = cluster.getCircuitBreaker().getName();
     this.Endpoint = endpoint;
   }

--- a/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/EchoStrategy.java
@@ -11,18 +11,19 @@ import redis.clients.jedis.UnifiedJedis;
 import redis.clients.jedis.MultiClusterClientConfig.StrategySupplier;
 
 public class EchoStrategy implements HealthCheckStrategy {
+  private static final int MAX_HEALTH_CHECK_POOL_SIZE = 2;
 
   private final UnifiedJedis jedis;
   private final HealthCheckStrategy.Config config;
 
   public EchoStrategy(HostAndPort hostAndPort, JedisClientConfig jedisClientConfig) {
-    this(hostAndPort, jedisClientConfig, HealthCheckStrategy.Config.builder().build());
+    this(hostAndPort, jedisClientConfig, HealthCheckStrategy.Config.create());
   }
 
   public EchoStrategy(HostAndPort hostAndPort, JedisClientConfig jedisClientConfig,
       HealthCheckStrategy.Config config) {
     GenericObjectPoolConfig<Connection> poolConfig = new GenericObjectPoolConfig<>();
-    poolConfig.setMaxTotal(2);
+    poolConfig.setMaxTotal(MAX_HEALTH_CHECK_POOL_SIZE);
     this.jedis = new JedisPooled(hostAndPort, jedisClientConfig, poolConfig);
     this.config = config;
   }

--- a/src/main/java/redis/clients/jedis/mcf/HealthCheckStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/HealthCheckStrategy.java
@@ -49,6 +49,11 @@ public interface HealthCheckStrategy extends Closeable {
   int getDelayInBetweenProbes();
 
   public static class Config {
+    private static final int INTERVAL_DEFAULT = 5000;
+    private static final int TIMEOUT_DEFAULT = 1000;
+    private static final int NUM_PROBES_DEFAULT = 3;
+    private static final int DELAY_IN_BETWEEN_PROBES_DEFAULT = 500;
+
     protected final int interval;
     protected final int timeout;
     protected final int numProbes;
@@ -97,14 +102,14 @@ public interface HealthCheckStrategy extends Closeable {
      * @return a new Config instance
      */
     public static Config create() {
-      return new Builder<>().build();
+      return builder().build();
     }
 
     /**
      * Create a new builder for HealthCheckStrategy.Config.
      * @return a new Builder instance
      */
-    public static Builder<?, Config> builder() {
+    public static Builder<?, ? extends Config> builder() {
       return new Builder<>();
     }
 
@@ -114,11 +119,11 @@ public interface HealthCheckStrategy extends Closeable {
      * @param <C> the config type being built
      */
     public static class Builder<T extends Builder<T, C>, C extends Config> {
-      protected int interval = 1000;
-      protected int timeout = 1000;
-      protected int numProbes = 3;
+      protected int interval = INTERVAL_DEFAULT;
+      protected int timeout = TIMEOUT_DEFAULT;
+      protected int numProbes = NUM_PROBES_DEFAULT;
       protected ProbingPolicy policy = ProbingPolicy.BuiltIn.ALL_SUCCESS;
-      protected int delayInBetweenProbes = 100;
+      protected int delayInBetweenProbes = DELAY_IN_BETWEEN_PROBES_DEFAULT;
 
       /**
        * Set the interval between health checks in milliseconds.

--- a/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
+++ b/src/main/java/redis/clients/jedis/mcf/LagAwareStrategy.java
@@ -94,7 +94,7 @@ public class LagAwareStrategy implements HealthCheckStrategy {
   public static class Config extends HealthCheckStrategy.Config {
 
     public static final boolean EXTENDED_CHECK_DEFAULT = true;
-    public static final Duration AVAILABILITY_LAG_TOLERANCE_DEFAULT = Duration.ofMillis(100);
+    public static final Duration AVAILABILITY_LAG_TOLERANCE_DEFAULT = Duration.ofMillis(5000);
 
     private final Endpoint restEndpoint;
     private final Supplier<RedisCredentials> credentialsSupplier;
@@ -102,7 +102,7 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     // SSL configuration for HTTPS connections to Redis Enterprise REST API
     private final SslOptions sslOptions;
 
-    // Maximum acceptable lag in milliseconds (default: 100);
+    // Maximum acceptable lag in milliseconds (default: 5000);
     private final Duration availability_lag_tolerance;
 
     // Enable extended lag checking (default: true - performs lag validation in addition to standard
@@ -111,7 +111,7 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     private final boolean extendedCheckEnabled;
 
     public Config(Endpoint restEndpoint, Supplier<RedisCredentials> credentialsSupplier) {
-      this(builder(restEndpoint, credentialsSupplier).interval(1000).timeout(1000).numProbes(3)
+      this(builder(restEndpoint, credentialsSupplier)
           .availabilityLagTolerance(AVAILABILITY_LAG_TOLERANCE_DEFAULT)
           .extendedCheckEnabled(EXTENDED_CHECK_DEFAULT));
     }
@@ -155,6 +155,15 @@ public class LagAwareStrategy implements HealthCheckStrategy {
     public static ConfigBuilder builder(Endpoint restEndpoint,
         Supplier<RedisCredentials> credentialsSupplier) {
       return new ConfigBuilder(restEndpoint, credentialsSupplier);
+    }
+
+    /**
+     * Use {@link LagAwareStrategy.Config#builder(Endpoint, Supplier)} instead.
+     * @return a new Builder instance
+     */
+    public static ConfigBuilder builder() {
+      throw new UnsupportedOperationException(
+          "Endpoint and credentials are required to build LagAwareStrategy.Config.");
     }
 
     /**

--- a/src/main/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProvider.java
@@ -12,8 +12,10 @@ import io.github.resilience4j.retry.RetryRegistry;
 
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -49,7 +51,7 @@ import redis.clients.jedis.util.Pool;
  *         isolated connection pool. With this ConnectionProvider users can seamlessly failover to
  *         Disaster Recovery (DR), Backup, and Active-Active cluster(s) by using simple
  *         configuration which is passed through from Resilience4j -
- *         https://resilience4j.readme.io/docs
+ *         <a href="https://resilience4j.readme.io/docs">docs</a>
  *         <p>
  *         Support for manual failback is provided by way of {@link #setActiveCluster(Endpoint)}
  *         <p>
@@ -321,11 +323,11 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
       // Register listeners BEFORE adding clusters to avoid missing events
       healthStatusManager.registerListener(config.getHostAndPort(), this::onHealthStatusChange);
       HealthCheck hc = healthStatusManager.add(config.getHostAndPort(), hcs);
-      cluster = new Cluster(pool, retry, hc, circuitBreaker, config.getWeight(),
-          multiClusterClientConfig);
+      cluster = new Cluster(config.getHostAndPort(), pool, retry, hc, circuitBreaker,
+          config.getWeight(), multiClusterClientConfig);
     } else {
-      cluster = new Cluster(pool, retry, circuitBreaker, config.getWeight(),
-          multiClusterClientConfig);
+      cluster = new Cluster(config.getHostAndPort(), pool, retry, circuitBreaker,
+          config.getWeight(), multiClusterClientConfig);
     }
 
     multiClusterMap.put(config.getHostAndPort(), cluster);
@@ -564,6 +566,14 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     }
   }
 
+  /**
+   * Returns the set of all configured endpoints.
+   * @return
+   */
+  public Set<Endpoint> getEndpoints() {
+    return new HashSet<>(multiClusterMap.keySet());
+  }
+
   public void setActiveCluster(Endpoint endpoint) {
     if (endpoint == null) {
       throw new JedisValidationException(
@@ -581,6 +591,12 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
 
   public void forceActiveCluster(Endpoint endpoint, long forcedActiveDuration) {
     Cluster cluster = multiClusterMap.get(endpoint);
+
+    if (cluster == null) {
+      throw new JedisValidationException("Provided endpoint: " + endpoint + " is not within "
+          + "the configured endpoints. Please use one from the configuration");
+    }
+
     cluster.clearGracePeriod();
     if (!cluster.isHealthy()) {
       throw new JedisValidationException("Provided endpoint: " + endpoint
@@ -685,6 +701,31 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     return multiClusterMap.get(endpoint);
   }
 
+  /**
+   * Returns the active endpoint
+   * <p>
+   * Active endpoint is the one which is currently being used for all operations. It can change at
+   * any time due to health checks, failover, failback, etc.
+   * @return the active cluster endpoint
+   */
+  public Endpoint getActiveEndpoint() {
+    return activeCluster.getEndpoint();
+  }
+
+  /**
+   * Returns the health state of the given endpoint
+   * @param endpoint the endpoint to check
+   * @return the health status of the endpoint
+   */
+  public boolean isHealthy(Endpoint endpoint) {
+    Cluster cluster = getCluster(endpoint);
+    if (cluster == null) {
+      throw new JedisValidationException(
+          "Endpoint " + endpoint + " does not exist in the provider");
+    }
+    return cluster.isHealthy();
+  }
+
   public CircuitBreaker getClusterCircuitBreaker() {
     return activeCluster.getCircuitBreaker();
   }
@@ -723,15 +764,17 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
     private final HealthCheck healthCheck;
     private final MultiClusterClientConfig multiClusterClientConfig;
     private boolean disabled = false;
+    private final Endpoint endpoint;
 
     // Grace period tracking
     private volatile long gracePeriodEndsAt = 0;
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private Cluster(TrackingConnectionPool connectionPool, Retry retry,
+    private Cluster(Endpoint endpoint, TrackingConnectionPool connectionPool, Retry retry,
         CircuitBreaker circuitBreaker, float weight,
         MultiClusterClientConfig multiClusterClientConfig) {
 
+      this.endpoint = endpoint;
       this.connectionPool = connectionPool;
       this.retry = retry;
       this.circuitBreaker = circuitBreaker;
@@ -740,16 +783,21 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
       this.healthCheck = null;
     }
 
-    private Cluster(TrackingConnectionPool connectionPool, Retry retry, HealthCheck hc,
-        CircuitBreaker circuitBreaker, float weight,
+    private Cluster(Endpoint endpoint, TrackingConnectionPool connectionPool, Retry retry,
+        HealthCheck hc, CircuitBreaker circuitBreaker, float weight,
         MultiClusterClientConfig multiClusterClientConfig) {
 
+      this.endpoint = endpoint;
       this.connectionPool = connectionPool;
       this.retry = retry;
       this.circuitBreaker = circuitBreaker;
       this.weight = weight;
       this.multiClusterClientConfig = multiClusterClientConfig;
       this.healthCheck = hc;
+    }
+
+    public Endpoint getEndpoint() {
+      return endpoint;
     }
 
     public Connection getConnection() {
@@ -886,5 +934,6 @@ public class MultiClusterPooledConnectionProvider implements ConnectionProvider 
           + retry + ", circuitBreaker=" + circuitBreaker + ", weight=" + weight + ", healthStatus="
           + getHealthStatus() + ", multiClusterClientConfig=" + multiClusterClientConfig + '}';
     }
+
   }
 }

--- a/src/test/java/redis/clients/jedis/MultiDbClientTest.java
+++ b/src/test/java/redis/clients/jedis/MultiDbClientTest.java
@@ -1,0 +1,206 @@
+package redis.clients.jedis;
+
+import eu.rekawek.toxiproxy.Proxy;
+import eu.rekawek.toxiproxy.ToxiproxyClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.*;
+
+import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
+import redis.clients.jedis.exceptions.JedisValidationException;
+import redis.clients.jedis.mcf.ClusterSwitchEventArgs;
+import redis.clients.jedis.mcf.SwitchReason;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Basic tests for MultiDbClient functionality.
+ */
+@Tag("integration")
+public class MultiDbClientTest {
+
+  private MultiDbClient client;
+  private static final EndpointConfig endpoint1 = HostAndPorts.getRedisEndpoint("redis-failover-1");
+  private static final EndpointConfig endpoint2 = HostAndPorts.getRedisEndpoint("redis-failover-2");
+
+  private static final ToxiproxyClient tp = new ToxiproxyClient("localhost", 8474);
+  private static Proxy redisProxy1;
+  private static Proxy redisProxy2;
+
+  @BeforeAll
+  public static void setupAdminClients() throws IOException {
+    if (tp.getProxyOrNull("redis-1") != null) {
+      tp.getProxy("redis-1").delete();
+    }
+    if (tp.getProxyOrNull("redis-2") != null) {
+      tp.getProxy("redis-2").delete();
+    }
+
+    redisProxy1 = tp.createProxy("redis-1", "0.0.0.0:29379", "redis-failover-1:9379");
+    redisProxy2 = tp.createProxy("redis-2", "0.0.0.0:29380", "redis-failover-2:9380");
+  }
+
+  @BeforeEach
+  void setUp() {
+    // Create a simple resilient client with mock endpoints for testing
+    MultiClusterClientConfig clientConfig = MultiClusterClientConfig.builder()
+        .endpoint(endpoint1.getHostAndPort(), 100.0f, endpoint1.getClientConfigBuilder().build())
+        .endpoint(endpoint2.getHostAndPort(), 50.0f, endpoint2.getClientConfigBuilder().build())
+        .build();
+
+    client = MultiDbClient.builder().multiDbConfig(clientConfig).build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  @Test
+  void testAddRemoveEndpointWithEndpointInterface() {
+    Endpoint newEndpoint = new HostAndPort("unavailable", 6381);
+
+    assertDoesNotThrow(
+      () -> client.addEndpoint(newEndpoint, 25.0f, DefaultJedisClientConfig.builder().build()));
+
+    assertThat(client.getEndpoints(), hasItems(newEndpoint));
+
+    assertDoesNotThrow(() -> client.removeEndpoint(newEndpoint));
+
+    assertThat(client.getEndpoints(), not(hasItems(newEndpoint)));
+  }
+
+  @Test
+  void testAddRemoveEndpointWithClusterConfig() {
+    // todo : (@ggivo) Replace HostAndPort with Endpoint
+    HostAndPort newEndpoint = new HostAndPort("unavailable", 6381);
+
+    ClusterConfig newConfig = ClusterConfig
+        .builder(newEndpoint, DefaultJedisClientConfig.builder().build()).weight(25.0f).build();
+
+    assertDoesNotThrow(() -> client.addEndpoint(newConfig));
+
+    assertThat(client.getEndpoints(), hasItems(newEndpoint));
+
+    assertDoesNotThrow(() -> client.removeEndpoint(newEndpoint));
+
+    assertThat(client.getEndpoints(), not(hasItems(newEndpoint)));
+  }
+
+  @Test
+  void testSetActiveDatabase() {
+    Endpoint endpoint = client.getActiveEndpoint();
+
+    awaitIsHealthy(endpoint1.getHostAndPort());
+    awaitIsHealthy(endpoint2.getHostAndPort());
+    // Ensure we have a healthy endpoint to switch to
+    Endpoint newEndpoint = client.getEndpoints().stream()
+        .filter(e -> e.equals(endpoint) && client.isHealthy(e)).findFirst().orElse(null);
+    assertNotNull(newEndpoint);
+
+    // Switch to the new endpoint
+    client.setActiveDatabase(newEndpoint);
+
+    assertEquals(newEndpoint, client.getActiveEndpoint());
+  }
+
+  @Test
+  void testBuilderWithMultipleEndpointTypes() {
+    MultiClusterClientConfig clientConfig = MultiClusterClientConfig.builder()
+        .endpoint(endpoint1.getHostAndPort(), 100.0f, DefaultJedisClientConfig.builder().build())
+        .endpoint(ClusterConfig
+            .builder(endpoint2.getHostAndPort(), DefaultJedisClientConfig.builder().build())
+            .weight(50.0f).build())
+        .build();
+
+    try (MultiDbClient testClient = MultiDbClient.builder().multiDbConfig(clientConfig).build()) {
+      assertThat(testClient.getEndpoints().size(), equalTo(2));
+      assertThat(testClient.getEndpoints(),
+        hasItems(endpoint1.getHostAndPort(), endpoint2.getHostAndPort()));
+    }
+  }
+
+  @Test
+  public void testForceActiveEndpoint() {
+    Endpoint endpoint = client.getActiveEndpoint();
+
+    // Ensure we have a healthy endpoint to switch to
+    awaitIsHealthy(endpoint1.getHostAndPort());
+    awaitIsHealthy(endpoint2.getHostAndPort());
+    Endpoint newEndpoint = client.getEndpoints().stream()
+        .filter(e -> e.equals(endpoint) && client.isHealthy(e)).findFirst().orElse(null);
+    assertNotNull(newEndpoint);
+
+    // Force switch to the new endpoint for 10 seconds
+    client.forceActiveEndpoint(newEndpoint, Duration.ofMillis(100).toMillis());
+
+    // Verify the active endpoint has changed
+    assertEquals(newEndpoint, client.getActiveEndpoint());
+  }
+
+  @Test
+  public void testForceActiveEndpointWithNonHealthyEndpoint() {
+    Endpoint newEndpoint = new HostAndPort("unavailable", 6381);
+    client.addEndpoint(newEndpoint, 25.0f, DefaultJedisClientConfig.builder().build());
+
+    assertThrows(JedisValidationException.class,
+      () -> client.forceActiveEndpoint(newEndpoint, Duration.ofMillis(100).toMillis()));
+  }
+
+  @Test
+  public void testForceActiveEndpointWithNonExistingEndpoint() {
+    Endpoint newEndpoint = new HostAndPort("unavailable", 6381);
+    assertThrows(JedisValidationException.class,
+      () -> client.forceActiveEndpoint(newEndpoint, Duration.ofMillis(100).toMillis()));
+  }
+
+  @Test
+  public void testWithDatabaseSwitchListener() {
+
+    MultiClusterClientConfig endpointsConfig = MultiClusterClientConfig.builder()
+        .endpoint(ClusterConfig
+            .builder(endpoint1.getHostAndPort(), endpoint1.getClientConfigBuilder().build())
+            .weight(100.0f).build())
+        .endpoint(ClusterConfig
+            .builder(endpoint2.getHostAndPort(), endpoint2.getClientConfigBuilder().build())
+            .weight(50.0f).build())
+        .build();
+
+    Consumer<ClusterSwitchEventArgs> eventConsumer;
+    List<ClusterSwitchEventArgs> events = new ArrayList<>();
+    eventConsumer = events::add;
+
+    try (MultiDbClient testClient = MultiDbClient.builder().databaseSwitchListener(eventConsumer)
+        .multiDbConfig(endpointsConfig).build()) {
+
+      assertThat(events.size(), equalTo(0));
+
+      awaitIsHealthy(endpoint2.getHostAndPort());
+      testClient.setActiveDatabase(endpoint2.getHostAndPort());
+
+      assertThat(events.size(), equalTo(1));
+      assertThat(events.get(0).getEndpoint(), equalTo(endpoint2.getHostAndPort()));
+      assertThat(events.get(0).getReason(), equalTo(SwitchReason.FORCED));
+    }
+  }
+
+  private void awaitIsHealthy(HostAndPort hostAndPort) {
+    await().atMost(Duration.ofSeconds(1)).until(() -> client.isHealthy(hostAndPort));
+  }
+
+}

--- a/src/test/java/redis/clients/jedis/mcf/ActiveActiveLocalFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/ActiveActiveLocalFailoverTest.java
@@ -109,9 +109,7 @@ public class ActiveActiveLocalFailoverTest {
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(clusterConfig);
 
-    builder.circuitBreakerSlidingWindowType(CircuitBreakerConfig.SlidingWindowType.TIME_BASED);
     builder.circuitBreakerSlidingWindowSize(1); // SLIDING WINDOW SIZE IN SECONDS
-    builder.circuitBreakerSlidingWindowMinCalls(1);
     builder.circuitBreakerFailureRateThreshold(10.0f); // percentage of failures to trigger circuit
                                                        // breaker
 

--- a/src/test/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/CircuitBreakerThresholdsTest.java
@@ -1,0 +1,249 @@
+package redis.clients.jedis.mcf;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.MultiClusterClientConfig;
+import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
+import redis.clients.jedis.util.ReflectionTestUtil;
+
+/**
+ * Tests for circuit breaker thresholds: both failure-rate threshold and minimum number of failures
+ * must be exceeded to trigger failover. Uses a real CircuitBreaker and real Retry, but mocks the
+ * provider and cluster wiring to avoid network I/O.
+ */
+public class CircuitBreakerThresholdsTest {
+
+  private MultiClusterPooledConnectionProvider realProvider;
+  private MultiClusterPooledConnectionProvider spyProvider;
+  private Cluster cluster;
+  private CircuitBreakerCommandExecutor executor;
+  private CommandObject<String> dummyCommand;
+  private TrackingConnectionPool poolMock;
+  private HostAndPort fakeEndpoint = new HostAndPort("fake", 6379);
+  private HostAndPort fakeEndpoint2 = new HostAndPort("fake2", 6379);
+  private ClusterConfig[] fakeClusterConfigs;
+
+  @BeforeEach
+  public void setup() throws Exception {
+
+    ClusterConfig[] clusterConfigs = new ClusterConfig[] {
+        ClusterConfig.builder(fakeEndpoint, DefaultJedisClientConfig.builder().build())
+            .healthCheckEnabled(false).weight(1.0f).build(),
+        ClusterConfig.builder(fakeEndpoint2, DefaultJedisClientConfig.builder().build())
+            .healthCheckEnabled(false).weight(0.5f).build() };
+    fakeClusterConfigs = clusterConfigs;
+
+    MultiClusterClientConfig.Builder cfgBuilder = MultiClusterClientConfig.builder(clusterConfigs)
+        .circuitBreakerFailureRateThreshold(50.0f).circuitBreakerMinNumOfFailures(3)
+        .circuitBreakerSlidingWindowSize(10).retryMaxAttempts(1).retryOnFailover(false);
+
+    MultiClusterClientConfig mcc = cfgBuilder.build();
+
+    realProvider = new MultiClusterPooledConnectionProvider(mcc);
+    spyProvider = spy(realProvider);
+
+    cluster = spyProvider.getCluster();
+
+    executor = new CircuitBreakerCommandExecutor(spyProvider);
+
+    dummyCommand = new CommandObject<>(new CommandArguments(Protocol.Command.PING),
+        BuilderFactory.STRING);
+
+    // Replace the cluster's pool with a mock to avoid real network I/O
+    poolMock = mock(TrackingConnectionPool.class);
+    ReflectionTestUtil.setField(cluster, "connectionPool", poolMock);
+  }
+
+  /**
+   * Below minimum failures; even if all calls are failures, failover should NOT trigger.
+   */
+  @Test
+  public void belowMinFailures_doesNotFailover() {
+    // Always failing connections
+    Connection failing = mock(Connection.class);
+    when(failing.executeCommand(org.mockito.Mockito.<CommandObject<?>> any()))
+        .thenThrow(new JedisConnectionException("fail"));
+    doNothing().when(failing).close();
+    when(poolMock.getResource()).thenReturn(failing);
+
+    for (int i = 0; i < 2; i++) {
+      assertThrows(JedisConnectionException.class, () -> executor.executeCommand(dummyCommand));
+    }
+
+    // Below min failures; CB remains CLOSED
+    assertEquals(CircuitBreaker.State.CLOSED, spyProvider.getClusterCircuitBreaker().getState());
+  }
+
+  /**
+   * Reaching minFailures and exceeding failure rate threshold should trigger failover.
+   */
+  @Test
+  public void minFailuresAndRateExceeded_triggersFailover() {
+    // Always failing connections
+    Connection failing = mock(Connection.class);
+    when(failing.executeCommand(org.mockito.Mockito.<CommandObject<?>> any()))
+        .thenThrow(new JedisConnectionException("fail"));
+    doNothing().when(failing).close();
+    when(poolMock.getResource()).thenReturn(failing);
+
+    // Reach min failures and exceed rate threshold
+    for (int i = 0; i < 3; i++) {
+      assertThrows(JedisConnectionException.class, () -> executor.executeCommand(dummyCommand));
+    }
+
+    // Next call should hit open CB (CallNotPermitted) and trigger failover
+    assertThrows(JedisConnectionException.class, () -> executor.executeCommand(dummyCommand));
+
+    verify(spyProvider, atLeastOnce()).switchToHealthyCluster(eq(SwitchReason.CIRCUIT_BREAKER),
+      any());
+    assertEquals(CircuitBreaker.State.FORCED_OPEN,
+      spyProvider.getCluster(fakeEndpoint).getCircuitBreaker().getState());
+  }
+
+  /**
+   * Even after reaching minFailures, if failure rate is below threshold, do not failover.
+   */
+  @Test
+  public void rateBelowThreshold_doesNotFailover() throws Exception {
+    // Use local provider with higher threshold (80%) and no retries
+    MultiClusterClientConfig.Builder cfgBuilder = MultiClusterClientConfig
+        .builder(fakeClusterConfigs).circuitBreakerFailureRateThreshold(80.0f)
+        .circuitBreakerMinNumOfFailures(3).circuitBreakerSlidingWindowSize(10).retryMaxAttempts(1)
+        .retryOnFailover(false);
+    MultiClusterPooledConnectionProvider rp = new MultiClusterPooledConnectionProvider(
+        cfgBuilder.build());
+    MultiClusterPooledConnectionProvider sp = spy(rp);
+    Cluster c = sp.getCluster();
+    try (CircuitBreakerCommandExecutor ex = new CircuitBreakerCommandExecutor(sp)) {
+      CommandObject<String> cmd = new CommandObject<>(new CommandArguments(Protocol.Command.PING),
+          BuilderFactory.STRING);
+
+      TrackingConnectionPool pool = mock(TrackingConnectionPool.class);
+      ReflectionTestUtil.setField(c, "connectionPool", pool);
+
+      // 3 successes
+      Connection success = mock(Connection.class);
+      when(success.executeCommand(org.mockito.Mockito.<CommandObject<String>> any()))
+          .thenReturn("PONG");
+      doNothing().when(success).close();
+      when(pool.getResource()).thenReturn(success);
+      for (int i = 0; i < 3; i++) {
+        assertEquals("PONG", ex.executeCommand(cmd));
+      }
+
+      // 3 failures -> total 6 calls, 50% failure rate; threshold 80% means stay CLOSED
+      Connection failing = mock(Connection.class);
+      when(failing.executeCommand(org.mockito.Mockito.<CommandObject<?>> any()))
+          .thenThrow(new JedisConnectionException("fail"));
+      doNothing().when(failing).close();
+      when(pool.getResource()).thenReturn(failing);
+      for (int i = 0; i < 3; i++) {
+        assertThrows(JedisConnectionException.class, () -> ex.executeCommand(cmd));
+      }
+
+      assertEquals(CircuitBreaker.State.CLOSED, sp.getClusterCircuitBreaker().getState());
+    }
+  }
+
+  @Test
+  public void providerBuilder_zeroRate_mapsToHundredAndHugeMinCalls() {
+    MultiClusterClientConfig.Builder cfgBuilder = MultiClusterClientConfig
+        .builder(fakeClusterConfigs);
+    cfgBuilder.circuitBreakerFailureRateThreshold(0.0f).circuitBreakerMinNumOfFailures(3)
+        .circuitBreakerSlidingWindowSize(10);
+    MultiClusterClientConfig mcc = cfgBuilder.build();
+
+    CircuitBreakerThresholdsAdapter adapter = new CircuitBreakerThresholdsAdapter(mcc);
+
+    assertEquals(100.0f, adapter.getFailureRateThreshold(), 0.0001f);
+    assertEquals(Integer.MAX_VALUE, adapter.getMinimumNumberOfCalls());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      // minFailures, ratePercent, successes, failures, expectFailoverOnNext
+      "0, 1.0, 0, 1, true", //
+      "1, 1.0, 0, 1, true", //
+      "3, 50.0, 0, 3, true", //
+      "1, 100.0, 0, 1, true", //
+      "0, 100.0, 99, 1, false", //
+      "0, 1.0, 99, 1, true", //
+      // additional edge cases
+      "1, 0.0, 0, 1, true", //
+      "3, 50.0, 3, 2, false", //
+      "1000, 1.0, 198, 2, false", })
+  public void thresholdMatrix(int minFailures, float ratePercent, int successes, int failures,
+      boolean expectFailoverOnNext) throws Exception {
+
+    MultiClusterClientConfig.Builder cfgBuilder = MultiClusterClientConfig
+        .builder(fakeClusterConfigs).circuitBreakerFailureRateThreshold(ratePercent)
+        .circuitBreakerMinNumOfFailures(minFailures)
+        .circuitBreakerSlidingWindowSize(Math.max(10, successes + failures + 2)).retryMaxAttempts(1)
+        .retryOnFailover(false);
+
+    MultiClusterPooledConnectionProvider real = new MultiClusterPooledConnectionProvider(
+        cfgBuilder.build());
+    MultiClusterPooledConnectionProvider spy = spy(real);
+    Cluster c = spy.getCluster();
+    try (CircuitBreakerCommandExecutor ex = new CircuitBreakerCommandExecutor(spy)) {
+
+      CommandObject<String> cmd = new CommandObject<>(new CommandArguments(Protocol.Command.PING),
+          BuilderFactory.STRING);
+
+      TrackingConnectionPool pool = mock(TrackingConnectionPool.class);
+      ReflectionTestUtil.setField(c, "connectionPool", pool);
+
+      if (successes > 0) {
+        Connection ok = mock(Connection.class);
+        when(ok.executeCommand(org.mockito.Mockito.<CommandObject<String>> any()))
+            .thenReturn("PONG");
+        doNothing().when(ok).close();
+        when(pool.getResource()).thenReturn(ok);
+        for (int i = 0; i < successes; i++) {
+          ex.executeCommand(cmd);
+        }
+      }
+
+      if (failures > 0) {
+        Connection bad = mock(Connection.class);
+        when(bad.executeCommand(org.mockito.Mockito.<CommandObject<?>> any()))
+            .thenThrow(new JedisConnectionException("fail"));
+        doNothing().when(bad).close();
+        when(pool.getResource()).thenReturn(bad);
+        for (int i = 0; i < failures; i++) {
+          try {
+            ex.executeCommand(cmd);
+          } catch (Exception ignore) {
+          }
+        }
+      }
+
+      if (expectFailoverOnNext) {
+        assertThrows(Exception.class, () -> ex.executeCommand(cmd));
+        verify(spy, atLeastOnce()).switchToHealthyCluster(eq(SwitchReason.CIRCUIT_BREAKER), any());
+        assertEquals(CircuitBreaker.State.FORCED_OPEN, c.getCircuitBreaker().getState());
+      } else {
+        CircuitBreaker.State st = c.getCircuitBreaker().getState();
+        assertTrue(st == CircuitBreaker.State.CLOSED || st == CircuitBreaker.State.HALF_OPEN);
+      }
+    }
+  }
+
+}

--- a/src/test/java/redis/clients/jedis/mcf/ClusterEvaluateThresholdsTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/ClusterEvaluateThresholdsTest.java
@@ -1,0 +1,183 @@
+package redis.clients.jedis.mcf;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.MultiClusterClientConfig;
+import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider.Cluster;
+
+/**
+ * Tests for circuit breaker thresholds: both failure-rate threshold and minimum number of failures
+ * must be exceeded to trigger failover. Uses a real CircuitBreaker and real Retry, but mocks the
+ * provider and cluster wiring to avoid network I/O.
+ */
+public class ClusterEvaluateThresholdsTest {
+
+  private MultiClusterPooledConnectionProvider provider;
+  private Cluster cluster;
+  private CircuitBreaker circuitBreaker;
+  private CircuitBreaker.Metrics metrics;
+
+  @BeforeEach
+  public void setup() {
+    provider = mock(MultiClusterPooledConnectionProvider.class);
+    cluster = mock(Cluster.class);
+
+    circuitBreaker = mock(CircuitBreaker.class);
+    metrics = mock(CircuitBreaker.Metrics.class);
+
+    when(cluster.getCircuitBreaker()).thenReturn(circuitBreaker);
+    when(circuitBreaker.getMetrics()).thenReturn(metrics);
+    when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+
+    // Configure the mock to call the real evaluateThresholds method
+    doCallRealMethod().when(cluster).evaluateThresholds(anyBoolean());
+
+  }
+
+  /**
+   * Below minimum failures; even if all calls are failures, failover should NOT trigger. Note: The
+   * isThresholdsExceeded method adds +1 to account for the current failing call, so we set
+   * failures=1 which becomes 2 with +1, still below minFailures=3.
+   */
+  @Test
+  public void belowMinFailures_doesNotFailover() {
+    when(cluster.getCircuitBreakerMinNumOfFailures()).thenReturn(3);
+    when(metrics.getNumberOfFailedCalls()).thenReturn(1); // +1 becomes 2, still < 3
+    when(metrics.getNumberOfSuccessfulCalls()).thenReturn(0);
+    when(cluster.getCircuitBreakerFailureRateThreshold()).thenReturn(50.0f);
+    when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+
+    cluster.evaluateThresholds(false);
+    verify(circuitBreaker, never()).transitionToOpenState();
+    verify(provider, never()).switchToHealthyCluster(any(), any());
+  }
+
+  /**
+   * Reaching minFailures and exceeding failure rate threshold should trigger circuit breaker to
+   * OPEN state. Note: The isThresholdsExceeded method adds +1 to account for the current failing
+   * call, so we set failures=2 which becomes 3 with +1, reaching minFailures=3.
+   */
+  @Test
+  public void minFailuresAndRateExceeded_triggersOpenState() {
+    when(cluster.getCircuitBreakerMinNumOfFailures()).thenReturn(3);
+    when(metrics.getNumberOfFailedCalls()).thenReturn(2); // +1 becomes 3, reaching minFailures
+    when(metrics.getNumberOfSuccessfulCalls()).thenReturn(0);
+    when(cluster.getCircuitBreakerFailureRateThreshold()).thenReturn(50.0f);
+    when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+
+    cluster.evaluateThresholds(false);
+    verify(circuitBreaker, times(1)).transitionToOpenState();
+  }
+
+  /**
+   * Even after reaching minFailures, if failure rate is below threshold, do not failover. Note: The
+   * isThresholdsExceeded method adds +1 to account for the current failing call, so we set
+   * failures=2 which becomes 3 with +1, reaching minFailures=3. Rate calculation: (3 failures) / (3
+   * failures + 3 successes) = 50% < 80% threshold.
+   */
+  @Test
+  public void rateBelowThreshold_doesNotFailover() {
+    when(cluster.getCircuitBreakerMinNumOfFailures()).thenReturn(3);
+    when(metrics.getNumberOfSuccessfulCalls()).thenReturn(3);
+    when(metrics.getNumberOfFailedCalls()).thenReturn(2); // +1 becomes 3, rate = 3/(3+3) = 50%
+    when(cluster.getCircuitBreakerFailureRateThreshold()).thenReturn(80.0f);
+    when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+
+    cluster.evaluateThresholds(false);
+
+    verify(circuitBreaker, never()).transitionToOpenState();
+    verify(provider, never()).switchToHealthyCluster(any(), any());
+  }
+
+  @Test
+  public void providerBuilder_zeroRate_mapsToHundredAndHugeMinCalls() {
+    MultiClusterClientConfig.Builder cfgBuilder = MultiClusterClientConfig
+        .builder(java.util.Arrays.asList(MultiClusterClientConfig.ClusterConfig
+            .builder(new HostAndPort("localhost", 6379), DefaultJedisClientConfig.builder().build())
+            .healthCheckEnabled(false).build()));
+    cfgBuilder.circuitBreakerFailureRateThreshold(0.0f).circuitBreakerMinNumOfFailures(3)
+        .circuitBreakerSlidingWindowSize(10);
+    MultiClusterClientConfig mcc = cfgBuilder.build();
+
+    CircuitBreakerThresholdsAdapter adapter = new CircuitBreakerThresholdsAdapter(mcc);
+
+    assertEquals(100.0f, adapter.getFailureRateThreshold(), 0.0001f);
+    assertEquals(Integer.MAX_VALUE, adapter.getMinimumNumberOfCalls());
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      // Format: "minFails, rate%, success, fails, lastFailRecorded, expected"
+
+      // === Basic threshold crossing cases ===
+      "0, 1.0, 0, 1, false, true", // +1 = 2 fails, rate=100% >= 1%, min=0 -> trigger
+      "0, 1.0, 0, 1, true, true", // +0 = 1 fails, rate=100% >= 1%, min=0 -> trigger
+
+      "1, 1.0, 0, 0, false, true", // +1 = 1 fails, rate=100% >= 1%, min=1 -> trigger
+      "1, 1.0, 0, 0, true, false", // +0 = 0 fails, 0 < 1 min -> no trigger
+
+      "3, 50.0, 0, 2, false, true", // +1 = 3 fails, rate=100% >= 50%, min=3 -> trigger
+      "3, 50.0, 0, 2, true, false", // +0 = 2 fails, 2 < 3 min -> no trigger
+
+      // === Rate threshold boundary cases ===
+      "1, 100.0, 0, 0, false, true", // +1 = 1 fails, rate=100% >= 100%, min=1 -> trigger
+      "1, 100.0, 0, 0, true, false", // +0 = 0 fails, 0 < 1 min -> no trigger
+
+      "0, 100.0, 99, 1, false, false", // +1 = 2 fails, rate=1.98% < 100% -> no trigger
+      "0, 100.0, 99, 1, true, false", // +0 = 1 fails, rate=1.0% < 100% -> no trigger
+
+      "0, 1.0, 99, 1, false, true", // +1 = 2 fails, rate=1.98% >= 1%, min=0 -> trigger
+      "0, 1.0, 99, 1, true, true", // +0 = 1 fails, rate=1.0% >= 1%, min=0 -> trigger
+
+      // === Zero rate threshold (always trigger if min failures met) ===
+      "1, 0.0, 0, 0, false, true", // +1 = 1 fails, rate=100% >= 0%, min=1 -> trigger
+      "1, 0.0, 0, 0, true, false", // +0 = 0 fails, 0 < 1 min -> no trigger
+      "1, 0.0, 100, 0, false, true", // +1 = 1 fails, rate=0.99% >= 0%, min=1 -> trigger
+      "1, 0.0, 100, 0, true, false", // +0 = 0 fails, 0 < 1 min -> no trigger
+
+      // === High minimum failures cases ===
+      "3, 50.0, 3, 1, false, false", // +1 = 2 fails, 2 < 3 min -> no trigger
+      "3, 50.0, 3, 1, true, false", // +0 = 1 fails, 1 < 3 min -> no trigger
+      "1000, 1.0, 198, 2, false, false", // +1 = 3 fails, 3 < 1000 min -> no trigger
+      "1000, 1.0, 198, 2, true, false", // +0 = 2 fails, 2 < 1000 min -> no trigger
+
+      // === Corner cases ===
+      "0, 50.0, 0, 0, false, true", // +1 = 1 fails, rate=100% >= 50%, min=0 -> trigger
+      "0, 50.0, 0, 0, true, false", // +0 = 0 fails, no calls -> no trigger
+      "1, 50.0, 1, 1, false, true", // +1 = 2 fails, rate=66.7% >= 50%, min=1 -> trigger
+      "1, 50.0, 1, 1, true, true", // +0 = 1 fails, rate=50% >= 50%, min=1 -> trigger
+      "2, 33.0, 2, 1, false, true", // +1 = 2 fails, rate=50% >= 33%, min=2 -> trigger
+      "2, 33.0, 2, 1, true, false", // +0 = 1 fails, 1 < 2 min -> no trigger
+      "5, 20.0, 20, 4, false, true", // +1 = 5 fails, rate=20% >= 20%, min=5 -> trigger
+      "5, 20.0, 20, 4, true, false", // +0 = 4 fails, 4 < 5 min -> no trigger
+      "3, 75.0, 1, 2, false, true", // +1 = 3 fails, rate=75% >= 75%, min=3 -> trigger
+      "3, 75.0, 1, 2, true, false", // +0 = 2 fails, 2 < 3 min -> no trigger
+  })
+  public void thresholdMatrix(int minFailures, float ratePercent, int successes, int failures,
+      boolean lastFailRecorded, boolean expectOpenState) {
+
+    when(cluster.getCircuitBreakerMinNumOfFailures()).thenReturn(minFailures);
+    when(metrics.getNumberOfSuccessfulCalls()).thenReturn(successes);
+    when(metrics.getNumberOfFailedCalls()).thenReturn(failures);
+    when(cluster.getCircuitBreakerFailureRateThreshold()).thenReturn(ratePercent);
+    when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+
+    cluster.evaluateThresholds(lastFailRecorded);
+
+    if (expectOpenState) {
+      verify(circuitBreaker, times(1)).transitionToOpenState();
+    } else {
+      verify(circuitBreaker, never()).transitionToOpenState();
+    }
+  }
+
+}

--- a/src/test/java/redis/clients/jedis/mcf/DefaultValuesTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/DefaultValuesTest.java
@@ -1,0 +1,77 @@
+package redis.clients.jedis.mcf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.MultiClusterClientConfig;
+
+public class DefaultValuesTest {
+
+  HostAndPort fakeEndpoint = new HostAndPort("fake", 6379);
+  JedisClientConfig config = DefaultJedisClientConfig.builder().build();
+
+  @Test
+  void testDefaultValuesInConfig() {
+
+    MultiClusterClientConfig.ClusterConfig clusterConfig = MultiClusterClientConfig.ClusterConfig
+        .builder(fakeEndpoint, config).build();
+    MultiClusterClientConfig multiConfig = new MultiClusterClientConfig.Builder(
+        new MultiClusterClientConfig.ClusterConfig[] { clusterConfig }).build();
+
+    // check for grace period
+    assertEquals(60000, multiConfig.getGracePeriod());
+
+    // check for cluster config
+    assertEquals(clusterConfig, multiConfig.getClusterConfigs()[0]);
+
+    // check healthchecks enabled
+    assertNotNull(clusterConfig.getHealthCheckStrategySupplier());
+
+    // check default healthcheck strategy is echo
+    assertEquals(EchoStrategy.DEFAULT, clusterConfig.getHealthCheckStrategySupplier());
+
+    // check number of probes
+    assertEquals(3,
+      clusterConfig.getHealthCheckStrategySupplier().get(fakeEndpoint, config).getNumProbes());
+
+    assertEquals(500, clusterConfig.getHealthCheckStrategySupplier().get(fakeEndpoint, config)
+        .getDelayInBetweenProbes());
+
+    assertEquals(ProbingPolicy.BuiltIn.ALL_SUCCESS,
+      clusterConfig.getHealthCheckStrategySupplier().get(fakeEndpoint, config).getPolicy());
+
+    // check health check interval
+    assertEquals(5000,
+      clusterConfig.getHealthCheckStrategySupplier().get(fakeEndpoint, config).getInterval());
+
+    // check lag aware tolerance
+    LagAwareStrategy.Config lagAwareConfig = LagAwareStrategy.Config
+        .builder(fakeEndpoint, config.getCredentialsProvider()).build();
+    assertEquals(Duration.ofMillis(5000), lagAwareConfig.getAvailabilityLagTolerance());
+
+    // TODO: check CB number of failures threshold -- 1000
+    // assertEquals(1000, multiConfig.circuitBreakerMinNumOfFailures());
+
+    // check CB failure rate threshold
+    assertEquals(10, multiConfig.getCircuitBreakerFailureRateThreshold());
+
+    // check CB sliding window size
+    assertEquals(2, multiConfig.getCircuitBreakerSlidingWindowSize());
+
+    // check failback check interval
+    assertEquals(120000, multiConfig.getFailbackCheckInterval());
+
+    // check failover max attempts before give up
+    assertEquals(10, multiConfig.getMaxNumFailoverAttempts());
+
+    // check delay between failover attempts
+    assertEquals(12000, multiConfig.getDelayInBetweenFailoverAttempts());
+
+  }
+}

--- a/src/test/java/redis/clients/jedis/mcf/FailbackMechanismUnitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/FailbackMechanismUnitTest.java
@@ -105,7 +105,7 @@ class FailbackMechanismUnitTest {
     MultiClusterClientConfig defaultConfig = new MultiClusterClientConfig.Builder(
         new MultiClusterClientConfig.ClusterConfig[] { clusterConfig }).build();
 
-    assertEquals(60000, defaultConfig.getGracePeriod()); // Default is 10 seconds
+    assertEquals(60000, defaultConfig.getGracePeriod());
 
     // Test custom value
     MultiClusterClientConfig customConfig = new MultiClusterClientConfig.Builder(

--- a/src/test/java/redis/clients/jedis/mcf/FailbackMechanismUnitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/FailbackMechanismUnitTest.java
@@ -32,7 +32,7 @@ class FailbackMechanismUnitTest {
     MultiClusterClientConfig defaultConfig = new MultiClusterClientConfig.Builder(
         new MultiClusterClientConfig.ClusterConfig[] { clusterConfig }).build();
 
-    assertEquals(5000, defaultConfig.getFailbackCheckInterval());
+    assertEquals(120000, defaultConfig.getFailbackCheckInterval());
 
     // Test custom value
     MultiClusterClientConfig customConfig = new MultiClusterClientConfig.Builder(
@@ -105,7 +105,7 @@ class FailbackMechanismUnitTest {
     MultiClusterClientConfig defaultConfig = new MultiClusterClientConfig.Builder(
         new MultiClusterClientConfig.ClusterConfig[] { clusterConfig }).build();
 
-    assertEquals(10000, defaultConfig.getGracePeriod()); // Default is 10 seconds
+    assertEquals(60000, defaultConfig.getGracePeriod()); // Default is 10 seconds
 
     // Test custom value
     MultiClusterClientConfig customConfig = new MultiClusterClientConfig.Builder(

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
 import redis.clients.jedis.EndpointConfig;
 import redis.clients.jedis.HostAndPorts;
 import redis.clients.jedis.JedisClientConfig;
@@ -94,10 +93,8 @@ public class HealthCheckIntegrationTest {
         .collect(Collectors.toList());
 
     MultiClusterClientConfig mccf = new MultiClusterClientConfig.Builder(clusterConfigs)
-        .retryMaxAttempts(1).retryWaitDuration(1)
-        .circuitBreakerSlidingWindowType(SlidingWindowType.COUNT_BASED)
-        .circuitBreakerSlidingWindowSize(1).circuitBreakerFailureRateThreshold(100)
-        .circuitBreakerSlidingWindowMinCalls(1).build();
+        .retryMaxAttempts(1).retryWaitDuration(1).circuitBreakerSlidingWindowSize(1)
+        .circuitBreakerFailureRateThreshold(100).build();
 
     return new MultiClusterPooledConnectionProvider(mccf);
   }

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
@@ -280,8 +280,11 @@ public class HealthCheckTest {
     // Register listener before adding health check to capture the initial event
     manager.registerListener(testEndpoint, listener);
 
+    HealthCheckStrategy delayedStrategy = new TestHealthCheckStrategy(2000, 1000, 3,
+        BuiltIn.ALL_SUCCESS, 100, e -> HealthStatus.HEALTHY);
+
     // Add health check - this will start async health checking
-    manager.add(testEndpoint, alwaysHealthyStrategy);
+    manager.add(testEndpoint, delayedStrategy);
 
     // Initially should still be UNKNOWN until first check completes
     assertEquals(HealthStatus.UNKNOWN, manager.getHealthStatus(testEndpoint));
@@ -785,7 +788,7 @@ public class HealthCheckTest {
     CountDownLatch unhealthyLatch = new CountDownLatch(1);
 
     TestHealthCheckStrategy strategy = new TestHealthCheckStrategy(
-        HealthCheckStrategy.Config.builder().interval(5).timeout(200).numProbes(4)
+        HealthCheckStrategy.Config.builder().interval(5000).timeout(200).numProbes(4)
             .policy(BuiltIn.MAJORITY_SUCCESS).delayInBetweenProbes(5).build(),
         e -> {
           int c = callCount.incrementAndGet();

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckTest.java
@@ -531,7 +531,7 @@ public class HealthCheckTest {
     // Test without config
     HealthCheckStrategy strategyWithoutConfig = supplier.get(testEndpoint, null);
     assertNotNull(strategyWithoutConfig);
-    assertEquals(1000, strategyWithoutConfig.getInterval()); // Default values
+    assertEquals(5000, strategyWithoutConfig.getInterval()); // Default values
     assertEquals(1000, strategyWithoutConfig.getTimeout());
   }
 

--- a/src/test/java/redis/clients/jedis/mcf/LagAwareStrategyUnitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/LagAwareStrategyUnitTest.java
@@ -50,7 +50,7 @@ public class LagAwareStrategyUnitTest {
     try (MockedConstruction<RedisRestAPI> mockedConstructor = mockConstruction(RedisRestAPI.class,
       (mock, context) -> {
         when(mock.getBdbs()).thenReturn(Arrays.asList(bdbInfo));
-        when(mock.checkBdbAvailability("1", true, 100L)).thenReturn(true);
+        when(mock.checkBdbAvailability("1", true, 5000L)).thenReturn(true);
         reference[0] = mock;
       })) {
       Config lagCheckConfig = Config.builder(endpoint, creds).interval(500).timeout(250)
@@ -61,7 +61,7 @@ public class LagAwareStrategyUnitTest {
 
         assertEquals(HealthStatus.HEALTHY, strategy.doHealthCheck(endpoint));
         verify(api, times(1)).getBdbs(); // Should not call getBdbs again when cached
-        verify(api, times(2)).checkBdbAvailability("1", true, 100L);
+        verify(api, times(2)).checkBdbAvailability("1", true, 5000L);
       }
     }
   }
@@ -97,7 +97,7 @@ public class LagAwareStrategyUnitTest {
         // First call throws exception, second call returns bdbInfo
         when(mock.getBdbs()).thenThrow(new RuntimeException("boom"))
             .thenReturn(Arrays.asList(bdbInfo));
-        when(mock.checkBdbAvailability("42", true, 100L)).thenReturn(true);
+        when(mock.checkBdbAvailability("42", true, 5000L)).thenReturn(true);
         reference[0] = mock;
       })) {
 
@@ -115,7 +115,7 @@ public class LagAwareStrategyUnitTest {
         // Verify getBdbs was called twice (once failed, once succeeded)
         verify(api, times(2)).getBdbs();
         // Verify availability check was called only once (on the successful attempt)
-        verify(api, times(1)).checkBdbAvailability("42", true, 100L);
+        verify(api, times(1)).checkBdbAvailability("42", true, 5000L);
       }
     }
   }
@@ -173,10 +173,10 @@ public class LagAwareStrategyUnitTest {
   void config_builder_creates_config_with_default_values() {
     Config config = Config.builder(endpoint, creds).build();
 
-    assertEquals(1000, config.interval);
+    assertEquals(5000, config.interval);
     assertEquals(1000, config.timeout);
     assertEquals(3, config.numProbes);
-    assertEquals(Duration.ofMillis(100), config.getAvailabilityLagTolerance());
+    assertEquals(Duration.ofMillis(5000), config.getAvailabilityLagTolerance());
     assertEquals(endpoint, config.getRestEndpoint());
     assertEquals(creds, config.getCredentialsSupplier());
   }
@@ -288,7 +288,7 @@ public class LagAwareStrategyUnitTest {
   void base_config_create_factory_method_uses_defaults() {
     HealthCheckStrategy.Config config = HealthCheckStrategy.Config.create();
 
-    assertEquals(1000, config.getInterval());
+    assertEquals(5000, config.getInterval());
     assertEquals(1000, config.getTimeout());
     assertEquals(3, config.getNumProbes());
   }

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterFailoverAttemptsConfigTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterFailoverAttemptsConfigTest.java
@@ -12,7 +12,8 @@ import redis.clients.jedis.MultiClusterClientConfig;
 import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
 import redis.clients.jedis.mcf.JedisFailoverException.JedisPermanentlyNotAvailableException;
 import redis.clients.jedis.mcf.JedisFailoverException.JedisTemporarilyNotAvailableException;
-import java.lang.reflect.Field;
+import redis.clients.jedis.util.ReflectionTestUtil;
+
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -147,53 +148,35 @@ public class MultiClusterFailoverAttemptsConfigTest {
 
   private static void setBuilderFailoverConfig(MultiClusterClientConfig.Builder builder,
       int maxAttempts, int delayMs) throws Exception {
-    Field fMax = builder.getClass().getDeclaredField("maxNumFailoverAttempts");
-    fMax.setAccessible(true);
-    fMax.setInt(builder, maxAttempts);
+    ReflectionTestUtil.setField(builder, "maxNumFailoverAttempts", maxAttempts);
 
-    Field fDelay = builder.getClass().getDeclaredField("delayInBetweenFailoverAttempts");
-    fDelay.setAccessible(true);
-    fDelay.setInt(builder, delayMs);
+    ReflectionTestUtil.setField(builder, "delayInBetweenFailoverAttempts", delayMs);
   }
 
   private void setProviderFailoverConfig(int maxAttempts, int delayMs) throws Exception {
     // Access the underlying MultiClusterClientConfig inside provider and adjust fields for this
     // test
-    Field cfgField = provider.getClass().getDeclaredField("multiClusterClientConfig");
-    cfgField.setAccessible(true);
-    Object cfg = cfgField.get(provider);
+    Object cfg = ReflectionTestUtil.getField(provider, "multiClusterClientConfig");
 
-    Field fMax = cfg.getClass().getDeclaredField("maxNumFailoverAttempts");
-    fMax.setAccessible(true);
-    fMax.setInt(cfg, maxAttempts);
+    ReflectionTestUtil.setField(cfg, "maxNumFailoverAttempts", maxAttempts);
 
-    Field fDelay = cfg.getClass().getDeclaredField("delayInBetweenFailoverAttempts");
-    fDelay.setAccessible(true);
-    fDelay.setInt(cfg, delayMs);
+    ReflectionTestUtil.setField(cfg, "delayInBetweenFailoverAttempts", delayMs);
   }
 
   private int getProviderMaxAttempts() throws Exception {
-    Field cfgField = provider.getClass().getDeclaredField("multiClusterClientConfig");
-    cfgField.setAccessible(true);
-    Object cfg = cfgField.get(provider);
-    Field fMax = cfg.getClass().getDeclaredField("maxNumFailoverAttempts");
-    fMax.setAccessible(true);
-    return fMax.getInt(cfg);
+    Object cfg = ReflectionTestUtil.getField(provider, "multiClusterClientConfig");
+
+    return ReflectionTestUtil.getField(cfg, "maxNumFailoverAttempts");
   }
 
   private int getProviderDelayMs() throws Exception {
-    Field cfgField = provider.getClass().getDeclaredField("multiClusterClientConfig");
-    cfgField.setAccessible(true);
-    Object cfg = cfgField.get(provider);
-    Field fDelay = cfg.getClass().getDeclaredField("delayInBetweenFailoverAttempts");
-    fDelay.setAccessible(true);
-    return fDelay.getInt(cfg);
+    Object cfg = ReflectionTestUtil.getField(provider, "multiClusterClientConfig");
+
+    return ReflectionTestUtil.getField(cfg, "delayInBetweenFailoverAttempts");
   }
 
   private int getProviderAttemptCount() throws Exception {
-    Field f = provider.getClass().getDeclaredField("failoverAttemptCount");
-    f.setAccessible(true);
-    AtomicInteger val = (AtomicInteger) f.get(provider);
+    AtomicInteger val = ReflectionTestUtil.getField(provider, "failoverAttemptCount");
     return val.get();
   }
 }

--- a/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/MultiClusterPooledConnectionProviderTest.java
@@ -1,8 +1,6 @@
 package redis.clients.jedis.mcf;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreaker;
-import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
-
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
 import org.junit.jupiter.api.*;
@@ -113,8 +111,8 @@ public class MultiClusterPooledConnectionProviderTest {
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(clusterConfigs);
 
     // Configures a single failed command to trigger an open circuit on the next subsequent failure
-    builder.circuitBreakerSlidingWindowSize(1);
-    builder.circuitBreakerSlidingWindowMinCalls(1);
+    builder.circuitBreakerSlidingWindowSize(3).circuitBreakerMinNumOfFailures(1)
+        .circuitBreakerFailureRateThreshold(0);
 
     AtomicBoolean isValidTest = new AtomicBoolean(false);
 
@@ -283,9 +281,7 @@ public class MultiClusterPooledConnectionProviderTest {
     // and open to impact from other defaulted values withing the components in use.
     MultiClusterPooledConnectionProvider testProvider = new MultiClusterPooledConnectionProvider(
         new MultiClusterClientConfig.Builder(clusterConfigs).delayInBetweenFailoverAttempts(100)
-            .maxNumFailoverAttempts(2).retryMaxAttempts(1).circuitBreakerSlidingWindowMinCalls(3)
-            .circuitBreakerSlidingWindowSize(5)
-            .circuitBreakerSlidingWindowType(SlidingWindowType.TIME_BASED)
+            .maxNumFailoverAttempts(2).retryMaxAttempts(1).circuitBreakerSlidingWindowSize(5)
             .circuitBreakerFailureRateThreshold(60).build()) {
     };
 

--- a/src/test/java/redis/clients/jedis/mcf/StatusTrackerTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/StatusTrackerTest.java
@@ -2,11 +2,13 @@ package redis.clients.jedis.mcf;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
+import static org.awaitility.Awaitility.await;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.awaitility.Durations;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -159,10 +161,12 @@ public class StatusTrackerTest {
     waitingThread.start();
 
     // Give some time for the listener to be registered
-    Thread.sleep(50);
+    await().atMost(Durations.FIVE_HUNDRED_MILLISECONDS)
+        .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS).untilAsserted(() -> {
+          assertNotNull(capturedListener[0], "Listener should have been registered");
+        });
 
     // Simulate status change for different endpoint (should be ignored)
-    assertNotNull(capturedListener[0], "Listener should have been registered");
     HealthStatusChangeEvent otherEvent = new HealthStatusChangeEvent(otherEndpoint,
         HealthStatus.UNKNOWN, HealthStatus.HEALTHY);
     capturedListener[0].onStatusChange(otherEvent);

--- a/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/misc/AutomaticFailoverTest.java
@@ -108,15 +108,15 @@ public class AutomaticFailoverTest {
 
   @Test
   public void commandFailoverUnresolvableHost() {
-    int slidingWindowMinCalls = 2;
+    int slidingWindowMinFails = 2;
     int slidingWindowSize = 2;
 
     HostAndPort unresolvableHostAndPort = new HostAndPort("unresolvable", 6379);
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
         getClusterConfigs(clientConfig, unresolvableHostAndPort, workingEndpoint.getHostAndPort()))
             .retryWaitDuration(1).retryMaxAttempts(1)
-            .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
-            .circuitBreakerSlidingWindowSize(slidingWindowSize);
+            .circuitBreakerSlidingWindowSize(slidingWindowSize)
+            .circuitBreakerMinNumOfFailures(slidingWindowMinFails);
 
     RedisFailoverReporter failoverReporter = new RedisFailoverReporter();
     MultiClusterPooledConnectionProvider connectionProvider = new MultiClusterPooledConnectionProvider(
@@ -129,16 +129,16 @@ public class AutomaticFailoverTest {
     log.info("Starting calls to Redis");
     assertFalse(failoverReporter.failedOver);
 
-    for (int attempt = 0; attempt < slidingWindowMinCalls; attempt++) {
+    for (int attempt = 0; attempt < slidingWindowMinFails; attempt++) {
+      assertFalse(failoverReporter.failedOver);
       Throwable thrown = assertThrows(JedisConnectionException.class,
         () -> jedis.hset(key, "f1", "v1"));
       assertThat(thrown.getCause(), instanceOf(UnknownHostException.class));
-      assertFalse(failoverReporter.failedOver);
     }
 
-    // should failover now
-    jedis.hset(key, "f1", "v1");
+    // already failed over now
     assertTrue(failoverReporter.failedOver);
+    jedis.hset(key, "f1", "v1");
 
     assertEquals(Collections.singletonMap("f1", "v1"), jedis.hgetAll(key));
     jedis.flushAll();
@@ -148,7 +148,7 @@ public class AutomaticFailoverTest {
 
   @Test
   public void commandFailover() {
-    int slidingWindowMinCalls = 6;
+    int slidingWindowMinFails = 6;
     int slidingWindowSize = 6;
     int retryMaxAttempts = 3;
 
@@ -157,7 +157,8 @@ public class AutomaticFailoverTest {
             .retryMaxAttempts(retryMaxAttempts) // Default
             // is
             // 3
-            .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
+            .circuitBreakerFailureRateThreshold(50)
+            .circuitBreakerMinNumOfFailures(slidingWindowMinFails)
             .circuitBreakerSlidingWindowSize(slidingWindowSize);
 
     RedisFailoverReporter failoverReporter = new RedisFailoverReporter();
@@ -191,12 +192,10 @@ public class AutomaticFailoverTest {
 
   @Test
   public void pipelineFailover() {
-    int slidingWindowMinCalls = 10;
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
         getClusterConfigs(clientConfig, hostPortWithFailure, workingEndpoint.getHostAndPort()))
-            .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
             .circuitBreakerSlidingWindowSize(slidingWindowSize)
             .fallbackExceptionList(Collections.singletonList(JedisConnectionException.class));
 
@@ -225,14 +224,11 @@ public class AutomaticFailoverTest {
 
   @Test
   public void failoverFromAuthError() {
-    int slidingWindowMinCalls = 10;
     int slidingWindowSize = 10;
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(
         getClusterConfigs(clientConfig, endpointForAuthFailure.getHostAndPort(),
-          workingEndpoint.getHostAndPort()))
-              .circuitBreakerSlidingWindowMinCalls(slidingWindowMinCalls)
-              .circuitBreakerSlidingWindowSize(slidingWindowSize)
+          workingEndpoint.getHostAndPort())).circuitBreakerSlidingWindowSize(slidingWindowSize)
               .fallbackExceptionList(Collections.singletonList(JedisAccessControlException.class));
 
     RedisFailoverReporter failoverReporter = new RedisFailoverReporter();

--- a/src/test/java/redis/clients/jedis/scenario/ActiveActiveFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/scenario/ActiveActiveFailoverTest.java
@@ -13,6 +13,7 @@ import redis.clients.jedis.MultiClusterClientConfig.ClusterConfig;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.mcf.ClusterSwitchEventArgs;
 import redis.clients.jedis.mcf.MultiClusterPooledConnectionProvider;
+import redis.clients.jedis.util.ClientTestUtil;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -57,32 +58,30 @@ public class ActiveActiveFailoverTest {
   @Test
   public void testFailover() {
 
-    MultiClusterClientConfig.ClusterConfig[] clusterConfig = new MultiClusterClientConfig.ClusterConfig[2];
-
     JedisClientConfig config = endpoint.getClientConfigBuilder()
       .socketTimeoutMillis(SOCKET_TIMEOUT_MS)
       .connectionTimeoutMillis(CONNECTION_TIMEOUT_MS).build();
 
-    clusterConfig[0] = ClusterConfig.builder(endpoint.getHostAndPort(0), config)
+    ClusterConfig primary = ClusterConfig.builder(endpoint.getHostAndPort(0), config)
       .connectionPoolConfig(RecommendedSettings.poolConfig).weight(1.0f).build();
-    clusterConfig[1] = ClusterConfig.builder(endpoint.getHostAndPort(1), config)
+
+    ClusterConfig secondary = ClusterConfig.builder(endpoint.getHostAndPort(1), config)
       .connectionPoolConfig(RecommendedSettings.poolConfig).weight(0.5f).build();
 
-    MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(clusterConfig);
-
-    builder.circuitBreakerSlidingWindowSize(1); // SLIDING WINDOW SIZE IN SECONDS
-    builder.circuitBreakerFailureRateThreshold(10.0f); // percentage of failures to trigger circuit breaker
-
-    builder.failbackSupported(true);
-    builder.failbackCheckInterval(1000);
-    builder.gracePeriod(2000);
-
-    builder.retryWaitDuration(10);
-    builder.retryMaxAttempts(1);
-    builder.retryWaitDurationExponentialBackoffMultiplier(1);
-    builder.fastFailover(true);
-    builder.retryOnFailover(false);
-
+    MultiClusterClientConfig multiConfig = MultiClusterClientConfig.builder()
+            .endpoint(primary)
+            .endpoint(secondary)
+            .circuitBreakerSlidingWindowSize(1) // SLIDING WINDOW SIZE IN SECONDS
+            .circuitBreakerFailureRateThreshold(10.0f) // percentage of failures to trigger circuit breaker
+            .failbackSupported(true)
+            .failbackCheckInterval(1000)
+            .gracePeriod(2000)
+            .retryWaitDuration(10)
+            .retryMaxAttempts(1)
+            .retryWaitDurationExponentialBackoffMultiplier(1)
+            .fastFailover(true)
+            .retryOnFailover(false)
+            .build();
     class FailoverReporter implements Consumer<ClusterSwitchEventArgs> {
 
       String currentClusterName = "not set";
@@ -115,12 +114,12 @@ public class ActiveActiveFailoverTest {
       }
     }
 
-    MultiClusterPooledConnectionProvider provider = new MultiClusterPooledConnectionProvider(builder.build());
     FailoverReporter reporter = new FailoverReporter();
-    provider.setClusterSwitchListener(reporter);
-    provider.setActiveCluster(endpoint.getHostAndPort(0));
 
-    UnifiedJedis client = new UnifiedJedis(provider);
+    MultiDbClient client = MultiDbClient.builder()
+            .multiDbConfig(multiConfig)
+            .databaseSwitchListener(reporter)
+            .build();
 
     AtomicLong executedCommands = new AtomicLong(0);
     AtomicLong retryingThreadsCounter = new AtomicLong(0);
@@ -209,7 +208,7 @@ public class ActiveActiveFailoverTest {
       throw new RuntimeException(e);
     }
 
-
+    MultiClusterPooledConnectionProvider provider = ClientTestUtil.getConnectionProvider(client);
     ConnectionPool pool1 = provider.getCluster(endpoint.getHostAndPort(0)).getConnectionPool();
     ConnectionPool pool2 = provider.getCluster(endpoint.getHostAndPort(1)).getConnectionPool();
 

--- a/src/test/java/redis/clients/jedis/scenario/ActiveActiveFailoverTest.java
+++ b/src/test/java/redis/clients/jedis/scenario/ActiveActiveFailoverTest.java
@@ -70,9 +70,7 @@ public class ActiveActiveFailoverTest {
 
     MultiClusterClientConfig.Builder builder = new MultiClusterClientConfig.Builder(clusterConfig);
 
-    builder.circuitBreakerSlidingWindowType(CircuitBreakerConfig.SlidingWindowType.TIME_BASED);
     builder.circuitBreakerSlidingWindowSize(1); // SLIDING WINDOW SIZE IN SECONDS
-    builder.circuitBreakerSlidingWindowMinCalls(1);
     builder.circuitBreakerFailureRateThreshold(10.0f); // percentage of failures to trigger circuit breaker
 
     builder.failbackSupported(true);

--- a/src/test/java/redis/clients/jedis/util/ClientTestUtil.java
+++ b/src/test/java/redis/clients/jedis/util/ClientTestUtil.java
@@ -1,0 +1,11 @@
+package redis.clients.jedis.util;
+
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.providers.ConnectionProvider;
+
+public class ClientTestUtil {
+
+  public static <T extends ConnectionProvider> T getConnectionProvider(UnifiedJedis jedis) {
+    return ReflectionTestUtil.getField(jedis, "provider");
+  }
+}

--- a/src/test/java/redis/clients/jedis/util/ReflectionTestUtil.java
+++ b/src/test/java/redis/clients/jedis/util/ReflectionTestUtil.java
@@ -1,0 +1,91 @@
+package redis.clients.jedis.util;
+
+import java.lang.reflect.Field;
+
+/**
+ * Simple utility for accessing private fields in tests using reflection.
+ * <p>
+ * This utility is intended for testing purposes only to access internal state that is not exposed
+ * through public APIs.
+ * </p>
+ */
+public class ReflectionTestUtil {
+
+  /**
+   * Gets the value of a private field from an object.
+   * @param target the object containing the field
+   * @param fieldName the name of the field to access
+   * @param <T> the expected type of the field value
+   * @return the value of the field
+   * @throws RuntimeException if the field cannot be accessed
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T getField(Object target, String fieldName) {
+    if (target == null) {
+      throw new IllegalArgumentException("Target object cannot be null");
+    }
+    if (fieldName == null || fieldName.isEmpty()) {
+      throw new IllegalArgumentException("Field name cannot be null or empty");
+    }
+
+    try {
+      Field field = findField(target.getClass(), fieldName);
+      field.setAccessible(true);
+      return (T) field.get(target);
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(
+          "Field '" + fieldName + "' not found in class " + target.getClass().getName(), e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(
+          "Cannot access field '" + fieldName + "' in class " + target.getClass().getName(), e);
+    }
+  }
+
+  /**
+   * Sets the value of a private field in an object.
+   * @param target the object containing the field
+   * @param fieldName the name of the field to set
+   * @param value the value to set
+   * @throws RuntimeException if the field cannot be accessed
+   */
+  public static void setField(Object target, String fieldName, Object value) {
+    if (target == null) {
+      throw new IllegalArgumentException("Target object cannot be null");
+    }
+    if (fieldName == null || fieldName.isEmpty()) {
+      throw new IllegalArgumentException("Field name cannot be null or empty");
+    }
+
+    try {
+      Field field = findField(target.getClass(), fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(
+          "Field '" + fieldName + "' not found in class " + target.getClass().getName(), e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(
+          "Cannot access field '" + fieldName + "' in class " + target.getClass().getName(), e);
+    }
+  }
+
+  /**
+   * Finds a field in the class hierarchy.
+   * @param clazz the class to search
+   * @param fieldName the name of the field
+   * @return the field
+   * @throws NoSuchFieldException if the field is not found
+   */
+  private static Field findField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+    Class<?> current = clazz;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(
+        "Field '" + fieldName + "' not found in class hierarchy of " + clazz.getName());
+  }
+}


### PR DESCRIPTION
# Circuit Breaker Two-Threshold Failover and MultiDbClient Introduction

This PR introduces a new dual-threshold circuit breaker mechanism and a simplified MultiDbClient API for Redis multi-endpoint deployments. The changes enhance failover precision by requiring both minimum failure count AND failure rate thresholds to be exceeded before triggering failover, preventing false positives from small sample sizes.

## 🚀 New Features Added

### 1. MultiDbClient - Simplified Multi-Endpoint Redis Client
- **NEW**: `MultiDbClient` class extending `UnifiedJedis` for high-availability Redis connectivity
- **NEW**: `MultiDbClientBuilder` abstract builder for creating multi-db Redis clients
- **NEW**: Simplified API for managing multiple weighted Redis endpoints
- **NEW**: Built-in automatic failover and failback capabilities
- **NEW**: Event-driven database switch notifications via `databaseSwitchListener`
- **NEW**: Dynamic endpoint management (add/remove endpoints at runtime)
- **NEW**: Force active endpoint functionality for maintenance scenarios

### 2. Dual-Threshold Circuit Breaker System
- **NEW**: `circuitBreakerMinNumOfFailures` configuration - Minimum number of failures required before circuit breaker can trip
- **NEW**: `CircuitBreakerThresholdsAdapter` - Disables Resilience4j's built-in evaluation to use Jedis custom logic
- **NEW**: `evaluateThresholds()` method in Cluster class for custom threshold evaluation
- **NEW**: Both minimum failures AND failure rate thresholds must be exceeded to trigger failover
- **NEW**: Prevents false positives from small sample sizes in low-traffic scenarios

### 3. Enhanced Configuration Flexibility
- **NEW**: `MultiClusterClientConfig.builder()` - No-argument builder for dynamic endpoint addition
- **NEW**: `endpoint(Endpoint, float, JedisClientConfig)` - Simplified endpoint addition method
- **NEW**: `endpoint(ClusterConfig)` - Pre-configured cluster addition method
- **NEW**: Validation to prevent both thresholds being zero simultaneously

## 🔧 Core Improvements

### 1. Circuit Breaker Logic Overhaul
- **CHANGED**: Default failure rate threshold reduced from 50% to 10% for faster failover detection
- **CHANGED**: Default sliding window size reduced from 100 to 2 seconds for quicker response
- **CHANGED**: Default minimum failures set to 1000 to prevent premature failover in low-traffic scenarios
- **CHANGED**: Resilience4j circuit breaker evaluation disabled in favor of custom dual-threshold logic
- **IMPROVED**: Circuit breaker now evaluates thresholds on every error event for immediate response
- **IMPROVED**: Forced circuit breaker state transitions when both thresholds are exceeded

### 2. Configuration Defaults Optimization
- **CHANGED**: Default failback check interval increased from 5 seconds to 2 minutes (120000ms)
- **CHANGED**: Default grace period increased from 10 seconds to 1 minute (60000ms)
- **CHANGED**: Default health check interval increased from 1 second to 5 seconds (5000ms)
- **CHANGED**: Default lag tolerance in LagAwareStrategy increased from 100ms to 5 seconds (5000ms)
- **CHANGED**: Default delay between probes increased from 100ms to 500ms
- **IMPROVED**: More conservative defaults to reduce unnecessary failover churn in production

### 3. API Modernization and Consistency
- **CHANGED**: `ClusterConfig` constructor now uses `Endpoint` interface instead of `HostAndPort`
- **CHANGED**: `getHostAndPort()` method renamed to `getEndpoint()` for consistency
- **CHANGED**: Builder pattern enhanced with fluent endpoint configuration methods
- **IMPROVED**: Type safety with `Endpoint` interface usage throughout the codebase
- **IMPROVED**: Consistent naming conventions across all configuration classes

### 4. Health Check System Enhancements
- **CHANGED**: EchoStrategy now uses connection pool with maximum 2 connections for health checks
- **IMPROVED**: Health check strategies now have more conservative default intervals
- **IMPROVED**: Better resource management for health check connections

## 📦 Package and Structure Changes

### 1. Test Infrastructure Improvements
- **NEW**: `CircuitBreakerThresholdsTest` - Comprehensive tests for dual-threshold behavior
- **NEW**: `ClusterEvaluateThresholdsTest` - Unit tests for threshold evaluation logic
- **NEW**: `DefaultValuesTest` - Validation of all default configuration values
- **NEW**: `MultiDbClientTest` - Integration tests for the new MultiDbClient API
- **NEW**: `ReflectionTestUtil` - Utility class for test reflection operations
- **UPDATED**: All existing tests updated to use new dual-threshold configuration

### 2. Maven Configuration Updates
- **NEW**: `excludedGroupsForUnitTests` property for flexible test group exclusion
- **IMPROVED**: Test execution configuration with parameterized excluded groups
- **IMPROVED**: Coverage configuration includes new MultiDbClient and test utilities

## 🔄 API Changes

### 1. MultiClusterClientConfig Builder
```java
// NEW: No-argument builder for dynamic configuration
MultiClusterClientConfig config = MultiClusterClientConfig.builder()
    .endpoint(endpoint1, 100.0f, clientConfig1)
    .endpoint(endpoint2, 50.0f, clientConfig2)
    .circuitBreakerMinNumOfFailures(1000)        // NEW: Minimum failures threshold
    .circuitBreakerFailureRateThreshold(10.0f)   // CHANGED: Default reduced to 10%
    .build();
```

### 2. MultiDbClient Usage
```java
// NEW: Simplified multi-endpoint client
MultiDbClient client = MultiDbClient.builder()
    .multiDbConfig(config)
    .databaseSwitchListener(event -> 
        System.out.println("Switched to: " + event.getEndpoint()))
    .build();

// NEW: Dynamic endpoint management
client.addEndpoint(newEndpoint, 25.0f, clientConfig);
client.removeEndpoint(oldEndpoint);
client.forceActiveEndpoint(endpoint, Duration.ofMinutes(5).toMillis());
```

### 3. ClusterConfig Constructor Changes
```java
// OLD: Using HostAndPort
ClusterConfig config = new ClusterConfig(hostAndPort, clientConfig);

// NEW: Using Endpoint interface
ClusterConfig config = new ClusterConfig(endpoint, clientConfig);
```

## 🐛 Bug Fixes

### 1. Circuit Breaker State Management
- **FIXED**: Circuit breaker now properly transitions to FORCED_OPEN state when thresholds exceeded
- **FIXED**: Immediate failover trigger when circuit breaker opens during command execution
- **SOLUTION**: Added circuit breaker state checking in command executors with automatic failover

### 2. Test Configuration Consistency
- **FIXED**: Test configurations updated to use new dual-threshold parameters
- **FIXED**: Default value assertions updated to match new configuration defaults
- **SOLUTION**: Comprehensive test updates across all failover and circuit breaker tests

## 🎯 Behavioral Changes

### 1. Circuit Breaker Failover Logic
**Before:**
- Single threshold (failure rate OR minimum calls) could trigger failover
- Small sample sizes could cause false positive failovers
- Resilience4j handled all circuit breaker state transitions

**After:**
- Dual threshold system requires BOTH minimum failures AND failure rate to be exceeded
- Prevents false positives in low-traffic scenarios
- Custom Jedis logic controls circuit breaker state transitions
- More precise failover decisions based on actual failure patterns

### 2. Configuration Defaults
**Before:**
- Aggressive defaults optimized for quick failover detection
- 50% failure rate threshold, 100-call sliding window
- 5-second failback checks, 10-second grace periods

**After:**
- Conservative defaults optimized for production stability
- 10% failure rate threshold, 2-second sliding window, 1000 minimum failures
- 2-minute failback checks, 1-minute grace periods
- Reduced unnecessary failover churn while maintaining responsiveness

### 3. API Usage Patterns
**Before:**
- Required pre-configured ClusterConfig arrays
- HostAndPort-based endpoint specification
- Limited dynamic endpoint management

**After:**
- Flexible builder pattern with dynamic endpoint addition
- Endpoint interface for consistent type usage
- Full runtime endpoint management capabilities

## 📊 Configuration Examples

### Basic Dual-Threshold Configuration
```java
MultiClusterClientConfig config = MultiClusterClientConfig.builder()
    .endpoint(primary, 100.0f, primaryConfig)
    .endpoint(secondary, 50.0f, secondaryConfig)
    .circuitBreakerMinNumOfFailures(500)         // Require 500+ failures
    .circuitBreakerFailureRateThreshold(15.0f)   // AND 15%+ failure rate
    .circuitBreakerSlidingWindowSize(3)          // Over 3-second window
    .build();
```

### MultiDbClient with Event Handling
```java
MultiDbClient client = MultiDbClient.builder()
    .multiDbConfig(config)
    .databaseSwitchListener(event -> {
        logger.info("Database switched: {} -> {} (reason: {})",
            event.getPreviousEndpoint(), event.getEndpoint(), event.getReason());
        metrics.incrementCounter("db.switch", "reason", event.getReason().name());
    })
    .build();
```

### Dynamic Endpoint Management
```java
// Add new endpoint at runtime
client.addEndpoint(newEndpoint, 75.0f, newClientConfig);

// Force specific endpoint for maintenance
client.forceActiveEndpoint(maintenanceEndpoint, Duration.ofMinutes(10).toMillis());

// Check endpoint health
if (client.isHealthy(endpoint)) {
    client.setActiveDatabase(endpoint);
}
```

## ⚠️ Breaking Changes

### API Changes
1. **ClusterConfig constructor**:
   - Changed: `ClusterConfig(HostAndPort, JedisClientConfig)` → `ClusterConfig(Endpoint, JedisClientConfig)`
   - Impact: Direct constructor usage needs to be updated

2. **ClusterConfig getter method**:
   - Changed: `getHostAndPort()` → `getEndpoint()`
   - Impact: Code accessing endpoint information needs updates

3. **Circuit breaker configuration**:
   - Removed: Several Resilience4j-specific configuration methods
   - Added: `circuitBreakerMinNumOfFailures()` method
   - Impact: Circuit breaker configuration needs dual-threshold setup

### Default Value Changes
- Failure rate threshold: 50% → 10%
- Sliding window size: 100 → 2 seconds
- Failback check interval: 5s → 120s
- Grace period: 10s → 60s
- Health check interval: 1s → 5s

### Migration Guide
```java
// OLD: Single threshold configuration
builder.circuitBreakerFailureRateThreshold(50.0f)
       .circuitBreakerSlidingWindowMinCalls(100);

// NEW: Dual threshold configuration
builder.circuitBreakerFailureRateThreshold(10.0f)
       .circuitBreakerMinNumOfFailures(1000)
       .circuitBreakerSlidingWindowSize(2);
```

## 🧪 Testing

All changes validated with:
- ✅ Comprehensive dual-threshold circuit breaker tests
- ✅ MultiDbClient integration tests with dynamic endpoint management
- ✅ Default configuration validation tests
- ✅ Backward compatibility tests for existing configurations
- ✅ Performance tests for new threshold evaluation logic
- ✅ Edge case testing for threshold boundary conditions

## 📝 Additional Notes

- New dual-threshold system enables more control on fail-over process in alternative ways in both low & high traffic scenarios
- MultiDbClient provides a simplified API for common multi-endpoint use cases
- Endpoint interface usage improves type safety and API consistency
- All existing functionality remains available through the enhanced configuration system
- Test infrastructure improvements provide better coverage and reliability validation
