### PR TITLE
Fix TSAddParams emitting DUPLICATE_POLICY twice

### DIFF
--- a/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
+++ b/src/main/java/redis/clients/jedis/timeseries/TSAddParams.java
@@ -109,10 +109,6 @@ public class TSAddParams implements IParams {
       args.add(DUPLICATE_POLICY).add(duplicatePolicy);
     }
 
-    if (duplicatePolicy != null) {
-      args.add(DUPLICATE_POLICY).add(duplicatePolicy);
-    }
-
     if (onDuplicate != null) {
       args.add(ON_DUPLICATE).add(onDuplicate);
     }

--- a/src/test/java/redis/clients/jedis/timeseries/TSAddParamsTest.java
+++ b/src/test/java/redis/clients/jedis/timeseries/TSAddParamsTest.java
@@ -11,46 +11,54 @@ import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArguments;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.args.RawableFactory;
 import redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesCommand;
 
 public class TSAddParamsTest {
 
-  private static CommandArguments args() {
-    return new CommandArguments(TimeSeriesCommand.ADD);
+  private static CommandArguments tsAddArgs() {
+    // mirrors CommandObjects.tsAdd(key, timestamp, value, params)
+    return new CommandArguments(TimeSeriesCommand.ADD).key("ts:1").add(1000L).add(25.5);
   }
 
   @Nested
   class AddParamsTests {
 
     @Test
-    public void emptyParamsAddsNothing() {
-      CommandArguments args = args();
+    public void noOptionalParamsAddsNothing() {
+      CommandArguments args = tsAddArgs();
       TSAddParams.addParams().addParams(args);
 
-      assertThat(args, hasArgumentCount(1));
-      assertThat(args, hasArguments(TimeSeriesCommand.ADD));
+      // Expected: TS.ADD ts:1 1000 25.5
+      assertThat(args, hasArgumentCount(4));
+      assertThat(args, hasArguments(TimeSeriesCommand.ADD, RawableFactory.from("ts:1"),
+        RawableFactory.from(1000L), RawableFactory.from(25.5)));
     }
 
     @Test
-    public void duplicatePolicyEmittedOnce() {
-      CommandArguments args = args();
+    public void duplicatePolicy() {
+      CommandArguments args = tsAddArgs();
       TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.LAST).addParams(args);
 
-      // Expected: TS.ADD DUPLICATE_POLICY LAST (not duplicated)
-      assertThat(args, hasArgumentCount(3));
-      assertThat(args, hasArguments(TimeSeriesCommand.ADD, DUPLICATE_POLICY, DuplicatePolicy.LAST));
+      // Expected: TS.ADD ts:1 1000 25.5 DUPLICATE_POLICY LAST
+      assertThat(args, hasArgumentCount(6));
+      assertThat(args,
+        hasArguments(TimeSeriesCommand.ADD, RawableFactory.from("ts:1"), RawableFactory.from(1000L),
+          RawableFactory.from(25.5), DUPLICATE_POLICY, DuplicatePolicy.LAST));
     }
 
     @Test
-    public void onDuplicateIndependentOfDuplicatePolicy() {
-      CommandArguments args = args();
+    public void duplicatePolicyWithOnDuplicate() {
+      CommandArguments args = tsAddArgs();
       TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.LAST)
           .onDuplicate(DuplicatePolicy.FIRST).addParams(args);
 
-      // Expected: TS.ADD DUPLICATE_POLICY LAST ON_DUPLICATE FIRST
-      assertThat(args, hasArgumentCount(5));
-      assertThat(args, hasArguments(TimeSeriesCommand.ADD, DUPLICATE_POLICY, DuplicatePolicy.LAST,
-        ON_DUPLICATE, DuplicatePolicy.FIRST));
+      // Expected: TS.ADD ts:1 1000 25.5 DUPLICATE_POLICY LAST ON_DUPLICATE FIRST
+      assertThat(args, hasArgumentCount(8));
+      assertThat(args,
+        hasArguments(TimeSeriesCommand.ADD, RawableFactory.from("ts:1"), RawableFactory.from(1000L),
+          RawableFactory.from(25.5), DUPLICATE_POLICY, DuplicatePolicy.LAST, ON_DUPLICATE,
+          DuplicatePolicy.FIRST));
     }
   }
 

--- a/src/test/java/redis/clients/jedis/timeseries/TSAddParamsTest.java
+++ b/src/test/java/redis/clients/jedis/timeseries/TSAddParamsTest.java
@@ -1,0 +1,76 @@
+package redis.clients.jedis.timeseries;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.DUPLICATE_POLICY;
+import static redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesKeyword.ON_DUPLICATE;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArgumentCount;
+import static redis.clients.jedis.util.CommandArgumentsMatchers.hasArguments;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.timeseries.TimeSeriesProtocol.TimeSeriesCommand;
+
+public class TSAddParamsTest {
+
+  private static CommandArguments args() {
+    return new CommandArguments(TimeSeriesCommand.ADD);
+  }
+
+  @Nested
+  class AddParamsTests {
+
+    @Test
+    public void emptyParamsAddsNothing() {
+      CommandArguments args = args();
+      TSAddParams.addParams().addParams(args);
+
+      assertThat(args, hasArgumentCount(1));
+      assertThat(args, hasArguments(TimeSeriesCommand.ADD));
+    }
+
+    @Test
+    public void duplicatePolicyEmittedOnce() {
+      CommandArguments args = args();
+      TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.LAST).addParams(args);
+
+      // Expected: TS.ADD DUPLICATE_POLICY LAST (not duplicated)
+      assertThat(args, hasArgumentCount(3));
+      assertThat(args, hasArguments(TimeSeriesCommand.ADD, DUPLICATE_POLICY, DuplicatePolicy.LAST));
+    }
+
+    @Test
+    public void onDuplicateIndependentOfDuplicatePolicy() {
+      CommandArguments args = args();
+      TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.LAST)
+          .onDuplicate(DuplicatePolicy.FIRST).addParams(args);
+
+      // Expected: TS.ADD DUPLICATE_POLICY LAST ON_DUPLICATE FIRST
+      assertThat(args, hasArgumentCount(5));
+      assertThat(args, hasArguments(TimeSeriesCommand.ADD, DUPLICATE_POLICY, DuplicatePolicy.LAST,
+        ON_DUPLICATE, DuplicatePolicy.FIRST));
+    }
+  }
+
+  @Nested
+  class EqualsHashCodeTests {
+
+    @Test
+    public void equalWhenSameConfiguration() {
+      TSAddParams a = TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.LAST)
+          .onDuplicate(DuplicatePolicy.FIRST);
+      TSAddParams b = TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.LAST)
+          .onDuplicate(DuplicatePolicy.FIRST);
+      assertEquals(a, b);
+      assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void notEqualWhenDuplicatePolicyDiffers() {
+      assertNotEquals(TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.LAST),
+        TSAddParams.addParams().duplicatePolicy(DuplicatePolicy.FIRST));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`TSAddParams.addParams` contained two identical `duplicatePolicy != null` blocks, so `duplicatePolicy(...)` serialized `DUPLICATE_POLICY` twice. Sibling types (`TSCreateParams`, `TSAlterParams`, `TSArithByParams`) emit the option once.

## Changes
- Remove the duplicated emission block in `TSAddParams.addParams`
- Add unit coverage for single `DUPLICATE_POLICY` emission and coexistence with `ON_DUPLICATE`

Fixes #4682

## Test plan
- [x] `mvn -Dformatter.skip=true -Dtest=TSAddParamsTest test` (5/5)
- [x] `mvn -Dformatter.skip=true -Dtest=TSAddParamsTest,TSReadParamsTest,TSRangeParamsTest,TSMRangeParamsTest,TSNRangeParamsTest,TSInfoLocaleTest,TSElementTest test` (84/84)
- [x] `mvn formatter:validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bugfix removing a duplicated argument emission block, with focused unit tests and no API or security changes.
> 
> **Overview**
> Fixes `TSAddParams.addParams` so `duplicatePolicy(...)` serializes **`DUPLICATE_POLICY` once** instead of twice, matching sibling params types.
> 
> Adds unit coverage for single emission and for using `DUPLICATE_POLICY` together with `ON_DUPLICATE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ad9cefda1badaeda28171fbda0d3a4e2e7b3540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->