### PR TITLE
Add missing plain overloads for experimental vector-set commands

### DIFF
--- a/src/main/java/redis/clients/jedis/CommandObjects.java
+++ b/src/main/java/redis/clients/jedis/CommandObjects.java
@@ -5476,6 +5476,10 @@ public class CommandObjects {
     return new CommandObject<>(args, BuilderFactory.BOOLEAN);
   }
 
+  public final CommandObject<Boolean> vadd(String key, float[] vector, String element, int reduceDim) {
+    return vadd(key, vector, element, reduceDim, null);
+  }
+
   public final CommandObject<Boolean> vadd(String key, float[] vector, String element, int reduceDim, VAddParams params) {
     CommandArguments args = commandArguments(Command.VADD).key(key);
     args.add(Keyword.REDUCE).add(reduceDim);
@@ -5485,12 +5489,20 @@ public class CommandObjects {
     return new CommandObject<>(args, BuilderFactory.BOOLEAN);
   }
 
+  public final CommandObject<Boolean> vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim) {
+    return vaddFP32(key, vectorBlob, element, reduceDim, null);
+  }
+
   public final CommandObject<Boolean> vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim, VAddParams params) {
     CommandArguments args = commandArguments(Command.VADD).key(key);
     args.add(Keyword.REDUCE).add(reduceDim);
     args.add(Keyword.FP32).add(vectorBlob).add(element);
     addOptionalParams(params, args);
     return new CommandObject<>(args, BuilderFactory.BOOLEAN);
+  }
+
+  public final CommandObject<Boolean> vadd(byte[] key, float[] vector, byte[] element, int reduceDim) {
+    return vadd(key, vector, element, reduceDim, null);
   }
 
   public final CommandObject<Boolean> vadd(byte[] key, float[] vector, byte[] element, int reduceDim, VAddParams params) {
@@ -5513,6 +5525,10 @@ public class CommandObjects {
     for (float value : vector) {
       args.add(value);
     }
+  }
+
+  public final CommandObject<Boolean> vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim) {
+    return vaddFP32(key, vectorBlob, element, reduceDim, null);
   }
 
   public final CommandObject<Boolean> vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim, VAddParams params) {
@@ -5541,12 +5557,20 @@ public class CommandObjects {
     }
   }
 
