### PR TITLE
Fix FTSearchParams.params(Map) dropping values when parameters are already set

### DIFF
--- a/src/main/java/redis/clients/jedis/search/FTSearchParams.java
+++ b/src/main/java/redis/clients/jedis/search/FTSearchParams.java
@@ -412,7 +412,7 @@ public class FTSearchParams implements IParams {
     if (this.params == null) {
       this.params = new HashMap<>(paramValues);
     } else {
-      this.params.putAll(params);
+      this.params.putAll(paramValues);
     }
     return this;
   }

--- a/src/main/java/redis/clients/jedis/search/FTSearchParams.java
+++ b/src/main/java/redis/clients/jedis/search/FTSearchParams.java
@@ -392,12 +392,15 @@ public class FTSearchParams implements IParams {
   }
 
   /**
-   * Parameters can be referenced in the query string by a $ , followed by the parameter name,
-   * e.g., $user , and each such reference in the search query to a parameter name is substituted
-   * by the corresponding parameter value.
+   * Adds a query parameter. Parameters are referenced in the query string by {@code $} followed
+   * by the parameter name, e.g. {@code $user}, and each such reference is substituted by the
+   * corresponding parameter value.
+   * <p>
+   * Adding a parameter with an existing name overwrites its previous value. Parameters
+   * accumulate across {@code addParam} and {@link #params(Map)} calls.
    *
-   * @param name
-   * @param value can be String, long or float
+   * @param name the parameter name, referenced in the query as {@code $name}
+   * @param value the parameter value; can be String, long or float
    * @return the query object itself
    */
   public FTSearchParams addParam(String name, Object value) {
@@ -408,6 +411,15 @@ public class FTSearchParams implements IParams {
     return this;
   }
 
+  /**
+   * Adds all entries of the given map as query parameters, merging them with any parameters
+   * already set via {@link #addParam(String, Object)} or previous {@code params} calls. An entry
+   * whose name is already set overwrites its previous value.
+   *
+   * @param paramValues parameter name to value; values can be String, long or float
+   * @return the query object itself
+   * @see #addParam(String, Object)
+   */
   public FTSearchParams params(Map<String, Object> paramValues) {
     if (this.params == null) {
       this.params = new HashMap<>(paramValues);

--- a/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
@@ -741,6 +741,23 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
   }
 
   @Test
+  public void testQueryParamsMixedAddParamAndMap() {
+    assertOK(jedis.ftCreate(INDEX, NumericField.of("numval")));
+
+    jedis.hset("1", "numval", "1");
+    jedis.hset("2", "numval", "2");
+    jedis.hset("3", "numval", "3");
+
+    Map<String, Object> paramValues = new HashMap<>();
+    paramValues.put("max", 2);
+    assertEquals(2,
+      jedis
+          .ftSearch(INDEX, "@numval:[$min $max]",
+            FTSearchParams.searchParams().addParam("min", 1).params(paramValues).dialect(2))
+          .getTotalResults());
+  }
+
+  @Test
   public void testSortQueryFlags() {
     assertOK(jedis.ftCreate(INDEX, TextField.of("title").sortable()));
 

--- a/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
+++ b/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
@@ -7,6 +7,7 @@ import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArgument;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import redis.clients.jedis.CommandArguments;
@@ -15,33 +16,47 @@ import redis.clients.jedis.search.SearchProtocol.SearchCommand;
 
 public class FTSearchParamsTest {
 
-  @Test
-  public void paramsMapMergesWhenParametersAlreadySet() {
-    Map<String, Object> more = new HashMap<>();
-    more.put("added", "2");
+  private static final String INDEX = "idx";
+  private static final String QUERY = "@price:[$min $max]";
 
-    FTSearchParams params = FTSearchParams.searchParams().addParam("existing", "1").params(more);
-
-    CommandArguments args = new CommandArguments(SearchCommand.SEARCH);
-    params.addParams(args);
-
-    assertThat(args, containsArguments("existing", "1", "added", "2"));
-    assertThat(args, hasArgument(2, RawableFactory.from(4)));
+  /** The command prefix FT.SEARCH is built with: SEARCH &lt;index&gt; &lt;query&gt;. */
+  private CommandArguments searchArguments() {
+    return new CommandArguments(SearchCommand.SEARCH).add(INDEX).add(QUERY);
   }
 
-  @Test
-  public void paramsMapMergesAcrossTwoMapCalls() {
-    Map<String, Object> first = new HashMap<>();
-    first.put("first", "1");
-    Map<String, Object> second = new HashMap<>();
-    second.put("second", "2");
+  @Nested
+  class AddParamsTests {
 
-    FTSearchParams params = FTSearchParams.searchParams().params(first).params(second);
+    @Test
+    public void paramsMapMergesWhenParametersAlreadySet() {
+      Map<String, Object> more = new HashMap<>();
+      more.put("max", "2");
 
-    CommandArguments args = new CommandArguments(SearchCommand.SEARCH);
-    params.addParams(args);
+      FTSearchParams params = FTSearchParams.searchParams().addParam("min", "1").params(more);
 
-    assertThat(args, containsArguments("first", "1", "second", "2"));
-    assertThat(args, hasArgument(2, RawableFactory.from(4)));
+      CommandArguments args = searchArguments();
+      params.addParams(args);
+
+      // Expected: FT.SEARCH idx @price:[$min $max] PARAMS 4 <min 1 max 2 in any order>
+      assertThat(args, containsArguments("min", "1", "max", "2"));
+      assertThat(args, hasArgument(4, RawableFactory.from(4)));
+    }
+
+    @Test
+    public void paramsMapMergesAcrossTwoMapCalls() {
+      Map<String, Object> first = new HashMap<>();
+      first.put("min", "1");
+      Map<String, Object> second = new HashMap<>();
+      second.put("max", "2");
+
+      FTSearchParams params = FTSearchParams.searchParams().params(first).params(second);
+
+      CommandArguments args = searchArguments();
+      params.addParams(args);
+
+      // Expected: FT.SEARCH idx @price:[$min $max] PARAMS 4 <min 1 max 2 in any order>
+      assertThat(args, containsArguments("min", "1", "max", "2"));
+      assertThat(args, hasArgument(4, RawableFactory.from(4)));
+    }
   }
 }

--- a/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
+++ b/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
@@ -58,5 +58,35 @@ public class FTSearchParamsTest {
       assertThat(args, containsArguments("min", "1", "max", "2"));
       assertThat(args, hasArgument(4, RawableFactory.from(4)));
     }
+
+    @Test
+    public void paramsMapOverwritesValueSetByAddParam() {
+      Map<String, Object> map = new HashMap<>();
+      map.put("min", "9");
+
+      FTSearchParams params = FTSearchParams.searchParams().addParam("min", "1").params(map);
+
+      CommandArguments args = searchArguments();
+      params.addParams(args);
+
+      // Expected: FT.SEARCH idx @price:[$min $max] PARAMS 2 min 9
+      assertThat(args, containsArguments("min", "9"));
+      assertThat(args, hasArgument(4, RawableFactory.from(2)));
+    }
+
+    @Test
+    public void addParamOverwritesValueSetByParamsMap() {
+      Map<String, Object> map = new HashMap<>();
+      map.put("min", "1");
+
+      FTSearchParams params = FTSearchParams.searchParams().params(map).addParam("min", "9");
+
+      CommandArguments args = searchArguments();
+      params.addParams(args);
+
+      // Expected: FT.SEARCH idx @price:[$min $max] PARAMS 2 min 9
+      assertThat(args, containsArguments("min", "9"));
+      assertThat(args, hasArgument(4, RawableFactory.from(2)));
+    }
   }
 }

--- a/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
+++ b/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
@@ -2,6 +2,7 @@ package redis.clients.jedis.search;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static redis.clients.jedis.util.CommandArgumentsMatchers.containsArguments;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArgument;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,12 +10,13 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.args.RawableFactory;
 import redis.clients.jedis.search.SearchProtocol.SearchCommand;
 
 public class FTSearchParamsTest {
 
   @Test
-  public void paramsMapMergesInsteadOfDroppingValues() {
+  public void paramsMapMergesWhenParametersAlreadySet() {
     Map<String, Object> more = new HashMap<>();
     more.put("added", "2");
 
@@ -28,5 +30,27 @@ public class FTSearchParamsTest {
     // Both the pre-existing parameter and the merged-in parameter must be emitted;
     // previously the merge branch copied the field onto itself and dropped the map.
     assertThat(args, containsArguments("existing", "1", "added", "2"));
+    // Pin the PARAMS arity token (two names + two values). containsArguments is
+    // presence-only, so it does not by itself catch a wrong count; the arity is the
+    // part the server parses.
+    assertThat(args, hasArgument(2, RawableFactory.from(4)));
+  }
+
+  @Test
+  public void paramsMapMergesAcrossTwoMapCalls() {
+    Map<String, Object> first = new HashMap<>();
+    first.put("first", "1");
+    Map<String, Object> second = new HashMap<>();
+    second.put("second", "2");
+
+    // The merge branch is also reached when params(map) is called a second time;
+    // the values from the first call must survive the second.
+    FTSearchParams params = FTSearchParams.searchParams().params(first).params(second);
+
+    CommandArguments args = new CommandArguments(SearchCommand.SEARCH);
+    params.addParams(args);
+
+    assertThat(args, containsArguments("first", "1", "second", "2"));
+    assertThat(args, hasArgument(2, RawableFactory.from(4)));
   }
 }

--- a/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
+++ b/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
@@ -20,19 +20,12 @@ public class FTSearchParamsTest {
     Map<String, Object> more = new HashMap<>();
     more.put("added", "2");
 
-    // Parameters are already present (via addParam) when the map overload is called,
-    // so params(map) takes the merge branch.
     FTSearchParams params = FTSearchParams.searchParams().addParam("existing", "1").params(more);
 
     CommandArguments args = new CommandArguments(SearchCommand.SEARCH);
     params.addParams(args);
 
-    // Both the pre-existing parameter and the merged-in parameter must be emitted;
-    // previously the merge branch copied the field onto itself and dropped the map.
     assertThat(args, containsArguments("existing", "1", "added", "2"));
-    // Pin the PARAMS arity token (two names + two values). containsArguments is
-    // presence-only, so it does not by itself catch a wrong count; the arity is the
-    // part the server parses.
     assertThat(args, hasArgument(2, RawableFactory.from(4)));
   }
 
@@ -43,8 +36,6 @@ public class FTSearchParamsTest {
     Map<String, Object> second = new HashMap<>();
     second.put("second", "2");
 
-    // The merge branch is also reached when params(map) is called a second time;
-    // the values from the first call must survive the second.
     FTSearchParams params = FTSearchParams.searchParams().params(first).params(second);
 
     CommandArguments args = new CommandArguments(SearchCommand.SEARCH);

--- a/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
+++ b/src/test/java/redis/clients/jedis/search/FTSearchParamsTest.java
@@ -1,0 +1,32 @@
+package redis.clients.jedis.search;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.containsArguments;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.search.SearchProtocol.SearchCommand;
+
+public class FTSearchParamsTest {
+
+  @Test
+  public void paramsMapMergesInsteadOfDroppingValues() {
+    Map<String, Object> more = new HashMap<>();
+    more.put("added", "2");
+
+    // Parameters are already present (via addParam) when the map overload is called,
+    // so params(map) takes the merge branch.
+    FTSearchParams params = FTSearchParams.searchParams().addParam("existing", "1").params(more);
+
+    CommandArguments args = new CommandArguments(SearchCommand.SEARCH);
+    params.addParams(args);
+
+    // Both the pre-existing parameter and the merged-in parameter must be emitted;
+    // previously the merge branch copied the field onto itself and dropped the map.
+    assertThat(args, containsArguments("existing", "1", "added", "2"));
+  }
+}


### PR DESCRIPTION
### What

`FTSearchParams.params(Map<String, Object> paramValues)` is meant to merge the
given values into any parameters already set. The merge branch copies the field
onto itself instead of the argument:

```java
public FTSearchParams params(Map<String, Object> paramValues) {
  if (this.params == null) {
    this.params = new HashMap<>(paramValues);
  } else {
    this.params.putAll(params);   // uses the field, not the argument
  }
  return this;
}
```

`params` here resolves to the field, so `this.params.putAll(params)` is
`this.params.putAll(this.params)` — a no-op, and the supplied `paramValues` are
dropped.

### Impact

Whenever parameters are already present — e.g. `addParam(...)` followed by
`params(map)`, or two `params(map)` calls — the second map is silently
discarded. Those values never reach the wire (the `PARAMS` clause omits them),
so an `FT.SEARCH` query that references the corresponding `$name` placeholders
does not get them substituted. When the parameter map starts empty the first
branch is taken and the value is preserved, which is why this went unnoticed.

### Fix

Use the `paramValues` argument in the merge branch.

### Test

Added `FTSearchParamsTest.paramsMapMergesInsteadOfDroppingValues`, a server-free
unit test that sets one parameter via `addParam`, then merges a second via
`params(Map)`, and asserts both are emitted in the built command arguments. It
fails on the current code and passes with the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fix to RediSearch query parameter assembly with dedicated unit and integration tests; no auth or data-path changes beyond correct PARAMS emission.
> 
> **Overview**
> Fixes **`FTSearchParams.params(Map)`** so a second map actually merges when parameters already exist (e.g. after **`addParam`** or an earlier **`params`** call). The merge branch incorrectly called **`putAll`** on the internal map with itself, so extra **`paramValues`** were dropped and never appeared in the **`PARAMS`** clause for **`FT.SEARCH`**.
> 
> Documents merge/overwrite behavior on **`addParam`** and **`params`**. Adds unit tests in **`FTSearchParamsTest`** and an integration test **`testQueryParamsMixedAddParamAndMap`** for mixed **`addParam`** + **`params`** usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7500187ca6049dad25506fba4bff161af71f792e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->