### PR TITLE
Add CAPA redirect support

### DIFF
--- a/src/main/java/redis/clients/jedis/ClientCapaConfig.java
+++ b/src/main/java/redis/clients/jedis/ClientCapaConfig.java
@@ -1,0 +1,25 @@
+package redis.clients.jedis;
+
+public class ClientCapaConfig {
+
+  private final boolean redirect;
+
+  public static final ClientCapaConfig DEFAULT = new ClientCapaConfig(false);
+  public static final ClientCapaConfig DISABLED = new ClientCapaConfig(false);
+
+  public ClientCapaConfig() {
+    this(false);
+  }
+
+  public ClientCapaConfig(boolean redirect) {
+    this.redirect = redirect;
+  }
+
+  public boolean isRedirect() {
+    return redirect;
+  }
+
+  public static ClientCapaConfig withRedirect() {
+    return new ClientCapaConfig(true);
+  }
+}

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -650,6 +650,13 @@ public class Connection implements Closeable {
         fireAndForgetMsg.add(new CommandArguments(Command.READONLY));
       }
 
+      ClientCapaConfig capaConfig = config.getClientCapaConfig();
+      if (capaConfig == null) capaConfig = ClientCapaConfig.DEFAULT;
+      if (capaConfig.isRedirect()) {
+        fireAndForgetMsg.add(new CommandArguments(Command.CLIENT).add(Keyword.CAPA)
+            .add(ClientAttributeOption.REDIRECT.getRaw()));
+      }
+
       for (CommandArguments arg : fireAndForgetMsg) {
         sendCommand(arg);
       }

--- a/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/DefaultJedisClientConfig.java
@@ -24,6 +24,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   private volatile Supplier<RedisCredentials> credentialsProvider;
   private final int database;
   private final String clientName;
+  private final ClientCapaConfig clientCapaConfig;
 
   private final boolean ssl;
   private final SSLSocketFactory sslSocketFactory;
@@ -52,6 +53,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     this.credentialsProvider = builder.credentialsProvider;
     this.database = builder.database;
     this.clientName = builder.clientName;
+    this.clientCapaConfig = builder.clientCapaConfig;
     this.ssl = builder.ssl;
     this.sslSocketFactory = builder.sslSocketFactory;
     this.sslParameters = builder.sslParameters;
@@ -120,6 +122,11 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
   @Override
   public String getClientName() {
     return clientName;
+  }
+
+  @Override
+  public ClientCapaConfig getClientCapaConfig() {
+    return clientCapaConfig;
   }
 
   @Override
@@ -253,6 +260,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
     private Supplier<RedisCredentials> credentialsProvider;
     private int database = Protocol.DEFAULT_DATABASE;
     private String clientName = null;
+    private ClientCapaConfig clientCapaConfig = ClientCapaConfig.DEFAULT;
 
     private boolean ssl = false;
     private SSLSocketFactory sslSocketFactory = null;
@@ -380,6 +388,11 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
 
     public Builder clientName(String clientName) {
       this.clientName = clientName;
+      return this;
+    }
+
+    public Builder clientCapaConfig(ClientCapaConfig capaConfig) {
+      this.clientCapaConfig = capaConfig;
       return this;
     }
 
@@ -513,6 +526,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
       this.credentialsProvider = instance.getCredentialsProvider();
       this.database = instance.getDatabase();
       this.clientName = instance.getClientName();
+      this.clientCapaConfig = instance.getClientCapaConfig();
       this.ssl = instance.isSsl();
       this.sslSocketFactory = instance.getSslSocketFactory();
       this.sslParameters = instance.getSslParameters();
