### PR TITLE
Start release notes for 8.1.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ It covers standalone, cluster, sentinel, and multi-db setups — with pipelining
 - **Keep documentation up to date.** If a change affects user-facing behavior, configuration, or the public API, update the relevant pages under [`docs/`](docs) (MkDocs).
 - **Add or update tests.** Every bug fix should include a regression test, and every new feature should include appropriate tests. Follow the conventions in [`docs/integration-testing.md`](docs/integration-testing.md) for choosing between unit and integration tests.
 - **Document breaking changes.** Any breaking change must be documented in the appropriate migration guide under [`docs/migration-guides/`](docs/migration-guides).
+- **Record behavior changes in the release notes.** If a change alters user-visible behavior without breaking the API, add an entry to the running notes for the next release under [`docs/release-notes/`](docs/release-notes) in the same PR, following the entry format in that file.
 - **Follow the contribution guidelines.** Ensure all changes comply with the project rules in [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 - **Request approval before adding dependencies.** Do not introduce new runtime, test, or build dependencies without explicit confirmation.
 - **Review-friendly changes.** Keep commits and pull requests focused and logically grouped. Separate feature or bug-fix changes from refactoring, formatting, and other mechanical changes whenever practical.

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -1,0 +1,33 @@
+# Jedis 8.1.0
+
+!!! warning "Unreleased"
+    Jedis 8.1.0 has not been released yet. These notes track changes on `master`
+    since 8.0.0 and are updated as changes merge; remove this notice when 8.1.0
+    ships.
+
+!!! note
+    If your change alters user-visible behavior, add an entry here in the same PR.
+
+## Highlights
+
+...
+
+## Behavior Changes
+
+Changes that may affect existing applications even though they are
+not breaking API changes.
+
+### Key pre-processor applied to all key arguments ([#4675](https://github.com/redis/jedis/pull/4675))
+
+The source key of `ZRANGESTORE`/`GEOSEARCHSTORE` and the script `KEYS` passed to
+`eval(script, keyCount, ...)` / `evalsha(sha1, keyCount, ...)` were previously not
+treated as keys: a configured `CommandKeyArgumentPreProcessor` (e.g. key prefixing)
+did not transform them, and the store commands' source key was invisible to cluster
+key routing. They are now handled like every other key argument: the pre-processor
+applies to them, and on cluster a cross-slot `ZRANGESTORE`/`GEOSEARCHSTORE` fails
+client-side with `JedisClusterOperationException` instead of the server's CROSSSLOT
+error.
+
+**Action required:** remove any manual prefixing workaround for these arguments
+(they would now be prefixed twice), and update `catch` blocks that matched the
+server CROSSSLOT `JedisDataException` for these commands.

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -1,11 +1,11 @@
 # Jedis 8.1.0 Release Notes
 
-**Full Changelog**: [v8.0.0...master](https://github.com/redis/jedis/compare/v8.0.0...master)
+This guide helps you upgrade from Jedis 8.0.0.
 
 !!! warning "Unreleased"
     Jedis 8.1.0 has not been released yet. These notes track changes on `master`
-    since 8.0.0 and are updated as changes merge. When 8.1.0 ships, remove this
-    notice and point the changelog link at `v8.0.0...v8.1.0`.
+    since 8.0.0 and are updated as changes merge; remove this notice when 8.1.0
+    ships.
 
 !!! note
     If your change alters user-visible behavior, add an entry here in the same PR.

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -1,9 +1,11 @@
-# Jedis 8.1.0
+# Jedis 8.1.0 Release Notes
+
+**Full Changelog**: [v8.0.0...master](https://github.com/redis/jedis/compare/v8.0.0...master)
 
 !!! warning "Unreleased"
     Jedis 8.1.0 has not been released yet. These notes track changes on `master`
-    since 8.0.0 and are updated as changes merge; remove this notice when 8.1.0
-    ships.
+    since 8.0.0 and are updated as changes merge. When 8.1.0 ships, remove this
+    notice and point the changelog link at `v8.0.0...v8.1.0`.
 
 !!! note
     If your change alters user-visible behavior, add an entry here in the same PR.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,8 @@ nav:
   - User Guide:
     - Transactions/Multi: transactions-multi.md
     - Hash Import (HIMPORT): hash-import.md
+  - Release Notes:
+      - 8.1.0: release-notes/8.1.0.md
   - Migrating to newer versions:
       - Jedis 8: migration-guides/v7-to-v8.md
       - Jedis 7: migration-guides/v6-to-v7.md


### PR DESCRIPTION
Adds a running `docs/release-notes/<version>.md` file, appended in the same PR as any user-visible behavior change, so notes are written at merge time instead of reconstructed at release time. Includes the mkdocs nav entry and an AGENTS.md rule making it part of the contribution conventions.

Seeded with the #4675 key pre-processor entry. The page carries an "Unreleased" notice until 8.1.0 ships; removing it is part of the release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and contributor-process updates only; no runtime or API changes in this diff.
> 
> **Overview**
> Introduces a **running release-notes workflow** for the next version: contributors add user-visible behavior changes to `docs/release-notes/8.1.0.md` in the same PR instead of writing notes at release time.
> 
> **AGENTS.md** now requires that non-breaking behavior changes get an entry under `docs/release-notes/`, and **MkDocs** adds a **Release Notes → 8.1.0** nav item. The new page is marked **Unreleased** until 8.1.0 ships and includes a **Behavior Changes** template plus the first entry for [#4675](https://github.com/redis/jedis/pull/4675) (key pre-processor coverage for `ZRANGESTORE`/`GEOSEARCHSTORE` source keys and `eval`/`evalsha` script keys, with upgrade actions for double-prefix workarounds and CROSSSLOT exception handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cd271fb19dddd155b29ebdd1d4ed24302ee6e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->