### PR TITLE
Do not deliver pub/sub push messages as replies outside an active subscription

### DIFF
--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -33,3 +33,25 @@ error.
 **Action required:** remove any manual prefixing workaround for these arguments
 (they would now be prefixed twice), and update `catch` blocks that matched the
 server CROSSSLOT `JedisDataException` for these commands.
+
+### Pub/sub push messages are no longer delivered as command replies outside a subscription ([#4701](https://github.com/redis/jedis/pull/4701))
+
+On RESP3, a pub/sub push frame that arrived while no pub/sub read loop was running —
+for example a `message` the server delivered after the `UNSUBSCRIBE` confirmation,
+as can happen behind the Redis Enterprise proxy — was returned as the next command's
+reply. This desynced the reply stream and typically surfaced as
+`ClassCastException: java.util.ArrayList cannot be cast to [B`.
+
+Such stray pub/sub pushes are now logged at debug level and dropped instead of being
+delivered to the application, and the following command receives its own reply.
+Behavior during an active `subscribe`/`psubscribe`/`ssubscribe` loop is unchanged.
+Custom `PushConsumer`s registered on a connection now also observe pub/sub-typed
+pushes received outside a subscription, which the built-in consumer previously
+propagated before they could see them; the public `PUBSUB_CONSUMER` constant is
+unchanged and still propagates unconditionally.
+
+**Action required:** none for typical applications. Code that relied on reading raw
+pub/sub frames from a connection without going through the `JedisPubSub`/
+`JedisShardedPubSub` loops (e.g. hand-rolled `sendCommand(SUBSCRIBE)` +
+`getUnflushedObject()`) will no longer receive those frames; use the pub/sub APIs or
+register a custom `PushConsumer` that propagates them.

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -195,12 +195,10 @@ public class Connection implements Closeable {
    * Marks whether a pub/sub read loop is currently driving this connection. Set by the
    * pub/sub implementations around their subscribe/process loop.
    */
-  @Internal
   void setActiveSubscription(boolean active) {
     this.activeSubscription = active;
   }
 
-  @Internal
   boolean isActiveSubscription() {
     return activeSubscription;
   }

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import redis.clients.jedis.Protocol.Command;
@@ -130,11 +129,10 @@ public class Connection implements Closeable {
   private int infiniteSoTimeout = 0;
   private boolean broken = false;
   private volatile Throwable brokenCause = null;
-  // True only while a pub/sub read loop is driving this connection; gates whether pub/sub
-  // pushes are propagated as read results or dropped as stray frames. Held in a shared
-  // mutable holder (not a plain field) so the push consumer chain observes the flag even
-  // through shallow copies of this connection (e.g. Mockito spies wired via AuthXManager).
-  private final AtomicBoolean activeSubscription = new AtomicBoolean(false);
+  // True only while a pub/sub read loop is driving this connection; set by the pub/sub
+  // loops and read by the push consumer chain to decide whether pub/sub pushes are
+  // propagated as read results or dropped as stray frames.
+  private volatile boolean activeSubscription = false;
   private boolean strValActive;
   private String strVal;
   protected String server;
@@ -190,9 +188,7 @@ public class Connection implements Closeable {
        * active on this connection; stray pub/sub frames (e.g. a message delivered after the
        * unsubscribe confirmation) must not surface as a regular command's reply.
        */
-      // Capture the holder, not `this`: shallow copies of this connection share the holder,
-      // so the chain sees flag updates made through any copy.
-      addPushConsumer(PushConsumerChainImpl.pubSubConsumer(activeSubscription::get));
+      addPushConsumer(PushConsumerChainImpl.pubSubConsumer(this::isActiveSubscription));
   }
 
   /**
@@ -201,12 +197,12 @@ public class Connection implements Closeable {
    */
   @Internal
   void setActiveSubscription(boolean active) {
-    this.activeSubscription.set(active);
+    this.activeSubscription = active;
   }
 
   @Internal
   boolean isActiveSubscription() {
-    return activeSubscription.get();
+    return activeSubscription;
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -129,6 +129,9 @@ public class Connection implements Closeable {
   private int infiniteSoTimeout = 0;
   private boolean broken = false;
   private volatile Throwable brokenCause = null;
+  // True only while a pub/sub read loop is driving this connection; gates whether pub/sub
+  // pushes are propagated as read results or dropped as stray frames.
+  private volatile boolean activeSubscription = false;
   private boolean strValActive;
   private String strVal;
   protected String server;
@@ -180,9 +183,25 @@ public class Connection implements Closeable {
       /*
        * Default consumers to process push messages.
        * Marks all @{link PushMessages as processed, except for pub/sub.
-       * Pub/sub messages are propagated to the client.
+       * Pub/sub messages are propagated to the client only while a pub/sub read loop is
+       * active on this connection; stray pub/sub frames (e.g. a message delivered after the
+       * unsubscribe confirmation) must not surface as a regular command's reply.
        */
-      addPushConsumer(PushConsumerChainImpl.PUBSUB_CONSUMER);
+      addPushConsumer(PushConsumerChainImpl.pubSubConsumer(this::isActiveSubscription));
+  }
+
+  /**
+   * Marks whether a pub/sub read loop is currently driving this connection. Set by the
+   * pub/sub implementations around their subscribe/process loop.
+   */
+  @Internal
+  void setActiveSubscription(boolean activeSubscription) {
+    this.activeSubscription = activeSubscription;
+  }
+
+  @Internal
+  boolean isActiveSubscription() {
+    return activeSubscription;
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -129,10 +129,11 @@ public class Connection implements Closeable {
   private int infiniteSoTimeout = 0;
   private boolean broken = false;
   private volatile Throwable brokenCause = null;
-  // True only while a pub/sub read loop is driving this connection; set by the pub/sub
-  // loops and read by the push consumer chain to decide whether pub/sub pushes are
-  // propagated as read results or dropped as stray frames.
-  private volatile boolean activeSubscription = false;
+  // True only while a pub/sub read loop is driving this connection; read by the push
+  // consumer chain to decide whether pub/sub pushes are propagated as read results or
+  // dropped as stray frames. Written and read only by the thread currently driving the
+  // connection; cross-thread hand-off is synchronized by the pool, so no volatile needed.
+  private boolean activeSubscription = false;
   private boolean strValActive;
   private String strVal;
   protected String server;

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import redis.clients.jedis.Protocol.Command;
@@ -130,8 +131,10 @@ public class Connection implements Closeable {
   private boolean broken = false;
   private volatile Throwable brokenCause = null;
   // True only while a pub/sub read loop is driving this connection; gates whether pub/sub
-  // pushes are propagated as read results or dropped as stray frames.
-  private volatile boolean activeSubscription = false;
+  // pushes are propagated as read results or dropped as stray frames. Held in a shared
+  // mutable holder (not a plain field) so the push consumer chain observes the flag even
+  // through shallow copies of this connection (e.g. Mockito spies wired via AuthXManager).
+  private final AtomicBoolean activeSubscription = new AtomicBoolean(false);
   private boolean strValActive;
   private String strVal;
   protected String server;
@@ -187,7 +190,9 @@ public class Connection implements Closeable {
        * active on this connection; stray pub/sub frames (e.g. a message delivered after the
        * unsubscribe confirmation) must not surface as a regular command's reply.
        */
-      addPushConsumer(PushConsumerChainImpl.pubSubConsumer(this::isActiveSubscription));
+      // Capture the holder, not `this`: shallow copies of this connection share the holder,
+      // so the chain sees flag updates made through any copy.
+      addPushConsumer(PushConsumerChainImpl.pubSubConsumer(activeSubscription::get));
   }
 
   /**
@@ -195,13 +200,13 @@ public class Connection implements Closeable {
    * pub/sub implementations around their subscribe/process loop.
    */
   @Internal
-  void setActiveSubscription(boolean activeSubscription) {
-    this.activeSubscription = activeSubscription;
+  void setActiveSubscription(boolean active) {
+    this.activeSubscription.set(active);
   }
 
   @Internal
   boolean isActiveSubscription() {
-    return activeSubscription;
+    return activeSubscription.get();
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/JedisPubSubBase.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSubBase.java
@@ -106,10 +106,12 @@ public abstract class JedisPubSubBase<T> {
   public final void proceed(Connection client, T... channels) {
     authenticator.registerForAuthentication(client);
     authenticator.client.setTimeoutInfinite();
+    authenticator.client.setActiveSubscription(true);
     try {
       subscribe(channels);
       process();
     } finally {
+      authenticator.client.setActiveSubscription(false);
       authenticator.client.rollbackTimeout();
     }
   }
@@ -117,10 +119,12 @@ public abstract class JedisPubSubBase<T> {
   public final void proceedWithPatterns(Connection client, T... patterns) {
     authenticator.registerForAuthentication(client);
     authenticator.client.setTimeoutInfinite();
+    authenticator.client.setActiveSubscription(true);
     try {
       psubscribe(patterns);
       process();
     } finally {
+      authenticator.client.setActiveSubscription(false);
       authenticator.client.rollbackTimeout();
     }
   }

--- a/src/main/java/redis/clients/jedis/JedisShardedPubSubBase.java
+++ b/src/main/java/redis/clients/jedis/JedisShardedPubSubBase.java
@@ -60,10 +60,12 @@ public abstract class JedisShardedPubSubBase<T> {
   public final void proceed(Connection client, T... channels) {
     authenticator.registerForAuthentication(client);
     authenticator.client.setTimeoutInfinite();
+    authenticator.client.setActiveSubscription(true);
     try {
       ssubscribe(channels);
       process();
     } finally {
+      authenticator.client.setActiveSubscription(false);
       authenticator.client.rollbackTimeout();
     }
   }

--- a/src/main/java/redis/clients/jedis/PushConsumerChainImpl.java
+++ b/src/main/java/redis/clients/jedis/PushConsumerChainImpl.java
@@ -1,11 +1,16 @@
 package redis.clients.jedis;
 
 import redis.clients.jedis.annots.Experimental;
+import redis.clients.jedis.util.SafeEncoder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 
 /**
  * A chain of PushConsumers that processes events in order.
@@ -15,6 +20,9 @@ import java.util.List;
  */
 @Experimental
 public final class PushConsumerChainImpl implements PushConsumerChain {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PushConsumerChainImpl.class);
+
   /**
    * PushConsumer that marks all push events to be propagated to the caller.
    */
@@ -30,7 +38,9 @@ public final class PushConsumerChainImpl implements PushConsumerChain {
   static final PushConsumerChain PROPAGATE_ALL_CONSUMER_CHAIN = of(PROPAGATE_ALL_CONSUMER);
 
   /**
-   * PushConsumer that marks pub/sub related events to be propagated to the caller.
+   * PushConsumer that marks pub/sub related events to be propagated to the caller unconditionally.
+   * Connections use the gated variant from {@link #pubSubConsumer(BooleanSupplier)} instead, so
+   * pub/sub pushes only propagate while a pub/sub read loop is actually consuming them.
    * <p>
    * NOTE: If a new pub/sub push type is added to {@link PushMessageTypes}, the {@code switch} in
    * {@link #isPubSubType(byte[])} must be updated. {@code PushConsumerChainImplTest} discovers
@@ -42,6 +52,31 @@ public final class PushConsumerChainImpl implements PushConsumerChain {
     }
     return context;
   };
+
+  /**
+   * PushConsumer that propagates pub/sub related events only while {@code activeSubscription}
+   * reports {@code true} (i.e. a pub/sub read loop is driving the connection). A pub/sub push
+   * received outside an active subscription — e.g. a message the server delivered after the
+   * unsubscribe confirmation — must not be returned as a regular command's reply; it is logged and
+   * left to the rest of the chain (consumed by default at end of chain).
+   * @param activeSubscription supplies whether the owning connection currently runs a pub/sub read
+   *          loop
+   * @return a pub/sub push consumer gated on the supplied subscription state
+   */
+  static PushConsumer pubSubConsumer(BooleanSupplier activeSubscription) {
+    return context -> {
+      if (isPubSubType(context.getMessage().getType())) {
+        if (activeSubscription.getAsBoolean()) {
+          context.propagate();
+        } else if (LOG.isDebugEnabled()) {
+          LOG.debug("Ignoring pub/sub push message of type '{}' received without an active "
+              + "subscription.",
+            SafeEncoder.encode(context.getMessage().getType()));
+        }
+      }
+      return context;
+    };
+  }
 
   /**
    * Returns {@code true} iff {@code t} is one of the pub/sub push message types declared in

--- a/src/test/java/redis/clients/jedis/ConnectionMockTest.java
+++ b/src/test/java/redis/clients/jedis/ConnectionMockTest.java
@@ -1,10 +1,11 @@
 package redis.clients.jedis;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import redis.clients.jedis.util.SafeEncoder;
 import redis.clients.jedis.util.server.TcpMockServer;
 
 /**
@@ -54,8 +56,8 @@ public class ConnectionMockTest {
 
       List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);
 
-      // Verify only PUBSUB_CONSUMER is registered by default
-      assertThat(consumers, contains(is(PushConsumerChainImpl.PUBSUB_CONSUMER)));
+      // Verify only the (gated) pub/sub consumer is registered by default
+      assertThat(consumers, hasSize(1));
     }
 
     @Test
@@ -70,8 +72,8 @@ public class ConnectionMockTest {
 
       List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);
 
-      // Verify only PUBSUB_CONSUMER is registered by default
-      assertThat(consumers, contains(is(PushConsumerChainImpl.PUBSUB_CONSUMER)));
+      // Verify only the (gated) pub/sub consumer is registered by default
+      assertThat(consumers, hasSize(1));
     }
 
     @Test
@@ -96,6 +98,50 @@ public class ConnectionMockTest {
         // Verify connection is still healthy
         assertFalse(conn.isBroken(), "Connection should not be broken");
         assertTrue(conn.isConnected(), "Connection should still be connected");
+      }
+    }
+
+    @Test
+    public void pubSubPushWithoutActiveSubscriptionDoesNotCorruptReply() throws Exception {
+      DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().resp3().build();
+
+      HostAndPort hostAndPort = new HostAndPort("localhost", mockServer.getPort());
+      DefaultJedisSocketFactory socketFactory = new DefaultJedisSocketFactory(hostAndPort, config);
+
+      try (Connection conn = new Connection(socketFactory, config)) {
+        assertTrue(conn.ping());
+
+        // A pub/sub message delivered while no pub/sub loop is running, e.g. a message the
+        // server sent after the unsubscribe confirmation on a reused pooled connection
+        mockServer.sendPushMessageToAll("message", "channel", "payload");
+        Thread.sleep(200); // let the push land in the socket receive buffer
+
+        assertTrue(conn.ping(), "PING must not receive the stray pub/sub push as its reply");
+        assertFalse(conn.isBroken(), "Connection should not be broken");
+      }
+    }
+
+    @Test
+    public void pubSubPushPropagatedDuringActiveSubscription() throws Exception {
+      DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().resp3().build();
+
+      HostAndPort hostAndPort = new HostAndPort("localhost", mockServer.getPort());
+      DefaultJedisSocketFactory socketFactory = new DefaultJedisSocketFactory(hostAndPort, config);
+
+      try (Connection conn = new Connection(socketFactory, config)) {
+        ConnectionTestHelper.setActiveSubscription(conn, true);
+
+        mockServer.sendPushMessageToAll("message", "channel", "payload");
+
+        // Blocking read; the pub/sub loop consumes propagated pushes this way
+        Object reply = conn.getUnflushedObject();
+        List<?> content = assertInstanceOf(List.class, reply);
+        assertArrayEquals(SafeEncoder.encode("message"), (byte[]) content.get(0));
+
+        ConnectionTestHelper.setActiveSubscription(conn, false);
+        mockServer.sendPushMessageToAll("message", "channel", "payload");
+        Thread.sleep(200);
+        assertTrue(conn.ping(), "After the subscription ends, pushes must be dropped again");
       }
     }
 

--- a/src/test/java/redis/clients/jedis/ConnectionMockTest.java
+++ b/src/test/java/redis/clients/jedis/ConnectionMockTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import redis.clients.jedis.util.SafeEncoder;
 import redis.clients.jedis.util.server.TcpMockServer;
 
@@ -142,6 +143,29 @@ public class ConnectionMockTest {
         mockServer.sendPushMessageToAll("message", "channel", "payload");
         Thread.sleep(200);
         assertTrue(conn.ping(), "After the subscription ends, pushes must be dropped again");
+      }
+    }
+
+    @Test
+    public void subscriptionFlagSetThroughShallowCopyIsVisibleToPushConsumers() {
+      // AuthXManager wiring may hand the pub/sub loop a shallow copy of the pooled
+      // connection (e.g. a Mockito spy, as in TokenBasedAuthenticationIntegrationTests).
+      // The subscription flag must stay shared with the push consumer chain, or the
+      // SUBSCRIBE confirmation push would be dropped instead of propagated.
+      DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().resp3().build();
+
+      HostAndPort hostAndPort = new HostAndPort("localhost", mockServer.getPort());
+      DefaultJedisSocketFactory socketFactory = new DefaultJedisSocketFactory(hostAndPort, config);
+
+      try (Connection conn = new Connection(socketFactory, config)) {
+        Connection copy = Mockito.spy(conn);
+        ConnectionTestHelper.setActiveSubscription(copy, true);
+
+        mockServer.sendPushMessageToAll("subscribe", "channel1", "1");
+
+        Object reply = copy.getUnflushedObject();
+        List<?> content = assertInstanceOf(List.class, reply);
+        assertArrayEquals(SafeEncoder.encode("subscribe"), (byte[]) content.get(0));
       }
     }
 

--- a/src/test/java/redis/clients/jedis/ConnectionMockTest.java
+++ b/src/test/java/redis/clients/jedis/ConnectionMockTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import redis.clients.jedis.util.SafeEncoder;
 import redis.clients.jedis.util.server.TcpMockServer;
 
@@ -143,29 +142,6 @@ public class ConnectionMockTest {
         mockServer.sendPushMessageToAll("message", "channel", "payload");
         Thread.sleep(200);
         assertTrue(conn.ping(), "After the subscription ends, pushes must be dropped again");
-      }
-    }
-
-    @Test
-    public void subscriptionFlagSetThroughShallowCopyIsVisibleToPushConsumers() {
-      // AuthXManager wiring may hand the pub/sub loop a shallow copy of the pooled
-      // connection (e.g. a Mockito spy, as in TokenBasedAuthenticationIntegrationTests).
-      // The subscription flag must stay shared with the push consumer chain, or the
-      // SUBSCRIBE confirmation push would be dropped instead of propagated.
-      DefaultJedisClientConfig config = DefaultJedisClientConfig.builder().resp3().build();
-
-      HostAndPort hostAndPort = new HostAndPort("localhost", mockServer.getPort());
-      DefaultJedisSocketFactory socketFactory = new DefaultJedisSocketFactory(hostAndPort, config);
-
-      try (Connection conn = new Connection(socketFactory, config)) {
-        Connection copy = Mockito.spy(conn);
-        ConnectionTestHelper.setActiveSubscription(copy, true);
-
-        mockServer.sendPushMessageToAll("subscribe", "channel1", "1");
-
-        Object reply = copy.getUnflushedObject();
-        List<?> content = assertInstanceOf(List.class, reply);
-        assertArrayEquals(SafeEncoder.encode("subscribe"), (byte[]) content.get(0));
       }
     }
 

--- a/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
+++ b/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
@@ -22,6 +22,16 @@ public class ConnectionTestHelper {
     return connection.getPushConsumers();
   }
 
+  /**
+   * Sets the active-subscription flag of a Connection, simulating a pub/sub read loop driving the
+   * connection.
+   * @param connection the connection to modify
+   * @param active whether a pub/sub read loop is active
+   */
+  public static void setActiveSubscription(Connection connection, boolean active) {
+    connection.setActiveSubscription(active);
+  }
+
   private ConnectionTestHelper() {
     // Utility class - prevent instantiation
   }

--- a/src/test/java/redis/clients/jedis/PushConsumerChainImplTest.java
+++ b/src/test/java/redis/clients/jedis/PushConsumerChainImplTest.java
@@ -255,6 +255,65 @@ public class PushConsumerChainImplTest {
   }
 
   /**
+   * Test the gated pub/sub consumer propagates pub/sub messages only while the subscription state
+   * reports active.
+   */
+  @Test
+  public void testGatedPubSubConsumerPropagatesOnlyWhileSubscriptionActive() {
+    PushConsumerChainImpl activeChain = PushConsumerChainImpl
+        .of(PushConsumerChainImpl.pubSubConsumer(() -> true));
+    PushConsumerChainImpl inactiveChain = PushConsumerChainImpl
+        .of(PushConsumerChainImpl.pubSubConsumer(() -> false));
+
+    String[] pubSubTypes = { PushMessageTypes.MESSAGE, PushMessageTypes.PMESSAGE,
+        PushMessageTypes.SMESSAGE, PushMessageTypes.SUBSCRIBE, PushMessageTypes.PSUBSCRIBE,
+        PushMessageTypes.SSUBSCRIBE, PushMessageTypes.UNSUBSCRIBE, PushMessageTypes.PUNSUBSCRIBE,
+        PushMessageTypes.SUNSUBSCRIBE };
+
+    for (String type : pubSubTypes) {
+      List<Object> content = new ArrayList<>();
+      content.add(SafeEncoder.encode(type));
+      content.add(SafeEncoder.encode("channel"));
+      PushMessage message = new PushMessage(content);
+
+      assertNotNull(activeChain.process(message),
+        "Pub/sub message type '" + type + "' should be propagated during active subscription");
+      assertNull(inactiveChain.process(message),
+        "Pub/sub message type '" + type + "' should be consumed without active subscription");
+    }
+  }
+
+  /**
+   * Test the gated pub/sub consumer leaves a pub/sub message to the rest of the chain (instead of
+   * dropping it) when no subscription is active, and never touches non-pub/sub messages.
+   */
+  @Test
+  public void testGatedPubSubConsumerFallsThroughWhenInactive() {
+    List<String> invocations = new ArrayList<>();
+    PushConsumer recording = context -> {
+      invocations.add(SafeEncoder.encode(context.getMessage().getType()));
+      return context;
+    };
+    PushConsumerChainImpl chain = PushConsumerChainImpl
+        .of(PushConsumerChainImpl.pubSubConsumer(() -> false), recording);
+
+    List<Object> pubSubContent = new ArrayList<>();
+    pubSubContent.add(SafeEncoder.encode(PushMessageTypes.MESSAGE));
+    pubSubContent.add(SafeEncoder.encode("channel"));
+    assertNull(chain.process(new PushMessage(pubSubContent)));
+
+    List<Object> otherContent = new ArrayList<>();
+    otherContent.add(SafeEncoder.encode(PushMessageTypes.INVALIDATE));
+    otherContent.add(SafeEncoder.encode("key"));
+    assertNull(chain.process(new PushMessage(otherContent)));
+
+    // Both messages reached the next consumer in the chain
+    assertEquals(2, invocations.size(), "Subsequent consumers should still see the messages");
+    assertEquals(PushMessageTypes.MESSAGE, invocations.get(0));
+    assertEquals(PushMessageTypes.INVALIDATE, invocations.get(1));
+  }
+
+  /**
    * Test PROPAGATE_ALL_CONSUMER propagates all messages.
    */
   @Test

--- a/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationIntegrationTests.java
+++ b/src/test/java/redis/clients/jedis/authentication/TokenBasedAuthenticationIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.AdditionalAnswers;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -193,7 +194,11 @@ public class TokenBasedAuthenticationIntegrationTests {
     authXManager = spy(authXManager);
     List<Connection> connections = new ArrayList<>();
     doAnswer(invocation -> {
-      Connection connection = spy((Connection) invocation.getArgument(0));
+      // A delegating mock records invocations for verify(...) but forwards every call to
+      // the one real Connection, unlike spy() which works on a shallow field-copy and
+      // would fork the connection's state from its push consumer chain.
+      Connection original = invocation.getArgument(0);
+      Connection connection = mock(Connection.class, AdditionalAnswers.delegatesTo(original));
       invocation.getArguments()[0] = connection;
       connections.add(connection);
       Object result = invocation.callRealMethod();

--- a/src/test/java/redis/clients/jedis/csc/CacheConnectionMockTest.java
+++ b/src/test/java/redis/clients/jedis/csc/CacheConnectionMockTest.java
@@ -3,7 +3,6 @@ package redis.clients.jedis.csc;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,7 +25,6 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.DefaultJedisSocketFactory;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.PushConsumer;
-import redis.clients.jedis.PushConsumerChainImpl;
 import redis.clients.jedis.util.server.TcpMockServer;
 
 /**
@@ -70,9 +68,9 @@ public class CacheConnectionMockTest {
 
       List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);
 
-      // Verify PushInvalidateConsumer is registered
-      assertThat(consumers, contains(is(PushConsumerChainImpl.PUBSUB_CONSUMER),
-        instanceOf(PushInvalidateConsumer.class)));
+      // Verify PushInvalidateConsumer is registered after the default pub/sub consumer
+      assertThat(consumers,
+        contains(instanceOf(PushConsumer.class), instanceOf(PushInvalidateConsumer.class)));
     }
 
     @Test
@@ -87,9 +85,9 @@ public class CacheConnectionMockTest {
 
       List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);
 
-      // Verify PushInvalidateConsumer is registered
-      assertThat(consumers, contains(is(PushConsumerChainImpl.PUBSUB_CONSUMER),
-        instanceOf(PushInvalidateConsumer.class)));
+      // Verify PushInvalidateConsumer is registered after the default pub/sub consumer
+      assertThat(consumers,
+        contains(instanceOf(PushConsumer.class), instanceOf(PushInvalidateConsumer.class)));
     }
 
     @Test

--- a/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
+++ b/src/test/java/redis/clients/jedis/mcf/TrackingConnectionPoolInitTest.java
@@ -1,8 +1,7 @@
 package redis.clients.jedis.mcf;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -19,7 +18,6 @@ import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.PushConsumer;
-import redis.clients.jedis.PushConsumerChainImpl;
 import redis.clients.jedis.util.server.TcpMockServer;
 
 public class TrackingConnectionPoolInitTest {
@@ -57,8 +55,8 @@ public class TrackingConnectionPoolInitTest {
         Connection conn = pool.getResource()) {
 
       List<PushConsumer> consumers = ConnectionTestHelper.getPushConsumers(conn);
-      // contains(...) is an exact-length matcher: two copies of PUBSUB_CONSUMER would fail.
-      assertThat(consumers, contains(is(PushConsumerChainImpl.PUBSUB_CONSUMER)));
+      // Double initialization would register the default pub/sub consumer twice.
+      assertThat(consumers, hasSize(1));
     }
   }
 


### PR DESCRIPTION
### Problem

A RESP3 pub/sub push arriving while no pub/sub read loop is running — e.g. a `message` frame the server delivers **after** the unsubscribe confirmation, as observed behind the Redis Enterprise DMC proxy — was propagated by the default push consumer, and `Protocol.process` returned it as the next command's reply. The reply stream desyncs and the command typically fails with:

```
java.lang.ClassCastException: java.util.ArrayList cannot be cast to [B
    at redis.clients.jedis.BuilderFactory$18.build(BuilderFactory.java:283)
```

This is the root cause of the flaky `advancedPubsubWithClientCache` failures in the Redis Enterprise nightly CI (any client that reuses a pooled connection after subscribe/unsubscribe is exposed).

### Fix

- `Connection` tracks a volatile `activeSubscription` flag, set/cleared around the subscribe/process loops of `JedisPubSubBase` (`proceed`, `proceedWithPatterns`) and `JedisShardedPubSubBase` (`proceed`) — cleared in `finally`, so pooled connections are always returned with the flag off.
- The default pub/sub push consumer is now created per connection via `PushConsumerChainImpl.pubSubConsumer(BooleanSupplier)` and only propagates pub/sub-typed pushes while the flag is set. Outside a subscription, the push is debug-logged and left to the rest of the consumer chain (consumed by default), so `Protocol.process` continues to the real reply.

### Behavior notes

- During a subscription, behavior is byte-for-byte identical to before; the pub/sub loops keep receiving propagated frames via `getUnflushedObject()`.
- RESP2 is unaffected: its pub/sub frames arrive as regular multi-bulk replies and never reach the push consumer chain.
- Custom push consumers keep their propagate/drop contract, and now also observe out-of-subscription pub/sub pushes that the default consumer previously short-circuited.
- The public `PUBSUB_CONSUMER` constant is unchanged.

### Testing

- New `ConnectionMockTest` cases deterministically reproduce the bug with `TcpMockServer`: a `message` push injected before a `PING` corrupts the reply without the fix (verified failing) and is dropped with it; a second test verifies propagation still works while the flag is set.
- New `PushConsumerChainImplTest` cases cover the gated consumer for all pub/sub push types and verify chain fall-through semantics when inactive.
- Full unit suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core RESP3 read/push handling on every connection; low risk for normal pub/sub API usage but can affect hand-rolled subscribe + `getUnflushedObject()` code paths.
> 
> **Overview**
> Fixes RESP3 reply-stream corruption when a **pub/sub push** (e.g. a `message` after `UNSUBSCRIBE`, as seen behind Redis Enterprise) arrives on a pooled connection **without** an active subscribe loop. Those frames were propagated by the default push consumer and returned as the next command reply, often causing `ClassCastException`.
> 
> **`Connection`** now tracks **`activeSubscription`**, set in **`finally`** around **`JedisPubSubBase`** / **`JedisShardedPubSubBase`** `proceed` loops. The default consumer is **`pubSubConsumer(this::isActiveSubscription)`** instead of always-on **`PUBSUB_CONSUMER`**: pub/sub pushes propagate only during a real read loop; otherwise they are **debug-logged** and **not** surfaced as command replies. Later **`PushConsumer`**s can still see those pushes when the default consumer does not propagate. **`PUBSUB_CONSUMER`** remains unchanged for unconditional propagation.
> 
> Release notes document the behavior change. Tests add mock-server regression coverage and gated-consumer unit tests; auth integration tests use a **delegating mock** so connection state is not forked by **`spy()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344f2e2d188271621c681bf08acac2c6fcf35b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->