### PR TITLE
refresh primaryNodesCache in JedisClusterInfoCache.discoverClusterSlots

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -249,6 +249,7 @@ public class JedisClusterInfoCache {
     w.lock();
     try {
       resetSlots();
+      primaryNodesCache.clear();
       if (clientSideCache != null) {
         clientSideCache.flush();
       }
@@ -274,6 +275,7 @@ public class JedisClusterInfoCache {
           hostAndPortKeys.add(getNodeKey(targetNode));
           setupNodeIfNotExist(targetNode);
           if (i == MASTER_NODE_INDEX) {
+            primaryNodesCache.put(getNodeKey(targetNode), getNode(targetNode));
             assignSlotsToNode(slotNums, targetNode);
           } else if (clientConfig.isReadOnlyForRedisClusterReplicas()) {
             assignSlotsToReplicaNode(slotNums, targetNode);

--- a/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
@@ -156,6 +156,33 @@ public class JedisClusterInfoCacheTest {
             hasEntry(equalTo(getNodeKey(REPLICA_1_HOST)), equalTo(cache.getNode(REPLICA_1_HOST))));
   }
 
+  @Test
+  public void getPrimaryNodesAfterMasterReplicaFailoverOnRenew() {
+    JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+            .readOnlyForRedisClusterReplicas().build();
+
+    Set<HostAndPort> startNodes = new HashSet<>();
+    startNodes.add(MASTER_HOST);
+
+    JedisClusterInfoCache cache = new JedisClusterInfoCache(clientConfig, startNodes);
+
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS"))))
+            .thenReturn(masterReplicaSlotsResponse(MASTER_HOST, REPLICA_1_HOST))
+            .thenReturn(masterReplicaSlotsResponse(REPLICA_1_HOST, MASTER_HOST));
+
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertThat(cache.getPrimaryNodes(),
+            hasEntry(equalTo(getNodeKey(MASTER_HOST)), equalTo(cache.getNode(MASTER_HOST))));
+
+    // Failover picked up through the slot renewal path (MOVED / topology refresh)
+    cache.renewClusterSlots(mockConnection);
+    assertThat(cache.getPrimaryNodes(), aMapWithSize(1));
+    assertThat(cache.getPrimaryNodes(),
+            hasEntry(equalTo(getNodeKey(REPLICA_1_HOST)), equalTo(cache.getNode(REPLICA_1_HOST))));
+    assertThat(cache.getShuffledPrimaryNodesPool(), equalTo(
+            Collections.singletonList(cache.getNode(REPLICA_1_HOST))));
+  }
+
   private List<Object> masterReplicaSlotsResponse(HostAndPort masterHost, HostAndPort replicaHost) {
     return createClusterSlotsResponse(
             new SlotRange.Builder(0, 16383).master(masterHost, masterHost.toString() + "-id")


### PR DESCRIPTION
`JedisClusterInfoCacheTest`, failover replayed through `renewClusterSlots` instead of `discoverClusterNodesAndSlots`:

    Expected: map containing ["127.0.0.1:7001"->...]
         but: map was [<127.0.0.1:7000=...>]

And against the `cluster-stable` docker env after `CLUSTER FAILOVER` on :7483:

    primaries after     : [localhost:7479, localhost:7480, localhost:7481]
    FLUSHALL -> JedisBroadcastException ... (2 succeeded, 1 failed; first error: READONLY You can't write against a read only replica.)
       localhost:7479 -> JedisDataException: READONLY You can't write against a read only replica.

`primaryNodesCache` is only written by `discoverClusterNodesAndSlots`, which runs once at construction. Every later refresh (MOVED handling, the topology-refresh timer, `refreshClusterTopology()`) goes through `discoverClusterSlots`, which rebuilds slots and prunes dead nodes but leaves the primary map as it was, so `ALL_SHARDS` broadcasts, keyless writes and `getConnection()` keep targeting the pre-failover primaries. Rebuild the map in the same write-locked block, as the initial discovery already does. With the change the run above ends in `[localhost:7480, localhost:7481, localhost:7483]` and `FLUSHALL -> OK`.

Fixes #4691.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 36ed7667efd82f9149ff87a5ea35b97d2f368192. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->