### PR TITLE
Stabilize integration tests against auth-required, high-latency environments

### DIFF
--- a/src/test/java/redis/clients/jedis/RedisClientTest.java
+++ b/src/test/java/redis/clients/jedis/RedisClientTest.java
@@ -77,6 +77,7 @@ public class RedisClientTest {
     config.setBlockWhenExhausted(false);
     try (
         RedisClient pool = RedisClient.builder().hostAndPort(endpointStandalone7.getHostAndPort())
+            .clientConfig(endpointStandalone7.getClientConfigBuilder().build())
             .poolConfig(config).build();
         Connection jedis = pool.getPool().getResource()) {
       assertThrows(JedisException.class, () -> pool.getPool().getResource());
@@ -148,7 +149,7 @@ public class RedisClientTest {
     try (
         RedisClient pool = RedisClient.builder().hostAndPort(endpointStandalone7.getHostAndPort())
             .clientConfig(
-              DefaultJedisClientConfig.builder().clientName("invalid client name").build())
+              endpointStandalone7.getClientConfigBuilder().clientName("invalid client name").build())
             .build();
         Connection jedis = pool.getPool().getResource()) {
     } catch (Exception e) {
@@ -176,7 +177,7 @@ public class RedisClientTest {
   public void getNumActiveReturnsTheCorrectNumber() {
     try (RedisClient pool = RedisClient.builder()
         .hostAndPort(endpointStandalone7.getHost(), endpointStandalone7.getPort())
-        .clientConfig(DefaultJedisClientConfig.builder().timeoutMillis(2000).build())
+        .clientConfig(endpointStandalone7.getClientConfigBuilder().timeoutMillis(2000).build())
         .poolConfig(new ConnectionPoolConfig()).build()) {
 
       Connection jedis = pool.getPool().getResource();

--- a/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
+++ b/src/test/java/redis/clients/jedis/csc/ClientSideCacheFunctionalityTest.java
@@ -105,6 +105,9 @@ public class ClientSideCacheFunctionalityTest extends ClientSideCacheTestBase {
   }
 
   @Test
+  // Relies on OSS `CLIENT LIST` output-buffer fields (oll/omem) that the Enterprise proxy
+  // does not faithfully expose for the tracked connection.
+  @ConditionalOnEnv(value = TestEnvUtil.ENV_REDIS_ENTERPRISE, enabled = false)
   public void pendingInvalidationMessagesTest() {
     final int count = 1000; // Hundreds of keys
 

--- a/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/HealthCheckIntegrationTest.java
@@ -69,8 +69,8 @@ public class HealthCheckIntegrationTest {
   public void testCustomStrategySupplier() {
     // Create a StrategySupplier that uses the JedisClientConfig when available
     MultiDbConfig.StrategySupplier strategySupplier = (hostAndPort, jedisClientConfig) -> {
-      return new TestHealthCheckStrategy(HealthCheckStrategy.Config.builder().interval(500)
-          .timeout(500).numProbes(1).policy(BuiltIn.ANY_SUCCESS).build(), (endpoint) -> {
+      return new TestHealthCheckStrategy(HealthCheckStrategy.Config.builder().interval(2000)
+          .timeout(2000).numProbes(1).policy(BuiltIn.ANY_SUCCESS).build(), (endpoint) -> {
             // Create connection per health check to avoid resource leak
             try (UnifiedJedis pinger = RedisClient.builder().hostAndPort(hostAndPort)
                 .clientConfig(jedisClientConfig).build()) {
@@ -117,8 +117,9 @@ public class HealthCheckIntegrationTest {
     AtomicInteger attemptCount = new AtomicInteger(0);
 
     StrategySupplier strategySupplier = (hostAndPort, jedisClientConfig) -> {
-      // Fast interval, short timeout, 3 probes, short delay
-      return new TestHealthCheckStrategy(100, 50, 3, BuiltIn.ANY_SUCCESS, 20, (endpoint) -> {
+      // 3 probes with a timeout large enough for a real connect + ping on remote
+      // (high-latency) endpoints; (timeout + delay) * probes stays below the 5s latch below
+      return new TestHealthCheckStrategy(1000, 1000, 3, BuiltIn.ANY_SUCCESS, 100, (endpoint) -> {
         int attempt = attemptCount.incrementAndGet();
         if (attempt <= 2) {
           // First 2 attempts fail


### PR DESCRIPTION
### What

Fixes three groups of integration tests that fail nightly in the Redis Enterprise CI environment (auth-required endpoints, ~50–150 ms network RTT) while passing against the local OSS docker env:

- **`RedisClientTest`** — `checkPoolOverflow`, `invalidClientName` and `getNumActiveReturnsTheCorrectNumber` built clients with a bare `DefaultJedisClientConfig` (no credentials). Since the switch to RESP3 auto-negotiation (#4468), the handshake eagerly sends `HELLO 3`, which auth-required servers reject with `NOAUTH` before any command runs (for `invalidClientName`, before client-name validation, so the test caught the wrong exception). The tests now use the endpoint's client config builder, which supplies credentials — same as sibling tests.
- **`ClientSideCacheFunctionalityTest.pendingInvalidationMessagesTest`** — waits for `oll=0`/`omem=0` in `CLIENT LIST` for the tracked connection, which the Enterprise DMC proxy does not faithfully expose, so the awaitility condition times out. Disabled on the `re` env via `@ConditionalOnEnv`, matching the sibling tests in the same class.
- **`HealthCheckIntegrationTest`** — probe strategies that open a real connection (TCP + HELLO/AUTH + PING) used 50–500 ms timeouts, below the RTT of remote endpoints, so all probes failed and the health check resolved UNHEALTHY. Timeouts raised to 1000–2000 ms; strategies with synchronous lambdas (no network I/O) are left untouched.

### Why

The nightly "Jedis RE Integration Tests" workflow has been red for over a week; these three groups account for the deterministic failures (see e.g. run [32432112302](https://github.com/redis-developer/cae-client-testing/actions/runs/32432112302)). The remaining flaky failure (`advancedPubsubWithClientCache` ClassCastException) is a product bug fixed separately.

### Testing

- Full unit suite passes locally.
- `(timeout + delay) × probes` in the adjusted health-check test stays within the existing 5 s latch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only adjustments (credentials, env skip, timeouts). No production, auth, or pooling logic is changed.
> 
> **Overview**
> Makes a handful of integration tests pass against Redis Enterprise (auth-required, higher RTT) without changing production code.
> 
> `RedisClientTest` now builds `checkPoolOverflow`, `invalidClientName`, and `getNumActiveReturnsTheCorrectNumber` from the endpoint’s client config so HELLO/AUTH credentials are present (bare `DefaultJedisClientConfig` was failing with `NOAUTH` after RESP3 auto-negotiation).
> 
> `pendingInvalidationMessagesTest` is skipped on Enterprise because it depends on OSS `CLIENT LIST` `oll`/`omem` fields the proxy does not expose.
> 
> Health-check tests that open a real connection raise probe interval/timeout (to 1–2s) so remote RTT does not mark the endpoint UNHEALTHY; in-memory probe tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108bebd8906fc5a085cf3cf02a22536ab5e3de74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->