### PR TITLE
Backport #4692 to 7.5.x: refresh primaryNodesCache in JedisClusterInfoCache.discoverClusterSlots

### DIFF
--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -249,6 +249,7 @@ public class JedisClusterInfoCache {
     w.lock();
     try {
       resetSlots();
+      primaryNodesCache.clear();
       if (clientSideCache != null) {
         clientSideCache.flush();
       }
@@ -274,6 +275,7 @@ public class JedisClusterInfoCache {
           hostAndPortKeys.add(getNodeKey(targetNode));
           setupNodeIfNotExist(targetNode);
           if (i == MASTER_NODE_INDEX) {
+            primaryNodesCache.put(getNodeKey(targetNode), getNode(targetNode));
             assignSlotsToNode(slotNums, targetNode);
           } else if (clientConfig.isReadOnlyForRedisClusterReplicas()) {
             assignSlotsToReplicaNode(slotNums, targetNode);

--- a/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
@@ -156,6 +156,33 @@ public class JedisClusterInfoCacheTest {
             hasEntry(equalTo(getNodeKey(REPLICA_1_HOST)), equalTo(cache.getNode(REPLICA_1_HOST))));
   }
 
+  @Test
+  public void getPrimaryNodesAfterMasterReplicaFailoverOnRenew() {
+    JedisClientConfig clientConfig = DefaultJedisClientConfig.builder()
+            .readOnlyForRedisClusterReplicas().build();
+
+    Set<HostAndPort> startNodes = new HashSet<>();
+    startNodes.add(MASTER_HOST);
+
+    JedisClusterInfoCache cache = new JedisClusterInfoCache(clientConfig, startNodes);
+
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS"))))
+            .thenReturn(masterReplicaSlotsResponse(MASTER_HOST, REPLICA_1_HOST))
+            .thenReturn(masterReplicaSlotsResponse(REPLICA_1_HOST, MASTER_HOST));
+
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertThat(cache.getPrimaryNodes(),
+            hasEntry(equalTo(getNodeKey(MASTER_HOST)), equalTo(cache.getNode(MASTER_HOST))));
+
+    // Failover picked up through the slot renewal path (MOVED / topology refresh)
+    cache.renewClusterSlots(mockConnection);
+    assertThat(cache.getPrimaryNodes(), aMapWithSize(1));
+    assertThat(cache.getPrimaryNodes(),
+            hasEntry(equalTo(getNodeKey(REPLICA_1_HOST)), equalTo(cache.getNode(REPLICA_1_HOST))));
+    assertThat(cache.getShuffledPrimaryNodesPool(), equalTo(
+            Collections.singletonList(cache.getNode(REPLICA_1_HOST))));
+  }
+
   private List<Object> masterReplicaSlotsResponse(HostAndPort masterHost, HostAndPort replicaHost) {
     return createClusterSlotsResponse(
             new SlotRange.Builder(0, 16383).master(masterHost, masterHost.toString() + "-id")


### PR DESCRIPTION
Cherry-pick of ecfed3de (#4692) onto `7.5.x` (clean auto-merge; `JedisClusterInfoCacheTest` green locally, 5/5, including the new `getPrimaryNodesAfterMasterReplicaFailoverOnRenew`).

`primaryNodesCache` was only written by `discoverClusterNodesAndSlots` at construction; every runtime refresh (`MOVED` handling, topology-refresh timer, `refreshClusterTopology()`) goes through `discoverClusterSlots`, leaving the primary map stale after failover or node replacement. This broke `ALL_SHARDS` broadcasts, keyless routing and `getConnection()` (READONLY errors, or `No reachable node in cluster` after rolling restarts). Regression from #4219, affects 6.2.0+.

Fixes #4691 for the 7.5.x line. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Redis Cluster topology cache used for routing after failover. The change is small and covered by a new unit test, but incorrect primary tracking would still break cluster-wide commands.
> 
> **Overview**
> Rebuilds `primaryNodesCache` during runtime slot rediscovery (`discoverClusterSlots` / `renewClusterSlots`), not only on initial `discoverClusterNodesAndSlots`.
> 
> After failover or node replacement, MOVED handling and topology refresh now update the primary map so `getPrimaryNodes()` / `getShuffledPrimaryNodesPool()` match current masters. That unsticks ALL_SHARDS broadcasts, keyless routing, and `getConnection()` (READONLY / no reachable node).
> 
> Adds a unit test covering master/replica role swap on the renew path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f14da1223a3f8784bdec9335bfd52865687f938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->