### PR TITLE
Fix cluster slot calculation for String keys with DBCS charsets

### DIFF
--- a/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
+++ b/src/main/java/redis/clients/jedis/util/JedisClusterCRC16.java
@@ -37,9 +37,7 @@ public final class JedisClusterCRC16 {
       throw new NullPointerException("Slot calculation of null is impossible");
     }
 
-    key = JedisClusterHashTag.getHashTag(key);
-    // optimization with modulo operator with power of 2 equivalent to getCRC16(key) % 16384
-    return getCRC16(key) & (16384 - 1);
+    return getSlot(SafeEncoder.encode(key));
   }
 
   public static int getSlot(byte[] key) {

--- a/src/test/java/redis/clients/jedis/util/JedisClusterCRC16Test.java
+++ b/src/test/java/redis/clients/jedis/util/JedisClusterCRC16Test.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -59,6 +60,22 @@ public class JedisClusterCRC16Test {
       JedisClusterCRC16.getSlot("bar".getBytes()));
     assertEquals(JedisClusterCRC16.getSlot("foo{bar}{zap}".getBytes()),
       JedisClusterCRC16.getSlot("bar".getBytes()));
+  }
+
+  @Test
+  public void testStringSlotUsesEncodedBytesForHashTagDetection() {
+    Charset original = SafeEncoder.DEFAULT_CHARSET;
+    try {
+      SafeEncoder.DEFAULT_CHARSET = Charset.forName("GBK");
+      String key = new String(new byte[] { (byte) 0x81, 0x7B, 0x41, (byte) 0x81, 0x7D },
+        SafeEncoder.DEFAULT_CHARSET);
+
+      assertEquals(JedisClusterCRC16.getSlot(SafeEncoder.encode(key)),
+        JedisClusterCRC16.getSlot(key));
+      assertEquals(16212, JedisClusterCRC16.getSlot(key));
+    } finally {
+      SafeEncoder.DEFAULT_CHARSET = original;
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- Make `JedisClusterCRC16.getSlot(String)` delegate to the byte-array slot calculation after `SafeEncoder` encoding
- Add a GBK regression test to ensure String and binary APIs compute the same cluster slot when encoded bytes contain hash tag delimiters

Fixes #4685.

## Verification
- Compiled the affected Jedis utility classes with JDK 8
- Ran an offline GBK slot verification; result: `OK 16212`
- Maven test command was attempted, but dependency download was blocked by the sandbox network policy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster slot routing, so a mistake can send keys to the wrong node. The change is small and covered by a charset-specific test.
> 
> **Overview**
> Fixes Redis Cluster slot calculation for `String` keys when a non-UTF-8 charset (e.g. GBK) is in use.
> 
> `JedisClusterCRC16.getSlot(String)` no longer extracts hash tags on Java characters. It encodes with `SafeEncoder` and reuses the byte-array path, so `{`/`}` are detected on the same bytes Redis would see. A GBK regression test checks String and binary APIs agree (slot `16212`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b86b5c9ca70e5c30afbffe8ac0f17b9e958bfc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->