### PR TITLE
docs: fix Redis wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Are you looking for a high-level library to handle object mapping? See [redis-om
 
 ## Supported Redis versions
 
-The most recent version of this library supports redis version 
+The most recent version of this library supports Redis versions
 [7.2](https://github.com/redis/redis/blob/7.2/00-RELEASENOTES),
 [7.4](https://github.com/redis/redis/blob/7.4/00-RELEASENOTES),
 [8.0](https://github.com/redis/redis/blob/8.0/00-RELEASENOTES),
@@ -64,7 +64,7 @@ To get started with Jedis, first add it as a dependency in your Java project. If
 
 To use the cutting-edge Jedis, check [here](https://redis.github.io/jedis/jedis-maven/).
 
-Next, you'll need to connect to Redis. Consider installing a redis server with docker:
+Next, you'll need to connect to Redis. Consider installing a Redis server with Docker:
 
 ```bash
 docker run -p 6379:6379 -it redis:latest


### PR DESCRIPTION
## Summary
- Use consistent Redis capitalization in the README
- Clarify that the library supports multiple Redis versions

## Verification
- Reviewed the Markdown diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording tweaks in README.md with no code or behavior changes.
> 
> **Overview**
> Fixes README wording so Redis and Docker are capitalized consistently, and so the supported-versions sentence refers to multiple Redis versions rather than a single “version.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5e8d090f3946a87c582c9faa1ac82c50b14e35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->