### PR TITLE
Bump snapshot version to 8.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ The most recent version of this library supports redis version
 [7.2](https://github.com/redis/redis/blob/7.2/00-RELEASENOTES),
 [7.4](https://github.com/redis/redis/blob/7.4/00-RELEASENOTES),
 [8.0](https://github.com/redis/redis/blob/8.0/00-RELEASENOTES),
-[8.2](https://github.com/redis/redis/blob/8.2/00-RELEASENOTES) and
-[8.4](https://github.com/redis/redis/blob/8.4/00-RELEASENOTES).
+[8.2](https://github.com/redis/redis/blob/8.2/00-RELEASENOTES),
+[8.4](https://github.com/redis/redis/blob/8.4/00-RELEASENOTES),
+[8.6](https://github.com/redis/redis/blob/8.6/00-RELEASENOTES),
+[8.8](https://github.com/redis/redis/blob/8.8/00-RELEASENOTES) and
+[8.10](https://github.com/redis/redis/blob/8.10/00-RELEASENOTES).
 
 The table below highlights version compatibility of the most-recent library versions with Redis and JDK versions. Compatibility means communication features, and Redis command capabilities.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The table below highlights version compatibility of the most-recent library vers
 | >= 5.2        | Version 7.2 to current                | 8, 11, 17, 21     |
 | >= 6.0        | Version 7.2 to current                | 8, 11, 17, 21     |
 | >= 7.0        | Version 7.2 to current                | 8, 11, 17, 21     |
+| >= 8.0        | Version 7.2 to current                | 8, 11, 17, 21, 25 |
 
 ## Getting started
 
@@ -54,7 +55,7 @@ To get started with Jedis, first add it as a dependency in your Java project. If
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>7.1.0</version>
+    <version>8.0.0</version>
 </dependency>
 ```
 

--- a/docs/jedis-maven.md
+++ b/docs/jedis-maven.md
@@ -6,7 +6,7 @@
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>6.2.0</version>
+    <version>8.0.0</version>
 </dependency>
 ```
 
@@ -15,8 +15,8 @@
 ```xml
 <repositories>
     <repository>
-        <id>sonatype-snapshots</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        <id>central-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <releases>
             <enabled>false</enabled>
         </releases>
@@ -34,7 +34,7 @@ and
     <dependency>
         <groupId>redis.clients</groupId>
         <artifactId>jedis</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+        <version>8.1.0-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>jar</packaging>
 	<groupId>redis.clients</groupId>
 	<artifactId>jedis</artifactId>
-	<version>8.0.0-SNAPSHOT</version>
+	<version>8.1.0-SNAPSHOT</version>
 	<name>Jedis</name>
 	<description>Jedis is a blazingly small and sane Redis java client.</description>
 	<url>https://github.com/redis/jedis</url>


### PR DESCRIPTION
8.0.0 has been released ([v8.0.0](https://github.com/redis/jedis/releases/tag/v8.0.0)); master now targets the next minor release, 8.1.0.

Bumping to `8.1.0-SNAPSHOT`  — upcoming work (e.g. smart client handoff) lands here, and new public API merged from now on should be annotated `@since 8.1`

Same as #4464 for the previous cycle.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and POM version metadata only; no runtime or API code changes.
> 
> **Overview**
> Moves **master** to the next minor development line by setting `pom.xml` to **`8.1.0-SNAPSHOT`** (from `8.0.0-SNAPSHOT`), matching the post-GA workflow where upcoming features target 8.1.
> 
> **README** updates the supported Redis server list (adds **8.6**, **8.8**, **8.10**), documents **Jedis ≥ 8.0** with **JDK 25** in the compatibility table, and changes the getting-started Maven example to **`8.0.0`**.
> 
> **`docs/jedis-maven.md`** points official releases at **`8.0.0`**, snapshot consumers at **`8.1.0-SNAPSHOT`**, and switches the snapshot repository to **Maven Central** (`central-snapshots` / `https://central.sonatype.com/repository/maven-snapshots/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d607fcecf09e08f379d59e126a9f57205344e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->