### PR TITLE
Add nightly test-metrics workflow

### DIFF
--- a/.github/workflows/nightly-metrics.yaml
+++ b/.github/workflows/nightly-metrics.yaml
@@ -112,6 +112,9 @@ jobs:
         # can't overwrite its unit results with its integration results.
         if: ${{ !cancelled() && steps.gate.outputs.run == 'true' }}
         run: |
+          # nullglob: a suite that never ran leaves no report dir; skip it
+          # instead of passing the unexpanded glob to cp.
+          shopt -s nullglob
           mkdir junit-reports
           for f in target/surefire-reports/*.xml; do cp "$f" "junit-reports/unit-$(basename "$f")"; done
           for f in target/failsafe-reports/*.xml; do cp "$f" "junit-reports/it-$(basename "$f")"; done

--- a/.github/workflows/nightly-metrics.yaml
+++ b/.github/workflows/nightly-metrics.yaml
@@ -1,0 +1,133 @@
+name: Nightly test metrics
+
+# Once a day, run the full jedis test suite (master, unit + integration)
+# against the newest unstable client-libs-test Redis image, and report
+# per-test durations to Grafana for performance regression tracking.
+
+on:
+  schedule:
+    - cron: '30 3 * * *' # nightly, staggered from the 01:00 CI runs
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-metrics
+  cancel-in-progress: false
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  nightly-metrics:
+    name: Redis unstable; test metrics
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      REDIS_ENV_WORK_DIR: ${{ github.workspace }}/redis-env-work
+      REDIS_ENV_CONF_DIR: ${{ github.workspace }}/src/test/resources/env
+    steps:
+      # Secrets can't be used in `if:` conditions, so a first step checks
+      # the token and later steps are gated on its output. Without the
+      # secret the job prints a warning and skips everything.
+      - name: Check for the metrics token
+        id: gate
+        env:
+          OTEL_TOKEN: ${{ secrets.OTEL_CI_VISIBILITY_TOKEN }}
+        run: |
+          if [ -z "$OTEL_TOKEN" ]; then
+            echo "::warning::The OTEL_CI_VISIBILITY_TOKEN secret is not set; skipping the nightly metrics run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.gate.outputs.run == 'true'
+
+      - name: Resolve latest unstable Redis image
+        id: unstable-image
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          # Pick the newest tag client-side instead of relying on the API's
+          # ordering parameter.
+          tag=$(curl -sf "https://hub.docker.com/v2/repositories/redislabs/client-libs-test/tags?page_size=100&name=unstable-" \
+            | jq -r '.results | max_by(.last_updated) | .name // empty')
+          if [ -z "$tag" ]; then
+            echo "::error::Could not resolve an unstable client-libs-test image tag from Docker Hub"
+            exit 1
+          fi
+          echo "Using image tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Java
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: System setup
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          sudo apt update
+          sudo apt install -y make
+          make compile-module
+
+      - name: Cache dependencies
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.m2/repository
+            /var/cache/apt
+          key: jedis-${{hashFiles('**/pom.xml')}}
+
+      - name: Maven offline
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          mvn -q dependency:go-offline
+
+      - name: Set up Docker Compose environment
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          mkdir -m 777 "$REDIS_ENV_WORK_DIR"
+          make start CLIENT_LIBS_TEST_IMAGE_TAG=${{ steps.unstable-image.outputs.tag }}
+
+      - name: Run all tests (unit + integration)
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          export TEST_ENV_PROVIDER=oss-docker
+          export TEST_WORK_FOLDER=$REDIS_ENV_WORK_DIR
+          # Unlike the per-PR docker matrix (which skips unit tests because
+          # unit-tests.yml already runs them), this run keeps them in: one
+          # `mvn verify` covers both suites, so every test ships a duration.
+          mvn -B -Dwith-param-names=true -Dmaven.javadoc.skip=true clean verify
+        env:
+          JVM_OPTS: -Xmx3200m
+
+      - name: Collect JUnit XML
+        # Surefire (unit) and failsafe (integration) write to two folders;
+        # the metrics action reads exactly one. Prefix the copies so a class
+        # that ever runs in both suites (method-level @Tag("integration"))
+        # can't overwrite its unit results with its integration results.
+        if: ${{ !cancelled() && steps.gate.outputs.run == 'true' }}
+        run: |
+          mkdir junit-reports
+          for f in target/surefire-reports/*.xml; do cp "$f" "junit-reports/unit-$(basename "$f")"; done
+          for f in target/failsafe-reports/*.xml; do cp "$f" "junit-reports/it-$(basename "$f")"; done
+          echo "$(ls junit-reports | wc -l) report files collected"
+
+      - name: Report test metrics
+        # Report even when tests fail, but not when the run was cancelled.
+        if: ${{ !cancelled() && steps.gate.outputs.run == 'true' }}
+        uses: redis-developer/cae-otel-ci-visibility@v4
+        with:
+          junit-xml-folder: 'junit-reports'
+          otlp-endpoint: 'https://otlp-gateway-prod-us-central-0.grafana.net/otlp/v1/metrics'
+          otlp-headers: 'Authorization=Basic ${{ secrets.OTEL_CI_VISIBILITY_TOKEN }}'
+          server-version: 'unstable'
+
+      - name: Tear down Docker Compose environment
+        if: ${{ always() && steps.gate.outputs.run == 'true' }}
+        run: |
+          make stop


### PR DESCRIPTION
Once a day, run the full test suite (unit and integration) against the newest unstable client-libs-test image and report every test's duration to PAWS via redis-developer/cae-otel-ci-visibility@v4, labeled server-version=unstable, for performance-regression tracking.

The workflow is self-contained: it no-ops with a warning until the OTEL_CI_VISIBILITY_TOKEN repository secret is set, needs only contents:read permissions, and changes no existing CI. To roll back, delete the workflow file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an isolated workflow with contents:read only; it does not alter existing CI or application code, and skips entirely without the metrics secret.
> 
> **Overview**
> Adds a **new scheduled GitHub Actions workflow** (`.github/workflows/nightly-metrics.yaml`) that runs once daily (and on `workflow_dispatch`) to measure test performance against the latest **unstable** `redislabs/client-libs-test` image.
> 
> The job **no-ops with a warning** unless `OTEL_CI_VISIBILITY_TOKEN` is set (a gate step works around secrets not being usable in `if:`). When enabled, it resolves the newest `unstable-*` tag from Docker Hub, boots the usual `make start` Docker test env, runs **`mvn clean verify`** (unit + integration in one pass, unlike the PR matrix), merges Surefire/Failsafe JUnit XML into a single folder with `unit-` / `it-` prefixes, and pushes per-test durations to Grafana via **`redis-developer/cae-otel-ci-visibility@v4`** with `server-version: unstable`. Teardown runs on `always()`; metrics are reported even on test failure but not on cancel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 000fb8c83706804d592e8b2621ce38d39e4639b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->