### PR TITLE
Fix cluster slot mismatch between String and byte[] keys under non-UTF-8 charsets (#4685)

### DIFF
--- a/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
+++ b/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
@@ -37,9 +37,11 @@ public final class JedisClusterCRC16 {
       throw new NullPointerException("Slot calculation of null is impossible");
     }
 
-    key = JedisClusterHashTag.getHashTag(key);
-    // optimization with modulo operator with power of 2 equivalent to getCRC16(key) % 16384
-    return getCRC16(key) & (16384 - 1);
+    // Scan for the hash tag on the encoded bytes so the '{' and '}' delimiters are located the same
+    // way the server does in keyHashSlot(). Under a DBCS default charset (GBK, Shift_JIS, Big5) a
+    // trail byte can be 0x7B/0x7D while the corresponding char is not a brace, so scanning the
+    // String would pick a different tag (or none) than the wire bytes and route to the wrong slot.
+    return getSlot(SafeEncoder.encode(key));
   }
 
   public static int getSlot(byte[] key) {

--- a/src/test/java/redis/clients/jedis/util/JedisClusterCRC16Test.java
+++ b/src/test/java/redis/clients/jedis/util/JedisClusterCRC16Test.java
@@ -3,6 +3,8 @@ package redis.clients.jedis.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -47,6 +49,28 @@ public class JedisClusterCRC16Test {
       JedisClusterCRC16.getSlot("{user1000}.followers"));
     assertNotEquals(JedisClusterCRC16.getSlot("foo{}{bar}"), JedisClusterCRC16.getSlot("bar"));
     assertEquals(JedisClusterCRC16.getSlot("foo{bar}{zap}"), JedisClusterCRC16.getSlot("bar"));
+  }
+
+  @Test
+  public void testHashtagGetSlotMatchesEncodedBytesUnderDbcsCharset() {
+    // GBK bytes 81 7B 41 81 7D: a lead byte followed by 0x7B ('{'), then 'A', then a lead byte
+    // followed by 0x7D ('}'). The server hashes the byte-level tag between 0x7B and 0x7D, so the
+    // String slot must agree with the byte slot regardless of the default charset.
+    byte[] gbkBytes = new byte[] { (byte) 0x81, 0x7B, 0x41, (byte) 0x81, 0x7D };
+    Charset original = SafeEncoder.DEFAULT_CHARSET;
+    try {
+      SafeEncoder.DEFAULT_CHARSET = Charset.forName("GBK");
+      String key = new String(gbkBytes, SafeEncoder.DEFAULT_CHARSET);
+      assertEquals(JedisClusterCRC16.getSlot(SafeEncoder.encode(key)),
+        JedisClusterCRC16.getSlot(key));
+    } finally {
+      SafeEncoder.DEFAULT_CHARSET = original;
+    }
+
+    // Under UTF-8 no multibyte sequence contains 0x7B/0x7D, so String and byte scanning agree.
+    SafeEncoder.DEFAULT_CHARSET = StandardCharsets.UTF_8;
+    assertEquals(JedisClusterCRC16.getSlot(SafeEncoder.encode("foo{bar}zap")),
+      JedisClusterCRC16.getSlot("foo{bar}zap"));
   }
 
   @Test


### PR DESCRIPTION
    getSlot("<GBK 81 7B 41 81 7D>")                     -> slot 14821
    getSlot(SafeEncoder.encode("<GBK 81 7B 41 81 7D>")) -> slot 16212   (== server keyHashSlot)

`getSlot(String)` locates the `{hash tag}` by scanning for the `{` and `}` characters and only encodes to bytes afterwards. The `byte[]` overload and the server's `keyHashSlot()` scan for `0x7B`/`0x7D` in the encoded bytes. Under a DBCS `SafeEncoder.DEFAULT_CHARSET` (GBK, Shift_JIS, Big5) a trail byte can be `0x7B`/`0x7D` while the char is not a brace, so the String path picks a different tag (or none) and routes to a slot the server does not own. It also disagrees with the binary API for the same logical key, which reaches routing through `CommandArguments.getKeyHashSlots()`.

Delegating to the byte overload moves brace scanning onto the wire bytes. No-op under UTF-8 since no multibyte sequence contains `0x7B`/`0x7D`; the added regression covers both the GBK mismatch and the UTF-8 parity.

Companion issue #4685.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cluster slot calculation for String keys; impact is localized and aligns with server routing, but any app relying on the old String-level hashtag parsing under DBCS could see different slots.
> 
> **Overview**
> Fixes **cluster slot routing** when `getSlot(String)` disagreed with Redis and with `getSlot(byte[])` under DBCS charsets (GBK, Shift_JIS, Big5).
> 
> **`getSlot(String)`** no longer extracts the hash tag via `JedisClusterHashTag` on Java characters before hashing. It **encodes the key first** and delegates to **`getSlot(byte[])`**, so `{`/`}` are found on **wire bytes** the same way as the server’s `keyHashSlot()`. That avoids false brace matches when a multibyte trail byte is `0x7B`/`0x7D` but the decoded character is not a brace—behavior that could send commands to the wrong shard. UTF-8 behavior is unchanged.
> 
> Adds a **GBK regression test** asserting `getSlot(String)` matches `getSlot(SafeEncoder.encode(key))` for a key whose encoded form contains byte-level `0x7B`/`0x7D` delimiters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 758b5ae7d19b719b5fb4049d9d87c42432317833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->