+  public final CommandObject<Map<String, Double>> vsimWithScores(String key, float[] vector) {
+    return vsimWithScores(key, vector, null);
+  }
+
   public final CommandObject<Map<String, Double>> vsimWithScores(String key, float[] vector, VSimParams params) {
     CommandArguments args = commandArguments(Command.VSIM).key(key);
     addVectors(vector, args);
     args.add(Keyword.WITHSCORES);
     addOptionalParams(params, args);
     return new CommandObject<>(args, BuilderFactory.STRING_DOUBLE_MAP);
+  }
+
+  public final CommandObject<Map<String, VSimScoreAttribs>> vsimWithScoresAndAttribs(String key, float[] vector) {
+    return vsimWithScoresAndAttribs(key, vector, null);
   }
 
   public final CommandObject<Map<String, VSimScoreAttribs>> vsimWithScoresAndAttribs(String key, float[] vector, VSimParams params) {
@@ -5569,12 +5593,20 @@ public class CommandObjects {
     return new CommandObject<>(args, BuilderFactory.STRING_LIST);
   }
 
+  public final CommandObject<Map<String, Double>> vsimByElementWithScores(String key, String element) {
+    return vsimByElementWithScores(key, element, null);
+  }
+
   public final CommandObject<Map<String, Double>> vsimByElementWithScores(String key, String element, VSimParams params) {
     CommandArguments args = commandArguments(Command.VSIM).key(key);
     args.add(Keyword.ELE).add(element);
     args.add(Keyword.WITHSCORES);
     addOptionalParams(params, args);
     return new CommandObject<>(args, BuilderFactory.STRING_DOUBLE_MAP);
+  }
+
+  public final CommandObject<Map<String, VSimScoreAttribs>> vsimByElementWithScoresAndAttribs(String key, String element) {
+    return vsimByElementWithScoresAndAttribs(key, element, null);
   }
 
   public final CommandObject<Map<String, VSimScoreAttribs>> vsimByElementWithScoresAndAttribs(String key, String element, VSimParams params) {
@@ -5597,12 +5629,20 @@ public class CommandObjects {
     return new CommandObject<>(args, BuilderFactory.BINARY_LIST);
   }
 
+  public final CommandObject<Map<byte[], Double>> vsimWithScores(byte[] key, float[] vector) {
+    return vsimWithScores(key, vector, null);
+  }
+
   public final CommandObject<Map<byte[], Double>> vsimWithScores(byte[] key, float[] vector, VSimParams params) {
     CommandArguments args = commandArguments(Command.VSIM).key(key);
     addVectors(vector, args);
     args.add(Keyword.WITHSCORES);
     addOptionalParams(params, args);
     return new CommandObject<>(args, BuilderFactory.BINARY_DOUBLE_MAP);
+  }
+
+  public final CommandObject<Map<byte[], VSimScoreAttribs>> vsimWithScoresAndAttribs(byte[] key, float[] vector) {
+    return vsimWithScoresAndAttribs(key, vector, null);
   }
 
   public final CommandObject<Map<byte[], VSimScoreAttribs>> vsimWithScoresAndAttribs(byte[] key, float[] vector, VSimParams params) {
@@ -5625,12 +5665,20 @@ public class CommandObjects {
     return new CommandObject<>(args, BuilderFactory.BINARY_LIST);
   }
 
+  public final CommandObject<Map<byte[], Double>> vsimByElementWithScores(byte[] key, byte[] element) {
+    return vsimByElementWithScores(key, element, null);
+  }
+
   public final CommandObject<Map<byte[], Double>> vsimByElementWithScores(byte[] key, byte[] element, VSimParams params) {
     CommandArguments args = commandArguments(Command.VSIM).key(key);
     args.add(Keyword.ELE).add(element);
     args.add(Keyword.WITHSCORES);
     addOptionalParams(params, args);
     return new CommandObject<>(args, BuilderFactory.BINARY_DOUBLE_MAP);
+  }
+
+  public final CommandObject<Map<byte[], VSimScoreAttribs>> vsimByElementWithScoresAndAttribs(byte[] key, byte[] element) {
+    return vsimByElementWithScoresAndAttribs(key, element, null);
   }
 
   public final CommandObject<Map<byte[], VSimScoreAttribs>> vsimByElementWithScoresAndAttribs(byte[] key, byte[] element, VSimParams params) {

--- a/src/main/java/redis/clients/jedis/Jedis.java
+++ b/src/main/java/redis/clients/jedis/Jedis.java
@@ -10935,9 +10935,21 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
+  public boolean vadd(String key, float[] vector, String element, int reduceDim) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vadd(key, vector, element, reduceDim));
+  }
+
+  @Override
   public boolean vadd(String key, float[] vector, String element, int reduceDim, VAddParams params) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.vadd(key, vector, element, reduceDim, params));
+  }
+
+  @Override
+  public boolean vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vaddFP32(key, vectorBlob, element, reduceDim));
   }
 
   @Override
@@ -10959,9 +10971,21 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
+  public Map<String, Double> vsimWithScores(String key, float[] vector) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimWithScores(key, vector));
+  }
+
+  @Override
   public Map<String, Double> vsimWithScores(String key, float[] vector, VSimParams params) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.vsimWithScores(key, vector, params));
+  }
+
+  @Override
+  public Map<String, VSimScoreAttribs> vsimWithScoresAndAttribs(String key, float[] vector) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimWithScoresAndAttribs(key, vector));
   }
 
   @Override
@@ -10983,9 +11007,21 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
+  public Map<String, Double> vsimByElementWithScores(String key, String element) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimByElementWithScores(key, element));
+  }
+
+  @Override
   public Map<String, Double> vsimByElementWithScores(String key, String element, VSimParams params) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.vsimByElementWithScores(key, element, params));
+  }
+
+  @Override
+  public Map<String, VSimScoreAttribs> vsimByElementWithScoresAndAttribs(String key, String element) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimByElementWithScoresAndAttribs(key, element));
   }
 
   @Override
@@ -11098,9 +11134,21 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
+  public boolean vadd(byte[] key, float[] vector, byte[] element, int reduceDim) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vadd(key, vector, element, reduceDim));
+  }
+
+  @Override
   public boolean vadd(byte[] key, float[] vector, byte[] element, int reduceDim, VAddParams params) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.vadd(key, vector, element, reduceDim, params));
+  }
+
+  @Override
+  public boolean vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vaddFP32(key, vectorBlob, element, reduceDim));
   }
 
   @Override
@@ -11122,9 +11170,21 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
+  public Map<byte[], Double> vsimWithScores(byte[] key, float[] vector) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimWithScores(key, vector));
+  }
+
+  @Override
   public Map<byte[], Double> vsimWithScores(byte[] key, float[] vector, VSimParams params) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.vsimWithScores(key, vector, params));