@@ -575,6 +589,7 @@ public final class DefaultJedisClientConfig implements JedisClientConfig {
 
     builder.database(copy.getDatabase());
     builder.clientName(copy.getClientName());
+    builder.clientCapaConfig(copy.getClientCapaConfig());
 
     builder.ssl(copy.isSsl());
     builder.sslSocketFactory(copy.getSslSocketFactory());

--- a/src/main/java/redis/clients/jedis/JedisClientConfig.java
+++ b/src/main/java/redis/clients/jedis/JedisClientConfig.java
@@ -90,6 +90,10 @@ public interface JedisClientConfig {
     return null;
   }
 
+  default ClientCapaConfig getClientCapaConfig() {
+    return ClientCapaConfig.DEFAULT;
+  }
+
   /**
    * Whether TLS/SSL should be used for connections.
    * <p>

--- a/src/main/java/redis/clients/jedis/Protocol.java
+++ b/src/main/java/redis/clients/jedis/Protocol.java
@@ -54,6 +54,7 @@ public final class Protocol {
   static final List<KeyValue> PROTOCOL_EMPTY_MAP = Collections.unmodifiableList(new ArrayList<>(0));
 
   private static final String ASK_PREFIX = "ASK ";
+  private static final String REDIRECT_PREFIX = "REDIRECT ";
   private static final String MOVED_PREFIX = "MOVED ";
   private static final String CLUSTERDOWN_PREFIX = "CLUSTERDOWN ";
   private static final String BUSY_PREFIX = "BUSY ";
@@ -95,6 +96,8 @@ public final class Protocol {
     } else if (message.startsWith(ASK_PREFIX)) {
       String[] askInfo = parseTargetHostAndSlot(message);
       throw new JedisAskDataException(message, HostAndPort.from(askInfo[1]), Integer.parseInt(askInfo[0]));
+    } else if (message.startsWith(REDIRECT_PREFIX)) {
+      throw new JedisRedirectionException(message, HostAndPort.from(parseTargetHost(message)), -1);
     } else if (message.startsWith(CLUSTERDOWN_PREFIX)) {
       throw new JedisClusterException(message);
     } else if (message.startsWith(BUSY_PREFIX)) {
@@ -126,6 +129,11 @@ public final class Protocol {
     response[0] = messageInfo[1];
     response[1] = messageInfo[2];
     return response;
+  }
+
+  private static String parseTargetHost(String redirectResponse) {
+    String[] messageInfo = redirectResponse.split(" ");
+    return messageInfo[1];
   }
 
   private static Object process(final RedisInputStream is, PushConsumerChain pushConsumer) {
@@ -405,7 +413,7 @@ public final class Protocol {
     DELETE, LIBRARYNAME, WITHCODE, DESCRIPTION, GETKEYS, GETKEYSANDFLAGS, DOCS, FILTERBY, DUMP,
     MODULE, ACLCAT, PATTERN, DOCTOR, LATEST, HISTORY, USAGE, SAMPLES, PURGE, STATS, LOADEX, CONFIG,
     ARGS, RANK, NOW, VERSION, ADDR, SKIPME, USER, LADDR, FIELDS,
-    CHANNELS, NUMPAT, NUMSUB, SHARDCHANNELS, SHARDNUMSUB, NOVALUES, MAXAGE, FXX, FNX,
+    CHANNELS, NUMPAT, NUMSUB, SHARDCHANNELS, SHARDNUMSUB, NOVALUES, MAXAGE, CAPA, FXX, FNX,
     // Vector set keywords
     REDUCE, CAS, NOQUANT, Q8, BIN, EF, SETATTR, M, VALUES, FP32, ELE, FILTER, FILTER_EF, TRUTH, NOTHREAD, RAW, EPSILON, WITHATTRIBS,
     // Hotkeys keywords

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -93,6 +93,34 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   /**
+   * Constructs a {@code UnifiedJedis} instance with a redirect-aware provider.
+   *
+   * @param provider connection provider for redirect handling
+   * @param maxAttempts maximum attempts to execute a command before giving up
+   * @param maxTotalRetriesDuration maximum total duration to retry commands before giving up
+   */
+  public UnifiedJedis(RedirectConnectionProvider provider, int maxAttempts,
+      Duration maxTotalRetriesDuration) {
+    this(new RedirectCommandExecutor(provider, maxAttempts, maxTotalRetriesDuration), provider,
+        (RedisProtocol) null, null);
+  }
+
+  /**
+   * Constructs a {@code UnifiedJedis} instance with a redirect-aware provider and explicit RESP
+   * protocol.
+   *
+   * @param provider connection provider for redirect handling
+   * @param maxAttempts maximum attempts to execute a command before giving up
+   * @param maxTotalRetriesDuration maximum total duration to retry commands before giving up
+   * @param protocol Redis protocol implementation to use
+   */
+  protected UnifiedJedis(RedirectConnectionProvider provider, int maxAttempts,
+      Duration maxTotalRetriesDuration, RedisProtocol protocol) {
+    this(new RedirectCommandExecutor(provider, maxAttempts, maxTotalRetriesDuration), provider, protocol,
+        null);
+  }
+
+  /**
    * Builder-facing constructor. The client owns {@link CommandObjects} construction: it reads the
    * protocol (and the {@code CommandObjects} knobs) from {@code clientConfig}, probes the provider
    * when the protocol is left unspecified, then delegates to

--- a/src/main/java/redis/clients/jedis/args/ClientAttributeOption.java
+++ b/src/main/java/redis/clients/jedis/args/ClientAttributeOption.java
@@ -8,7 +8,8 @@ import redis.clients.jedis.util.SafeEncoder;
  */
 public enum ClientAttributeOption implements Rawable {
     LIB_NAME("LIB-NAME"),
-    LIB_VER("LIB-VER");
+    LIB_VER("LIB-VER"),
+    REDIRECT("REDIRECT");
 
     private final byte[] raw;
 

--- a/src/main/java/redis/clients/jedis/executors/RedirectCommandExecutor.java
+++ b/src/main/java/redis/clients/jedis/executors/RedirectCommandExecutor.java
@@ -1,0 +1,134 @@
+package redis.clients.jedis.executors;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.annots.VisibleForTesting;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.exceptions.JedisRedirectionException;
+import redis.clients.jedis.providers.RedirectConnectionProvider;
+import redis.clients.jedis.util.IOUtils;
+import redis.clients.jedis.util.JedisAsserts;
+
+public class RedirectCommandExecutor implements CommandExecutor {
+
+  private final Logger log = LoggerFactory.getLogger(getClass());
+
+  public final RedirectConnectionProvider provider;
+  protected final int maxAttempts;
+  protected final Duration maxTotalRetriesDuration;
+
+  public RedirectCommandExecutor(RedirectConnectionProvider provider, int maxAttempts,
+      Duration maxTotalRetriesDuration) {
+    JedisAsserts.notNull(provider, "provider must not be null");
+    JedisAsserts.isTrue(maxAttempts > 0, "maxAttempts must be greater than 0");
+    JedisAsserts.notNull(maxTotalRetriesDuration, "maxTotalRetriesDuration must not be null");
+
+    this.provider = provider;
+    this.maxAttempts = maxAttempts;
+    this.maxTotalRetriesDuration = maxTotalRetriesDuration;
+  }
+
+  @Override
+  public void close() {
+    this.provider.close();
+  }
+
+  @Override
+  public final <T> T executeCommand(CommandObject<T> commandObject) {
+    Instant deadline = Instant.now().plus(maxTotalRetriesDuration);
+
+    int consecutiveConnectionFailures = 0;
+    Exception lastException = null;
+    for (int attemptsLeft = this.maxAttempts; attemptsLeft > 0; attemptsLeft--) {
+      Connection connection = null;
+      try {
+        connection = provider.getConnection();
+        return execute(connection, commandObject);
+
+      } catch (JedisConnectionException jce) {
+        lastException = jce;
+        ++consecutiveConnectionFailures;
+        log.debug("Failed connecting to Redis: {}", connection, jce);
+        boolean reset = handleConnectionProblem(attemptsLeft - 1, consecutiveConnectionFailures,
+          deadline);
+        if (reset) {
+          consecutiveConnectionFailures = 0;
+        }
+      } catch (JedisRedirectionException jre) {
+        if (lastException == null || lastException instanceof JedisRedirectionException) {
+          lastException = jre;
+        }
+        log.debug("Redirected by server to {}", jre.getTargetNode());
+        consecutiveConnectionFailures = 0;
+        provider.renewPool(connection, jre.getTargetNode());
+      } finally {
+        IOUtils.closeQuietly(connection);
+      }
+      if (Instant.now().isAfter(deadline)) {
+        throw new JedisException("Redirect retry deadline exceeded.");
+      }
+    }
+
+    JedisException maxRedirectException = new JedisException("No more redirect attempts left.");
+    if (lastException != null) {
+      maxRedirectException.addSuppressed(lastException);
+    }
+    throw maxRedirectException;
+  }
+
+  @VisibleForTesting
+  protected <T> T execute(Connection connection, CommandObject<T> commandObject) {
+    return connection.executeCommand(commandObject);
+  }
+
+  private boolean handleConnectionProblem(int attemptsLeft, int consecutiveConnectionFailures,
+      Instant doneDeadline) {
+    if (this.maxAttempts < 3) {
+      if (attemptsLeft == 0) {
+        provider.renewPool(null, null);
+        return true;
+      }
+      return false;
+    }
+
+    if (consecutiveConnectionFailures < 2) {
+      return false;
+    }
+
+    sleep(getBackoffSleepMillis(attemptsLeft, doneDeadline));
+    provider.renewPool(null, null);
+    return true;
+  }
+
+  private static long getBackoffSleepMillis(int attemptsLeft, Instant deadline) {
+    if (attemptsLeft <= 0) {
+      return 0;
+    }
+
+    long millisLeft = Duration.between(Instant.now(), deadline).toMillis();
+    if (millisLeft < 0) {
+      throw new JedisException("Redirect retry deadline exceeded.");
+    }
+
+    long maxBackOff = millisLeft / (attemptsLeft * attemptsLeft);
+    return ThreadLocalRandom.current().nextLong(maxBackOff + 1);
+  }
+
+  @VisibleForTesting
+  protected void sleep(long sleepMillis) {
+    try {
+      TimeUnit.MILLISECONDS.sleep(sleepMillis);
+    } catch (InterruptedException e) {
+      throw new JedisException(e);
+    }
+  }
+}

--- a/src/main/java/redis/clients/jedis/providers/RedirectConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/RedirectConnectionProvider.java
@@ -1,0 +1,118 @@
+package redis.clients.jedis.providers;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.ConnectionPool;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisClientConfig;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.util.Pool;
+
+public class RedirectConnectionProvider implements ConnectionProvider {
+
+  private static final Logger logger = LoggerFactory.getLogger(RedirectConnectionProvider.class);
+
+  private Pool<Connection> pool;
+  private HostAndPort hostAndPort;
+  private final JedisClientConfig clientConfig;
+  private final GenericObjectPoolConfig<Connection> poolConfig;
+
+  private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
+  private final Lock r = rwl.readLock();
+  private final Lock w = rwl.writeLock();
+  private final Lock rediscoverLock = new ReentrantLock();
+
+  public RedirectConnectionProvider(HostAndPort hostAndPort) {
+    this(hostAndPort, DefaultJedisClientConfig.builder().build());
+  }
+
+  public RedirectConnectionProvider(HostAndPort hostAndPort, JedisClientConfig clientConfig) {
+    this(hostAndPort, clientConfig, new GenericObjectPoolConfig<>());
+  }
+
+  public RedirectConnectionProvider(HostAndPort hostAndPort, JedisClientConfig clientConfig,
+      GenericObjectPoolConfig<Connection> poolConfig) {
+    this.hostAndPort = hostAndPort;
+    this.clientConfig = clientConfig;
+    this.poolConfig = poolConfig;
+    this.pool = new ConnectionPool(hostAndPort, clientConfig, poolConfig);
+  }
+
+  public void renewPool(Connection connection, HostAndPort targetNode) {
+    if (rediscoverLock.tryLock()) {
+      try {
+        HostAndPort oldNode = hostAndPort;
+        if (targetNode != null) {
+          this.hostAndPort = targetNode;
+        }
+
+        w.lock();
+        try {
+          if (!pool.isClosed()) {
+            try {
+              pool.close();
+            } catch (JedisException e) {
+              logger.warn("close pool get exception, hostAndPort:{}", oldNode, e);
+            }
+          }
+          this.pool = new ConnectionPool(hostAndPort, clientConfig, poolConfig);
+        } finally {
+          w.unlock();
+        }
+      } finally {
+        rediscoverLock.unlock();
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    w.lock();
+    try {
+      pool.close();
+    } finally {
+      w.unlock();
+    }
+  }
+
+  @Override
+  public Connection getConnection(CommandArguments args) {
+    return getConnection();
+  }
+
+  @Override
+  public Connection getConnection() {
+    r.lock();
+    try {
+      return pool.getResource();
+    } finally {
+      r.unlock();
+    }
+  }
+
+  @Override
+  public Map<?, Pool<Connection>> getConnectionMap() {
+    r.lock();
+    try {
+      return Collections.singletonMap(hostAndPort, pool);
+    } finally {
+      r.unlock();
+    }
+  }
+
+  @Override
+  public Map<?, Pool<Connection>> getPrimaryNodesConnectionMap() {
+    return getConnectionMap();
+  }
+}

--- a/src/test/java/redis/clients/jedis/DefaultJedisClientConfigTest.java
+++ b/src/test/java/redis/clients/jedis/DefaultJedisClientConfigTest.java
@@ -125,5 +125,40 @@ class DefaultJedisClientConfigTest {
       assertThat(copied.getUser(), equalTo("testuser"));
       assertThat(copied.getPassword(), equalTo("testpass"));
     }
+
+    @Test
+    void builderUsesDefaultClientCapaConfig() {
+      DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().build();
+
+      assertFalse(config.getClientCapaConfig().isRedirect());
+    }
+
+    @Test
+    void builderAppliesClientCapaConfig() {
+      DefaultJedisClientConfig config = DefaultJedisClientConfig.builder()
+          .clientCapaConfig(ClientCapaConfig.withRedirect()).build();
+
+      assertTrue(config.getClientCapaConfig().isRedirect());
+    }
+
+    @Test
+    void builderFromCopiesClientCapaConfig() {
+      DefaultJedisClientConfig original = DefaultJedisClientConfig.builder()
+          .clientCapaConfig(ClientCapaConfig.withRedirect()).build();
+
+      DefaultJedisClientConfig copied = DefaultJedisClientConfig.builder().from(original).build();
+
+      assertTrue(copied.getClientCapaConfig().isRedirect());
+    }
+
+    @Test
+    void copyConfigCopiesClientCapaConfig() {
+      DefaultJedisClientConfig original = DefaultJedisClientConfig.builder()
+          .clientCapaConfig(ClientCapaConfig.withRedirect()).build();
+
+      JedisClientConfig copied = DefaultJedisClientConfig.copyConfig(original);
+
+      assertTrue(copied.getClientCapaConfig().isRedirect());
+    }
   }
 }

--- a/src/test/java/redis/clients/jedis/ProtocolTest.java
+++ b/src/test/java/redis/clients/jedis/ProtocolTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 
 import redis.clients.jedis.exceptions.JedisBusyException;
+import redis.clients.jedis.exceptions.JedisRedirectionException;
 import redis.clients.jedis.util.RedisInputStream;
 import redis.clients.jedis.util.RedisOutputStream;
 import redis.clients.jedis.util.SafeEncoder;
@@ -140,6 +141,20 @@ public class ProtocolTest {
       return;
     }
     fail("Expected a JedisBusyException to be thrown.");
+  }
+
+  @Test
+  public void redirectReply() {
+    final String redirectMessage = "REDIRECT 127.0.0.1:6380";
+    final InputStream is = new ByteArrayInputStream(('-' + redirectMessage + "\r\n").getBytes());
+
+    JedisRedirectionException exception = assertThrows(JedisRedirectionException.class,
+        () -> Protocol.read(new RedisInputStream(is)));
+
+    assertEquals(redirectMessage, exception.getMessage());
+    assertEquals("127.0.0.1", exception.getTargetNode().getHost());
+    assertEquals(6380, exception.getTargetNode().getPort());
+    assertEquals(-1, exception.getSlot());
   }
 
   // ==================== Verbatim String Tests (RESP3) ====================

--- a/src/test/java/redis/clients/jedis/RedirectPoolTest.java
+++ b/src/test/java/redis/clients/jedis/RedirectPoolTest.java
@@ -1,0 +1,190 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.redis.test.annotations.ConditionalOnEnv;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.args.ClientPauseMode;
+import redis.clients.jedis.providers.RedirectConnectionProvider;
+import redis.clients.jedis.util.EnvCondition;
+import redis.clients.jedis.util.TestEnvUtil;
+
+@Tag("integration")
+@ConditionalOnEnv(value = TestEnvUtil.ENV_OSS_DOCKER, enabled = true)
+public class RedirectPoolTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(RedirectPoolTest.class);
+  private static final String NODE1_ENDPOINT = "standalone9-failover";
+  private static final String NODE2_ENDPOINT = "standalone10-replica-of-standalone9";
+
+  @RegisterExtension
+  public static EnvCondition envCondition = new EnvCondition();
+
+  private static EndpointConfig node1;
+  private static EndpointConfig node2;
+  private static JedisClientConfig node1ClientConfig;
+  private static JedisClientConfig node2ClientConfig;
+
+  private HostAndPort masterAddress;
+  private HostAndPort replicaAddress;
+  private JedisClientConfig masterClientConfig;
+
+  @BeforeAll
+  public static void setUp() {
+    node1 = Endpoints.getRedisEndpoint(NODE1_ENDPOINT);
+    node2 = Endpoints.getRedisEndpoint(NODE2_ENDPOINT);
+    node1ClientConfig = createClientConfig(node1);
+    node2ClientConfig = createClientConfig(node2);
+    Assumptions.assumeTrue(isRedirectCapabilityAvailable(),
+      "Server does not support CLIENT CAPA REDIRECT.");
+  }
+
+  private static boolean isRedirectCapabilityAvailable() {
+    try (Jedis jedis = new Jedis(node1.getHostAndPort(), node1ClientConfig)) {
+      return "PONG".equals(jedis.ping());
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  @BeforeEach
+  public void prepare() {
+    String role1;
+    String role2;
+    try (Jedis jedis1 = new Jedis(node1.getHostAndPort(), node1ClientConfig)) {
+      role1 = roleOf(jedis1);
+    }
+    try (Jedis jedis2 = new Jedis(node2.getHostAndPort(), node2ClientConfig)) {
+      role2 = roleOf(jedis2);
+    }
+
+    if (isMaster(role1) && isReplica(role2)) {
+      masterAddress = node1.getHostAndPort();
+      replicaAddress = node2.getHostAndPort();
+      masterClientConfig = node1ClientConfig;
+    } else if (isMaster(role2) && isReplica(role1)) {
+      masterAddress = node2.getHostAndPort();
+      replicaAddress = node1.getHostAndPort();
+      masterClientConfig = node2ClientConfig;
+    } else {
+      fail("role not match, node1=" + role1 + ", node2=" + role2);
+    }
+  }
+
+  private static JedisClientConfig createClientConfig(EndpointConfig endpoint) {
+    return endpoint.getClientConfigBuilder().socketTimeoutMillis(60000).autoNegotiateProtocol(false)
+        .clientSetInfoConfig(ClientSetInfoConfig.DISABLED)
+        .clientCapaConfig(ClientCapaConfig.withRedirect()).build();
+  }
+
+  private static String roleOf(Jedis jedis) {
+    return ((String) jedis.role().get(0)).toLowerCase(Locale.ROOT);
+  }
+
+  private static boolean isMaster(String role) {
+    return "master".equals(role);
+  }
+
+  private static boolean isReplica(String role) {
+    return "slave".equals(role) || "replica".equals(role);
+  }
+
+  private JedisClientConfig clientConfigFor(HostAndPort hostAndPort) {
+    if (node1.getHostAndPort().equals(hostAndPort)) {
+      return node1ClientConfig;
+    }
+    if (node2.getHostAndPort().equals(hostAndPort)) {
+      return node2ClientConfig;
+    }
+    throw new IllegalArgumentException("Unknown node: " + hostAndPort);
+  }
+
+  private void changeMaster() throws Exception {
+    prepare();
+    try (Jedis masterJedis = new Jedis(masterAddress, clientConfigFor(masterAddress));
+        Jedis replicaJedis = new Jedis(replicaAddress, clientConfigFor(replicaAddress))) {
+      replicaJedis.readonly();
+      masterJedis.clientPause(60000, ClientPauseMode.WRITE);
+      try {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        while (masterJedis.dbSize() != replicaJedis.dbSize()) {
+          if (System.nanoTime() > deadline) {
+            fail("Replication did not catch up before redirect master change.");
+          }
+          Thread.sleep(100);
+        }
+        replicaJedis.replicaofNoOne();
+        masterJedis.replicaof(replicaAddress.getHost(), replicaAddress.getPort());
+      } finally {
+        masterJedis.clientUnpause();
+      }
+    }
+  }
+
+  @Test
+  @Timeout(60)
+  public void basicRedirect() throws Exception {
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    try (UnifiedJedis unifiedJedis = new UnifiedJedis(
+        new RedirectConnectionProvider(masterAddress, masterClientConfig), 60,
+        Duration.ofSeconds(60))) {
+      Thread[] workers = new Thread[4];
+      for (int i = 0; i < workers.length; i++) {
+        final int workerId = i;
+        workers[i] = new Thread(() -> {
+          try {
+            for (int j = 0; j < 120; j++) {
+              Thread.sleep(50);
+              String key = "redirect:" + workerId + ':' + j;
+              String value = workerId + ":" + j;
+              assertEquals("OK", unifiedJedis.set(key, value));
+              assertEquals(value, unifiedJedis.get(key));
+            }
+          } catch (Throwable t) {
+            failure.compareAndSet(null, t);
+          }
+        });
+      }
+
+      Thread failover = new Thread(() -> {
+        try {
+          for (int i = 0; i < 3; i++) {
+            Thread.sleep(1500);
+            changeMaster();
+            logger.info("Changed master {} time(s)", i + 1);
+          }
+        } catch (Throwable t) {
+          failure.compareAndSet(null, t);
+        }
+      });
+
+      for (Thread worker : workers) {
+        worker.start();
+      }
+      failover.start();
+      for (Thread worker : workers) {
+        worker.join();
+      }
+      failover.join();
+    }
+
+    Throwable throwable = failure.get();
+    if (throwable != null) {
+      fail("Redirect should not throw exception", throwable);
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/executors/RedirectCommandExecutorTest.java
+++ b/src/test/java/redis/clients/jedis/executors/RedirectCommandExecutorTest.java
@@ -1,0 +1,137 @@
+package redis.clients.jedis.executors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.exceptions.JedisRedirectionException;
+import redis.clients.jedis.providers.RedirectConnectionProvider;
+
+@ExtendWith(MockitoExtension.class)
+public class RedirectCommandExecutorTest {
+
+  @Mock
+  private RedirectConnectionProvider mockProvider;
+
+  @Mock
+  private Connection firstConnection;
+
+  @Mock
+  private Connection secondConnection;
+
+  @Mock
+  private CommandObject<String> mockCommandObject;
+
+  @Test
+  public void constructorRejectsNullProvider() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> new RedirectCommandExecutor(null, 3, Duration.ofSeconds(1)));
+
+    assertTrue(exception.getMessage().contains("provider"));
+  }
+
+  @Test
+  public void constructorRejectsInvalidMaxAttempts() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> new RedirectCommandExecutor(mockProvider, 0, Duration.ofSeconds(1)));
+
+    assertTrue(exception.getMessage().contains("maxAttempts"));
+  }
+
+  @Test
+  public void constructorRejectsNullMaxTotalRetriesDuration() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+      () -> new RedirectCommandExecutor(mockProvider, 3, null));
+
+    assertTrue(exception.getMessage().contains("maxTotalRetriesDuration"));
+  }
+
+  @Test
+  public void constructorAcceptsValidValues() {
+    assertDoesNotThrow(() -> new RedirectCommandExecutor(mockProvider, 1, Duration.ZERO));
+    assertDoesNotThrow(() -> new RedirectCommandExecutor(mockProvider, 3, Duration.ofSeconds(1)));
+  }
+
+  @Test
+  public void executeCommandReturnsSuccessfulResult() {
+    when(mockProvider.getConnection()).thenReturn(firstConnection);
+    when(firstConnection.executeCommand(mockCommandObject)).thenReturn("success");
+
+    RedirectCommandExecutor executor = new RedirectCommandExecutor(mockProvider, 1,
+        Duration.ofSeconds(1));
+
+    assertEquals("success", executor.executeCommand(mockCommandObject));
+    verify(mockProvider, times(1)).getConnection();
+    verify(firstConnection, times(1)).close();
+  }
+
+  @Test
+  public void executeCommandRenewsPoolAndRetriesOnRedirect() {
+    HostAndPort targetNode = new HostAndPort("127.0.0.1", 6380);
+    JedisRedirectionException redirect = new JedisRedirectionException("REDIRECT 127.0.0.1:6380",
+        targetNode, -1);
+    when(mockProvider.getConnection()).thenReturn(firstConnection, secondConnection);
+    when(firstConnection.executeCommand(mockCommandObject)).thenThrow(redirect);
+    when(secondConnection.executeCommand(mockCommandObject)).thenReturn("success");
+
+    RedirectCommandExecutor executor = new RedirectCommandExecutor(mockProvider, 2,
+        Duration.ofSeconds(1));
+
+    assertEquals("success", executor.executeCommand(mockCommandObject));
+    verify(mockProvider, times(2)).getConnection();
+    verify(mockProvider, times(1)).renewPool(firstConnection, targetNode);
+    verify(firstConnection, times(1)).close();
+    verify(secondConnection, times(1)).close();
+  }
+
+  @Test
+  public void executeCommandStopsAfterMaxRedirectAttempts() {
+    HostAndPort targetNode = new HostAndPort("127.0.0.1", 6380);
+    JedisRedirectionException redirect = new JedisRedirectionException("REDIRECT 127.0.0.1:6380",
+        targetNode, -1);
+    when(mockProvider.getConnection()).thenReturn(firstConnection);
+    when(firstConnection.executeCommand(mockCommandObject)).thenThrow(redirect);
+
+    RedirectCommandExecutor executor = new RedirectCommandExecutor(mockProvider, 2,
+        Duration.ofSeconds(1));
+
+    JedisException exception = assertThrows(JedisException.class,
+      () -> executor.executeCommand(mockCommandObject));
+
+    assertEquals("No more redirect attempts left.", exception.getMessage());
+    assertEquals(1, exception.getSuppressed().length);
+    verify(mockProvider, times(2)).getConnection();
+    verify(mockProvider, times(2)).renewPool(firstConnection, targetNode);
+    verify(firstConnection, times(2)).close();
+  }
+
+  @Test
+  public void executeCommandRenewsPoolOnFinalConnectionFailureWhenRetriesAreLow() {
+    when(mockProvider.getConnection()).thenThrow(new JedisConnectionException("connection failed"));
+    RedirectCommandExecutor executor = new RedirectCommandExecutor(mockProvider, 1,
+        Duration.ofSeconds(1));
+
+    JedisException exception = assertThrows(JedisException.class,
+      () -> executor.executeCommand(mockCommandObject));
+
+    assertEquals("No more redirect attempts left.", exception.getMessage());
+    verify(mockProvider, times(1)).renewPool(eq(null), eq(null));
+  }
+}


