### PR TITLE
Log connection identity for maintenance events and applied socket timeouts

### DIFF
--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -20,6 +20,9 @@ import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import redis.clients.jedis.Protocol.Command;
 import redis.clients.jedis.Protocol.Keyword;
 import redis.clients.jedis.TimeoutSource.TimeoutInfo;
@@ -35,6 +38,8 @@ import redis.clients.jedis.util.RedisInputStream;
 import redis.clients.jedis.util.RedisOutputStream;
 
 public class Connection implements Closeable {
+
+  private static final Logger logger = LoggerFactory.getLogger(Connection.class);
 
   public static class Builder {
     private JedisSocketFactory socketFactory;
@@ -390,6 +395,10 @@ public class Connection implements Closeable {
       throw markBroken(new JedisConnectionException("Failed to set SO_TIMEOUT", e));
     }
     appliedSoTimeout = timeout;
+    if (logger.isDebugEnabled()) {
+      logger.debug("Timeout applied millis={} blocking={} conn={}", timeout, isBlocking,
+        toIdentityString());
+    }
   }
 
   /**
@@ -531,14 +540,18 @@ public class Connection implements Closeable {
     if (!isConnected()) {
       try {
         socket = socketFactory.createSocket();
+        // Fresh socket: the broken flag and the cached identity describe the previous socket;
+        // reset both before anything logs. Any failure below re-marks the connection broken.
+        broken = false;
+        strVal = null;
         // here clientConfig means we have a potential custom/new value as timeout from supplier, so
         // we apply it to the socket
         //
         // if no clientConfig, we use socket timeout to set defaults in the supplier
         if (this.clientConfig != null) {
-          socket.setSoTimeout(currentTimeout());
-          // Fresh socket: align the applied-timeout cache with the new socket's actual SO_TIMEOUT.
-          appliedSoTimeout = socket.getSoTimeout();
+          // Fresh socket: invalidate the applied-timeout cache so the initial timeout is applied
+          appliedSoTimeout = -1;
+          applyCurrentTimeout();
         } else {
           defaultTimeoutSource.setDefaults(socket.getSoTimeout(), getBlockingSoTimeout());
         }
@@ -547,7 +560,6 @@ public class Connection implements Closeable {
         outputStream = new RedisOutputStream(socket.getOutputStream());
         inputStream = new RedisInputStream(socket.getInputStream());
 
-        broken = false; // unset broken status when connection is (re)initialized
         himportState.reset(); // a fresh socket lost any server-side HIMPORT fieldsets
 
       } catch (JedisConnectionException jce) {

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -144,7 +144,10 @@ final class MaintenanceEventController
 
   @Override
   public void onMoving(MovingEvent e, Connection c) {
-    logger.debug("Moving to {} (seq={}, ttl={}s)", e.target, e.seq, e.ttlSeconds);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Moving to {} (seq={}, ttl={}s) conn={}", e.target, e.seq, e.ttlSeconds,
+        c.toIdentityString());
+    }
     SocketAddress affectedPeer = c.getRemoteSocketAddress();
     if (affectedPeer == null) {
       return; // receiver socket already closed; no peer to register
@@ -231,25 +234,36 @@ final class MaintenanceEventController
 
   @Override
   public void onMigrating(MigratingEvent e, Connection c) {
-    logger.debug("Migrating shards {} (seq={}, ttl={}s)", e.shardIds, e.seq, e.ttlSeconds);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Migrating shards {} (seq={}, ttl={}s) conn={}", e.shardIds, e.seq, e.ttlSeconds,
+        c.toIdentityString());
+    }
     relaxConnectionTimeoutsFor(c, maxRelaxedDurationNanos + NanoClock.INSTANCE.getAsLong());
   }
 
   @Override
   public void onFailingOver(FailingOverEvent e, Connection c) {
-    logger.debug("Failing over shards {} (seq={}, ttl={}s)", e.shardIds, e.seq, e.ttlSeconds);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Failing over shards {} (seq={}, ttl={}s) conn={}", e.shardIds, e.seq,
+        e.ttlSeconds, c.toIdentityString());
+    }
     relaxConnectionTimeoutsFor(c, maxRelaxedDurationNanos + NanoClock.INSTANCE.getAsLong());
   }
 
   @Override
   public void onMigrated(MigratedEvent e, Connection c) {
-    logger.debug("Migrated shards {} (seq={})", e.shardIds, e.seq);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Migrated shards {} (seq={}) conn={}", e.shardIds, e.seq, c.toIdentityString());
+    }
     relaxConnectionTimeoutsFor(c, 0);
   }
 
   @Override
   public void onFailedOver(FailedOverEvent e, Connection c) {
-    logger.debug("Failed over shards {} (seq={})", e.shardIds, e.seq);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Failed over shards {} (seq={}) conn={}", e.shardIds, e.seq,
+        c.toIdentityString());
+    }
     relaxConnectionTimeoutsFor(c, 0);
   }
 


### PR DESCRIPTION
Maintenance handling is per connection, but the debug logs did not say which connection an event or timeout change applied to. Every controller event log now carries the connection identity, and each SO_TIMEOUT actually pushed to a socket logs value, blocking flag, and connection. Extracted from the SCH scenario-test work, where these logs are used to correlate per-connection behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly debug logging plus a small reconnect-path tweak to timeout/identity cache. Does not change auth, protocol, or public API behavior.
> 
> **Overview**
> Debug logs for maintenance handling now identify **which connection** an event or SO_TIMEOUT change applied to, so per-connection rebind/relax behavior can be correlated.
> 
> `MaintenanceEventController` event logs include `conn=` via `toIdentityString()`, gated with `isDebugEnabled()`. `applyCurrentTimeout()` logs millis, blocking flag, and the same identity.
> 
> On reconnect, `broken` and the cached identity string are cleared immediately after the new socket is created (before logging), and the applied-timeout cache is invalidated so the initial timeout goes through `applyCurrentTimeout()` instead of a one-off `setSoTimeout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b685e7d92bdfa56c229563c04bfcf34613bc2e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->