+  }
+
+  @Override
+  public Map<byte[], VSimScoreAttribs> vsimWithScoresAndAttribs(byte[] key, float[] vector) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimWithScoresAndAttribs(key, vector));
   }
 
   @Override
@@ -11146,9 +11206,21 @@ public class Jedis implements ServerCommands, DatabaseCommands, JedisCommands, J
   }
 
   @Override
+  public Map<byte[], Double> vsimByElementWithScores(byte[] key, byte[] element) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimByElementWithScores(key, element));
+  }
+
+  @Override
   public Map<byte[], Double> vsimByElementWithScores(byte[] key, byte[] element, VSimParams params) {
     checkIsInMultiOrPipeline();
     return connection.executeCommand(commandObjects.vsimByElementWithScores(key, element, params));
+  }
+
+  @Override
+  public Map<byte[], VSimScoreAttribs> vsimByElementWithScoresAndAttribs(byte[] key, byte[] element) {
+    checkIsInMultiOrPipeline();
+    return connection.executeCommand(commandObjects.vsimByElementWithScoresAndAttribs(key, element));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/PipeliningBase.java
+++ b/src/main/java/redis/clients/jedis/PipeliningBase.java
@@ -5231,8 +5231,18 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<Boolean> vadd(String key, float[] vector, String element, int reduceDim) {
+    return appendCommand(commandObjects.vadd(key, vector, element, reduceDim));
+  }
+
+  @Override
   public Response<Boolean> vadd(String key, float[] vector, String element, int reduceDim, VAddParams params) {
     return appendCommand(commandObjects.vadd(key, vector, element, reduceDim, params));
+  }
+
+  @Override
+  public Response<Boolean> vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim) {
+    return appendCommand(commandObjects.vaddFP32(key, vectorBlob, element, reduceDim));
   }
 
   @Override
@@ -5251,6 +5261,11 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<Map<String, Double>> vsimWithScores(String key, float[] vector) {
+    return appendCommand(commandObjects.vsimWithScores(key, vector));
+  }
+
+  @Override
   public Response<Map<String, Double>> vsimWithScores(String key, float[] vector, VSimParams params) {
     return appendCommand(commandObjects.vsimWithScores(key, vector, params));
   }
@@ -5263,6 +5278,11 @@ public abstract class PipeliningBase
   @Override
   public Response<List<String>> vsimByElement(String key, String element, VSimParams params) {
     return appendCommand(commandObjects.vsimByElement(key, element, params));
+  }
+
+  @Override
+  public Response<Map<String, Double>> vsimByElementWithScores(String key, String element) {
+    return appendCommand(commandObjects.vsimByElementWithScores(key, element));
   }
 
   @Override
@@ -5357,8 +5377,18 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<Boolean> vadd(byte[] key, float[] vector, byte[] element, int reduceDim) {
+    return appendCommand(commandObjects.vadd(key, vector, element, reduceDim));
+  }
+
+  @Override
   public Response<Boolean> vadd(byte[] key, float[] vector, byte[] element, int reduceDim, VAddParams params) {
     return appendCommand(commandObjects.vadd(key, vector, element, reduceDim, params));
+  }
+
+  @Override
+  public Response<Boolean> vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim) {
+    return appendCommand(commandObjects.vaddFP32(key, vectorBlob, element, reduceDim));
   }
 
   @Override
@@ -5377,6 +5407,11 @@ public abstract class PipeliningBase
   }
 
   @Override
+  public Response<Map<byte[], Double>> vsimWithScores(byte[] key, float[] vector) {
+    return appendCommand(commandObjects.vsimWithScores(key, vector));
+  }
+
+  @Override
   public Response<Map<byte[], Double>> vsimWithScores(byte[] key, float[] vector, VSimParams params) {
     return appendCommand(commandObjects.vsimWithScores(key, vector, params));
   }
@@ -5389,6 +5424,11 @@ public abstract class PipeliningBase
   @Override
   public Response<List<byte[]>> vsimByElement(byte[] key, byte[] element, VSimParams params) {
     return appendCommand(commandObjects.vsimByElement(key, element, params));
+  }
+
+  @Override
+  public Response<Map<byte[], Double>> vsimByElementWithScores(byte[] key, byte[] element) {
+    return appendCommand(commandObjects.vsimByElementWithScores(key, element));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/UnifiedJedis.java
+++ b/src/main/java/redis/clients/jedis/UnifiedJedis.java
@@ -6172,8 +6172,18 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public boolean vadd(String key, float[] vector, String element, int reduceDim) {
+    return executeCommand(commandObjects.vadd(key, vector, element, reduceDim));
+  }
+
+  @Override
   public boolean vadd(String key, float[] vector, String element, int reduceDim, VAddParams params) {
     return executeCommand(commandObjects.vadd(key, vector, element, reduceDim, params));
+  }
+
+  @Override
+  public boolean vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim) {
+    return executeCommand(commandObjects.vaddFP32(key, vectorBlob, element, reduceDim));
   }
 
   @Override
