### PR TITLE
compare byte arrays as unsigned in ByteArrayComparator

### DIFF
--- a/src/main/java/redis/clients/jedis/util/ByteArrayComparator.java
+++ b/src/main/java/redis/clients/jedis/util/ByteArrayComparator.java
@@ -11,10 +11,8 @@ public final class ByteArrayComparator {
     int lmin = Math.min(len1, len2);
 
     for (int i = 0; i < lmin; i++) {
-      byte b1 = val1[i];
-      byte b2 = val2[i];
-      if (b1 < b2) return -1;
-      if (b1 > b2) return 1;
+      int result = Integer.compare(val1[i] & 0xFF, val2[i] & 0xFF);
+      if (result != 0) return result;
     }
 
     if (len1 < len2) return -1;

--- a/src/test/java/redis/clients/jedis/util/ByteArrayComparatorTest.java
+++ b/src/test/java/redis/clients/jedis/util/ByteArrayComparatorTest.java
@@ -24,4 +24,19 @@ public class ByteArrayComparatorTest {
     assertTrue(ByteArrayComparator.compare(foo, fooo) < 0);
     assertTrue(ByteArrayComparator.compare(fooo, foo) > 0);
   }
+
+  @Test
+  public void testHighBitBytesOrderUnsigned() {
+    // Bytes must order as unsigned (0..255) to match Redis' own byte ordering.
+    byte[] low = { (byte) 0x7F }; // 127
+    byte[] high = { (byte) 0x80 }; // 128 unsigned
+    assertTrue(ByteArrayComparator.compare(high, low) > 0);
+    assertTrue(ByteArrayComparator.compare(low, high) < 0);
+
+    // ASCII 'e' (0x65) sorts before the UTF-8 bytes of U+00E9 (0xC3 0xA9).
+    byte[] e = { (byte) 0x65 };
+    byte[] eAcute = { (byte) 0xC3, (byte) 0xA9 };
+    assertTrue(ByteArrayComparator.compare(e, eAcute) < 0);
+    assertTrue(ByteArrayComparator.compare(eAcute, e) > 0);
+  }
 }


### PR DESCRIPTION
    ByteArrayComparator.compare(new byte[]{ (byte) 0x80 }, new byte[]{ 0x7F }) == -1

Java bytes are signed, so a byte with the high bit set reads as negative: 0x80 becomes -128 and sorts before 0x7F. The comparator is meant to order raw bytes lexicographically, which is unsigned, so every value in 0x80..0xFF currently orders before 0x00..0x7F rather than after. That disagrees with Redis' own unsigned byte ordering and shows up for any non-ASCII UTF-8 or binary content.

Tuple implements Comparable<Tuple> and falls back to this comparator to break score ties, so Collections.sort / TreeSet over sorted-set members comes out wrong for those members. The existing tests only cover ASCII (all bytes < 0x80), which is why it went unnoticed.

Fixed by comparing each byte as unsigned with Integer.compare(a & 0xFF, b & 0xFF); the -1/0/1 result and the length tie-break stay as they were. Added a regression for the high-bit and multi-byte UTF-8 cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sort order for non-ASCII/binary sorted-set members and any other ByteArrayComparator callers; behavior aligns with Redis but may reorder existing client-side collections that relied on the buggy ordering.
> 
> **Overview**
> Fixes **lexicographic byte ordering** in `ByteArrayComparator` so each byte is compared as **unsigned** (`0..255`) via `Integer.compare(a & 0xFF, b & 0xFF)` instead of signed Java `byte` comparison. Length tie-breaking is unchanged.
> 
> That wrong ordering affected anything using this helper for raw keys— notably **`Tuple` score ties** in sorted-set sorting— for UTF-8 or binary members with bytes `>= 0x80`. Adds **`testHighBitBytesOrderUnsigned`** for `0x80` vs `0x7F` and a multi-byte UTF-8 case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9468374ba0de653b6fcd6de37470973c10977391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->