### PR DESCRIPTION
This PR adds client-side redirect support for primary/replica deployments in Jedis.

The capability originally came from Redis PR [redis/redis#12192](https://github.com/redis/redis/pull/12192) and is currently implemented in [Valkey](https://valkey.io/commands/client-capa/). It has shown clear benefits for our customers during primary/replica switchovers, and we would like to help make this capability available across more client libraries. 

The feature is disabled by default in Jedis and can be explicitly enabled by users. The integration test also checks server capability and only runs when the server supports `CLIENT CAPA REDIRECT`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection initialization and command retry/failover behavior when enabled; default remains off, but misconfiguration could affect traffic routing during primary/replica transitions.
> 
> **Overview**
> Adds **opt-in** support for Redis/Valkey **CLIENT CAPA REDIRECT**, so standalone primary/replica clients can survive switchovers when the server returns `-REDIRECT host:port`.
> 
> **Configuration:** New `ClientCapaConfig` (default off) is wired through `JedisClientConfig` / `DefaultJedisClientConfig`. When redirect is enabled, `Connection` sends `CLIENT CAPA REDIRECT` during the post-handshake setup batch.
> 
> **Runtime path:** `Protocol` maps `-REDIRECT …` replies to `JedisRedirectionException` (reusing the existing redirection exception type). `RedirectConnectionProvider` holds a single-host pool and **rebuilds the pool** toward the redirect target via `renewPool`. `RedirectCommandExecutor` retries commands on redirect (and on connection failures with backoff/deadline), similar in spirit to cluster retry executors. `UnifiedJedis` gains constructors that pair this provider with `RedirectCommandExecutor`.
> 
> Tests cover config copying, protocol parsing, executor behavior, and a gated integration test under failover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dcaf2dd9df89fcec68c4755afb4a787d3bf1864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->