@@ -6192,8 +6202,18 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public Map<String, Double> vsimWithScores(String key, float[] vector) {
+    return executeCommand(commandObjects.vsimWithScores(key, vector));
+  }
+
+  @Override
   public Map<String, Double> vsimWithScores(String key, float[] vector, VSimParams params) {
     return executeCommand(commandObjects.vsimWithScores(key, vector, params));
+  }
+
+  @Override
+  public Map<String, VSimScoreAttribs> vsimWithScoresAndAttribs(String key, float[] vector) {
+    return executeCommand(commandObjects.vsimWithScoresAndAttribs(key, vector));
   }
 
   @Override
@@ -6212,8 +6232,18 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public Map<String, Double> vsimByElementWithScores(String key, String element) {
+    return executeCommand(commandObjects.vsimByElementWithScores(key, element));
+  }
+
+  @Override
   public Map<String, Double> vsimByElementWithScores(String key, String element, VSimParams params) {
     return executeCommand(commandObjects.vsimByElementWithScores(key, element, params));
+  }
+
+  @Override
+  public Map<String, VSimScoreAttribs> vsimByElementWithScoresAndAttribs(String key, String element) {
+    return executeCommand(commandObjects.vsimByElementWithScoresAndAttribs(key, element));
   }
 
   @Override
@@ -6308,8 +6338,18 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public boolean vadd(byte[] key, float[] vector, byte[] element, int reduceDim) {
+    return executeCommand(commandObjects.vadd(key, vector, element, reduceDim));
+  }
+
+  @Override
   public boolean vadd(byte[] key, float[] vector, byte[] element, int reduceDim, VAddParams params) {
     return executeCommand(commandObjects.vadd(key, vector, element, reduceDim, params));
+  }
+
+  @Override
+  public boolean vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim) {
+    return executeCommand(commandObjects.vaddFP32(key, vectorBlob, element, reduceDim));
   }
 
   @Override
@@ -6328,8 +6368,18 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public Map<byte[], Double> vsimWithScores(byte[] key, float[] vector) {
+    return executeCommand(commandObjects.vsimWithScores(key, vector));
+  }
+
+  @Override
   public Map<byte[], Double> vsimWithScores(byte[] key, float[] vector, VSimParams params) {
     return executeCommand(commandObjects.vsimWithScores(key, vector, params));
+  }
+
+  @Override
+  public Map<byte[], VSimScoreAttribs> vsimWithScoresAndAttribs(byte[] key, float[] vector) {
+    return executeCommand(commandObjects.vsimWithScoresAndAttribs(key, vector));
   }
 
   @Override
@@ -6348,8 +6398,18 @@ public class UnifiedJedis implements JedisCommands, JedisBinaryCommands,
   }
 
   @Override
+  public Map<byte[], Double> vsimByElementWithScores(byte[] key, byte[] element) {
+    return executeCommand(commandObjects.vsimByElementWithScores(key, element));
+  }
+
+  @Override
   public Map<byte[], Double> vsimByElementWithScores(byte[] key, byte[] element, VSimParams params) {
     return executeCommand(commandObjects.vsimByElementWithScores(key, element, params));
+  }
+
+  @Override
+  public Map<byte[], VSimScoreAttribs> vsimByElementWithScoresAndAttribs(byte[] key, byte[] element) {
+    return executeCommand(commandObjects.vsimByElementWithScoresAndAttribs(key, element));
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/commands/VectorSetBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/VectorSetBinaryCommands.java
@@ -75,6 +75,22 @@ public interface VectorSetBinaryCommands {
 
   /**
    * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
+   * into the vector set specified by key with dimension reduction.
+   * <p>
+   * Time complexity: O(log(N)) for each element added, where N is the number of elements in the
+   * vector set.
+   * @param key the name of the key that will hold the vector set data
+   * @param vector the vector as floating point numbers
+   * @param element the name of the element that is being added to the vector set
+   * @param reduceDim the target dimension after reduction using random projection
+   * @return 1 if key was added; 0 if key was not added
+   * @since 8.1
+   */
+  @Experimental
+  boolean vadd(byte[] key, float[] vector, byte[] element, int reduceDim);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
    * into the vector set specified by key with dimension reduction and additional parameters.
    * <p>
    * Time complexity: O(log(N)) for each element added, where N is the number of elements in the
@@ -88,6 +104,22 @@ public interface VectorSetBinaryCommands {
    */
   @Experimental
   boolean vadd(byte[] key, float[] vector, byte[] element, int reduceDim, VAddParams params);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
+   * into the vector set specified by key using FP32 binary format with dimension reduction.
+   * <p>
+   * Time complexity: O(log(N)) for each element added, where N is the number of elements in the
+   * vector set.
+   * @param key the name of the key that will hold the vector set data
+   * @param vectorBlob the vector as FP32 binary blob
+   * @param element the name of the element that is being added to the vector set
+   * @param reduceDim the target dimension after reduction using random projection
+   * @return 1 if key was added; 0 if key was not added
+   * @since 8.1
+   */
+  @Experimental
+  boolean vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim);
 
   /**
    * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
@@ -142,6 +174,13 @@ public interface VectorSetBinaryCommands {
    *          added)
    * @return map of element names to their similarity scores
    */
+  /**
+   * Return elements similar to a given vector with their similarity scores.
+   * @since 8.1
+   */
+  @Experimental
+  Map<byte[], Double> vsimWithScores(byte[] key, float[] vector);
+
   @Experimental
   Map<byte[], Double> vsimWithScores(byte[] key, float[] vector, VSimParams params);
 
@@ -156,6 +195,13 @@ public interface VectorSetBinaryCommands {
    *          automatically added)
    * @return map of element names to their similarity scores and attributes
    */
+  /**
+   * Return elements similar to a given vector with their similarity scores and attributes.
+   * @since 8.1
+   */
+  @Experimental
+  Map<byte[], VSimScoreAttribs> vsimWithScoresAndAttribs(byte[] key, float[] vector);
+
   @Experimental
   Map<byte[], VSimScoreAttribs> vsimWithScoresAndAttribs(byte[] key, float[] vector,
       VSimParams params);
@@ -196,6 +242,13 @@ public interface VectorSetBinaryCommands {
    *          added)
    * @return map of element names to their similarity scores
    */
+  /**
+   * Return elements similar to a given element with their similarity scores.
+   * @since 8.1
+   */
+  @Experimental
+  Map<byte[], Double> vsimByElementWithScores(byte[] key, byte[] element);
+
   @Experimental
   Map<byte[], Double> vsimByElementWithScores(byte[] key, byte[] element, VSimParams params);
 
@@ -210,6 +263,13 @@ public interface VectorSetBinaryCommands {
    *          automatically added)
    * @return map of element names to their similarity scores and attributes
    */
+  /**
+   * Return elements similar to a given element with their similarity scores and attributes.
+   * @since 8.1
+   */
+  @Experimental
+  Map<byte[], VSimScoreAttribs> vsimByElementWithScoresAndAttribs(byte[] key, byte[] element);
+
   @Experimental
   Map<byte[], VSimScoreAttribs> vsimByElementWithScoresAndAttribs(byte[] key, byte[] element,
       VSimParams params);

--- a/src/main/java/redis/clients/jedis/commands/VectorSetCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/VectorSetCommands.java
@@ -76,6 +76,22 @@ public interface VectorSetCommands {
 
   /**
    * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
+   * into the vector set specified by key with dimension reduction.
+   * <p>
+   * Time complexity: O(log(N)) for each element added, where N is the number of elements in the
+   * vector set.
+   * @param key the name of the key that will hold the vector set data
+   * @param vector the vector as floating point numbers
+   * @param element the name of the element that is being added to the vector set
+   * @param reduceDim the target dimension after reduction using random projection
+   * @return 1 if key was added; 0 if key was not added
+   * @since 8.1
+   */
+  @Experimental
+  boolean vadd(String key, float[] vector, String element, int reduceDim);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
    * into the vector set specified by key with dimension reduction and additional parameters.
    * <p>
    * Time complexity: O(log(N)) for each element added, where N is the number of elements in the
@@ -89,6 +105,22 @@ public interface VectorSetCommands {
    */
   @Experimental
   boolean vadd(String key, float[] vector, String element, int reduceDim, VAddParams params);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
+   * into the vector set specified by key using FP32 binary format with dimension reduction.
+   * <p>
+   * Time complexity: O(log(N)) for each element added, where N is the number of elements in the
+   * vector set.
+   * @param key the name of the key that will hold the vector set data
+   * @param vectorBlob the vector as FP32 binary blob
+   * @param element the name of the element that is being added to the vector set
+   * @param reduceDim the target dimension after reduction using random projection
+   * @return 1 if key was added; 0 if key was not added
+   * @since 8.1
+   */
+  @Experimental
+  boolean vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim);
 
   /**
    * <b><a href="https://redis.io/docs/latest/commands/vadd/">VADD Command</a></b> Add a new element
@@ -139,12 +171,38 @@ public interface VectorSetCommands {
    * Time complexity: O(log(N)) where N is the number of elements in the vector set.
    * @param key the name of the key that holds the vector set data
    * @param vector the vector to use as similarity reference
+   * @return map of element names to their similarity scores
+   * @since 8.1
+   */
+  @Experimental
+  Map<String, Double> vsimWithScores(String key, float[] vector);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vsim/">VSIM Command</a></b> Return elements
+   * similar to a given vector with their similarity scores.
+   * <p>
+   * Time complexity: O(log(N)) where N is the number of elements in the vector set.
+   * @param key the name of the key that holds the vector set data
+   * @param vector the vector to use as similarity reference
    * @param params additional parameters for the VSIM command (WITHSCORES will be automatically
    *          added)
    * @return map of element names to their similarity scores
    */
   @Experimental
   Map<String, Double> vsimWithScores(String key, float[] vector, VSimParams params);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vsim/">VSIM Command</a></b> Return elements
+   * similar to a given vector with their similarity scores and attributes.
+   * <p>
+   * Time complexity: O(log(N)) where N is the number of elements in the vector set.
+   * @param key the name of the key that holds the vector set data
+   * @param vector the vector to use as similarity reference
+   * @return map of element names to their similarity scores and attributes
+   * @since 8.1
+   */
+  @Experimental
+  Map<String, VSimScoreAttribs> vsimWithScoresAndAttribs(String key, float[] vector);
 
   /**
    * <b><a href="https://redis.io/docs/latest/commands/vsim/">VSIM Command</a></b> Return elements
@@ -193,12 +251,38 @@ public interface VectorSetCommands {
    * Time complexity: O(log(N)) where N is the number of elements in the vector set.
    * @param key the name of the key that holds the vector set data
    * @param element the name of the element to use as similarity reference
+   * @return map of element names to their similarity scores
+   * @since 8.1
+   */
+  @Experimental
+  Map<String, Double> vsimByElementWithScores(String key, String element);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vsim/">VSIM Command</a></b> Return elements
+   * similar to a given element in the vector set with their similarity scores.
+   * <p>
+   * Time complexity: O(log(N)) where N is the number of elements in the vector set.
+   * @param key the name of the key that holds the vector set data
+   * @param element the name of the element to use as similarity reference
    * @param params additional parameters for the VSIM command (WITHSCORES will be automatically
    *          added)
    * @return map of element names to their similarity scores
    */
   @Experimental
   Map<String, Double> vsimByElementWithScores(String key, String element, VSimParams params);
+
+  /**
+   * <b><a href="https://redis.io/docs/latest/commands/vsim/">VSIM Command</a></b> Return elements
+   * similar to a given element in the vector set with their similarity scores and attributes.
+   * <p>
+   * Time complexity: O(log(N)) where N is the number of elements in the vector set.
+   * @param key the name of the key that holds the vector set data
+   * @param element the name of the element to use as similarity reference
+   * @return map of element names to their similarity scores and attributes
+   * @since 8.1
+   */
+  @Experimental
+  Map<String, VSimScoreAttribs> vsimByElementWithScoresAndAttribs(String key, String element);
 
   /**
    * <b><a href="https://redis.io/docs/latest/commands/vsim/">VSIM Command</a></b> Return elements

--- a/src/main/java/redis/clients/jedis/commands/VectorSetPipelineBinaryCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/VectorSetPipelineBinaryCommands.java
@@ -86,6 +86,13 @@ public interface VectorSetPipelineBinaryCommands {
    * @param params additional parameters for the VADD command
    * @return Response wrapping 1 if key was added; 0 if key was not added
    */
+  /**
+   * Add a new element into the vector set with dimension reduction.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Boolean> vadd(byte[] key, float[] vector, byte[] element, int reduceDim);
+
   @Experimental
   Response<Boolean> vadd(byte[] key, float[] vector, byte[] element, int reduceDim,
       VAddParams params);
@@ -104,6 +111,13 @@ public interface VectorSetPipelineBinaryCommands {
    * @param params additional parameters for the VADD command
    * @return Response wrapping 1 if key was added; 0 if key was not added
    */
+  /**
+   * Add a new element into the vector set using FP32 binary format with dimension reduction.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Boolean> vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim);
+
   @Experimental
   Response<Boolean> vaddFP32(byte[] key, byte[] vectorBlob, byte[] element, int reduceDim,
       VAddParams params);
@@ -144,6 +158,13 @@ public interface VectorSetPipelineBinaryCommands {
    *          added)
    * @return Response wrapping map of element names to their similarity scores
    */
+  /**
+   * Return elements similar to a given vector with their similarity scores.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Map<byte[], Double>> vsimWithScores(byte[] key, float[] vector);
+
   @Experimental
   Response<Map<byte[], Double>> vsimWithScores(byte[] key, float[] vector, VSimParams params);
 
@@ -183,6 +204,13 @@ public interface VectorSetPipelineBinaryCommands {
    *          added)
    * @return Response wrapping map of element names to their similarity scores
    */
+  /**
+   * Return elements similar to a given element with their similarity scores.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Map<byte[], Double>> vsimByElementWithScores(byte[] key, byte[] element);
+
   @Experimental
   Response<Map<byte[], Double>> vsimByElementWithScores(byte[] key, byte[] element,
       VSimParams params);

--- a/src/main/java/redis/clients/jedis/commands/VectorSetPipelineCommands.java
+++ b/src/main/java/redis/clients/jedis/commands/VectorSetPipelineCommands.java
@@ -87,6 +87,13 @@ public interface VectorSetPipelineCommands {
    * @param params additional parameters for the VADD command
    * @return Response wrapping 1 if key was added; 0 if key was not added
    */
+  /**
+   * Add a new element into the vector set with dimension reduction.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Boolean> vadd(String key, float[] vector, String element, int reduceDim);
+
   @Experimental
   Response<Boolean> vadd(String key, float[] vector, String element, int reduceDim,
       VAddParams params);
@@ -105,6 +112,13 @@ public interface VectorSetPipelineCommands {
    * @param params additional parameters for the VADD command
    * @return Response wrapping 1 if key was added; 0 if key was not added
    */
+  /**
+   * Add a new element into the vector set using FP32 binary format with dimension reduction.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Boolean> vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim);
+
   @Experimental
   Response<Boolean> vaddFP32(String key, byte[] vectorBlob, String element, int reduceDim,
       VAddParams params);
@@ -145,6 +159,13 @@ public interface VectorSetPipelineCommands {
    *          added)
    * @return Response wrapping map of element names to their similarity scores
    */
+  /**
+   * Return elements similar to a given vector with their similarity scores.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Map<String, Double>> vsimWithScores(String key, float[] vector);
+
   @Experimental
   Response<Map<String, Double>> vsimWithScores(String key, float[] vector, VSimParams params);
 
@@ -184,6 +205,13 @@ public interface VectorSetPipelineCommands {
    *          added)
    * @return Response wrapping map of element names to their similarity scores
    */
+  /**
+   * Return elements similar to a given element with their similarity scores.
+   * @since 8.1
+   */
+  @Experimental
+  Response<Map<String, Double>> vsimByElementWithScores(String key, String element);
+
   @Experimental
   Response<Map<String, Double>> vsimByElementWithScores(String key, String element,
       VSimParams params);

--- a/src/test/java/redis/clients/jedis/commands/VectorSetPlainOverloadsTest.java
+++ b/src/test/java/redis/clients/jedis/commands/VectorSetPlainOverloadsTest.java
@@ -1,0 +1,104 @@
+package redis.clients.jedis.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import redis.clients.jedis.CommandObjects;
+import redis.clients.jedis.RedisProtocol;
+
+/**
+ * #4688 PR A: missing plain vector-set overloads must encode the same command as the params
+ * overload with {@code null} params.
+ */
+public class VectorSetPlainOverloadsTest {
+
+  private final CommandObjects commands = new CommandObjects(RedisProtocol.RESP2);
+
+  @Test
+  public void vaddWithReduceDimDelegatesWithoutParams() {
+    float[] vector = { 1.0f, 2.0f, 3.0f, 4.0f };
+    assertEquals(commands.vadd("vs", vector, "el", 2, null), commands.vadd("vs", vector, "el", 2));
+  }
+
+  @Test
+  public void vaddFP32WithReduceDimDelegatesWithoutParams() {
+    byte[] blob = { 0, 1, 2, 3 };
+    assertEquals(commands.vaddFP32("vs", blob, "el", 2, null),
+      commands.vaddFP32("vs", blob, "el", 2));
+  }
+
+  @Test
+  public void binaryVaddWithReduceDimDelegatesWithoutParams() {
+    float[] vector = { 1.0f, 2.0f };
+    byte[] key = { 'v' };
+    byte[] element = { 'e' };
+    assertEquals(commands.vadd(key, vector, element, 1, null),
+      commands.vadd(key, vector, element, 1));
+  }
+
+  @Test
+  public void binaryVaddFP32WithReduceDimDelegatesWithoutParams() {
+    byte[] blob = { 0, 1, 2, 3 };
+    byte[] key = { 'v' };
+    byte[] element = { 'e' };
+    assertEquals(commands.vaddFP32(key, blob, element, 1, null),
+      commands.vaddFP32(key, blob, element, 1));
+  }
+
+  @Test
+  public void vsimWithScoresDelegatesWithoutParams() {
+    float[] vector = { 1.0f, 0.0f };
+    assertEquals(commands.vsimWithScores("vs", vector, null),
+      commands.vsimWithScores("vs", vector));
+  }
+
+  @Test
+  public void vsimByElementWithScoresDelegatesWithoutParams() {
+    assertEquals(commands.vsimByElementWithScores("vs", "el", null),
+      commands.vsimByElementWithScores("vs", "el"));
+  }
+
+  @Test
+  public void vsimWithScoresAndAttribsDelegatesWithoutParams() {
+    float[] vector = { 1.0f, 0.0f };
+    assertEquals(commands.vsimWithScoresAndAttribs("vs", vector, null),
+      commands.vsimWithScoresAndAttribs("vs", vector));
+  }
+
+  @Test
+  public void vsimByElementWithScoresAndAttribsDelegatesWithoutParams() {
+    assertEquals(commands.vsimByElementWithScoresAndAttribs("vs", "el", null),
+      commands.vsimByElementWithScoresAndAttribs("vs", "el"));
+  }
+
+  @Test
+  public void binaryVsimWithScoresDelegatesWithoutParams() {
+    float[] vector = { 1.0f, 0.0f };
+    byte[] key = { 'v' };
+    assertEquals(commands.vsimWithScores(key, vector, null), commands.vsimWithScores(key, vector));
+  }
+
+  @Test
+  public void binaryVsimByElementWithScoresDelegatesWithoutParams() {
+    byte[] key = { 'v' };
+    byte[] element = { 'e' };
+    assertEquals(commands.vsimByElementWithScores(key, element, null),
+      commands.vsimByElementWithScores(key, element));
+  }
+
+  @Test
+  public void binaryVsimWithScoresAndAttribsDelegatesWithoutParams() {
+    float[] vector = { 1.0f, 0.0f };
+    byte[] key = { 'v' };
+    assertEquals(commands.vsimWithScoresAndAttribs(key, vector, null),
+      commands.vsimWithScoresAndAttribs(key, vector));
+  }
+
+  @Test
+  public void binaryVsimByElementWithScoresAndAttribsDelegatesWithoutParams() {
+    byte[] key = { 'v' };
+    byte[] element = { 'e' };
+    assertEquals(commands.vsimByElementWithScoresAndAttribs(key, element, null),
+      commands.vsimByElementWithScoresAndAttribs(key, element));
+  }
+}


### PR DESCRIPTION
## Summary
Experimental vector-set methods that take `reduceDim` or return scores currently have no no-params overload, so callers have to pass `null`. The rest of Jedis models optional params as a plain method plus a params-taking one.

This is the additive part of #4688:
- `vadd` / `vaddFP32` with `reduceDim` and no params
- `vsimWithScores` / `vsimByElementWithScores` with no params
- `vsimWithScoresAndAttribs` / `vsimByElementWithScoresAndAttribs` with no params (command surfaces only; pipeline does not have those variants)

Plain overloads encode the same argv as the existing params overload with `null`. Null-tolerance removal is left for a follow-up.

## Test plan
- [x] `mvn -Dtest=VectorSetPlainOverloadsTest test` (12/12)
- [x] `mvn -DskipTests compile test-compile`
- [x] `mvn formatter:validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API overloads that delegate to existing command encoding; no protocol or behavior change beyond convenience methods.
> 
> **Overview**
> Adds no-params overloads for experimental vector-set APIs so callers no longer need to pass `null` for optional params.
> 
> Covers `vadd`/`vaddFP32` with `reduceDim`, plus `vsimWithScores` / `vsimByElementWithScores` (and the scores+attribs variants on the command surfaces). Pipeline gets the reduce-dim and with-scores overloads only; scores+attribs pipeline methods were not present before and are not added.
> 
> Plain overloads delegate to the existing params methods with `null`. Tests assert they encode the same command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14fc8c45150a63c824b03689989be359bee120a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->