### PR TITLE
Do not throw from close() when pool replenishment fails

### DIFF
--- a/src/main/java/redis/clients/jedis/util/Pool.java
+++ b/src/main/java/redis/clients/jedis/util/Pool.java
@@ -3,9 +3,14 @@ package redis.clients.jedis.util;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import redis.clients.jedis.exceptions.JedisException;
 
 public class Pool<T> extends GenericObjectPool<T> {
+
+  private static final Logger log = LoggerFactory.getLogger(Pool.class);
 
   // Legacy
   public Pool(GenericObjectPoolConfig<T> poolConfig, PooledObjectFactory<T> factory) {
@@ -61,7 +66,10 @@ public class Pool<T> extends GenericObjectPool<T> {
     try {
       super.invalidateObject(resource);
     } catch (Exception e) {
-      throw new JedisException("Could not return the broken resource to the pool", e);
+      // The broken object is already destroyed. commons-pool2 2.13+ then always
+      // tries to replenish (POOL-431); that replacement must not escape close()
+      // when the server is down. Swallowing also covers the 2.12 waiter path.
+      log.warn("Could not return the broken resource to the pool", e);
     }
   }
 

--- a/src/test/java/redis/clients/jedis/UnavailableConnectionTest.java
+++ b/src/test/java/redis/clients/jedis/UnavailableConnectionTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
-import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.EnvCondition;
 
 import redis.clients.jedis.util.TestEnvUtil;
@@ -21,7 +20,6 @@ import redis.clients.jedis.util.TestEnvUtil;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -88,17 +86,9 @@ public class UnavailableConnectionTest {
     threadForBrokenJedis1.join();
     assertFalse(threadForBrokenJedis1.isAlive());
     assertTrue(brokenJedis1.isBroken());
-    try {
-      brokenJedis1.close(); // we need capture/mock to test this properly
-    } catch (JedisException e) {
-      // Behavior change in commons-pool2 2.13.1: GenericObjectPool#invalidateObject now
-      // attempts to replace the invalidated instance, which fails when
-      // ConnectionFactory#makeObject() cannot reach the (unavailable) server. The
-      // underlying socket failure varies by environment (Connection refused / reset /
-      // etc.), so we only assert on the exception type.
-      assertInstanceOf(JedisConnectionException.class, e.getCause(),
-          "Unexpected cause for broken-resource return: " + e.getCause());
-    }
+    // close() must not throw when pool replenishment fails (commons-pool2 2.13+
+    // invalidateObject always calls addObject(); see #4690).
+    brokenJedis1.close();
     try {
       poolForBrokenJedis1.getResource();
       fail("Should not get connection from pool");

--- a/src/test/java/redis/clients/jedis/util/PoolTest.java
+++ b/src/test/java/redis/clients/jedis/util/PoolTest.java
@@ -1,0 +1,99 @@
+package redis.clients.jedis.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.exceptions.JedisException;
+
+public class PoolTest {
+
+  @Test
+  public void returnBrokenResourceDoesNotThrowWhenReplacementFails() {
+    FailingReplacementFactory factory = new FailingReplacementFactory();
+    GenericObjectPoolConfig<Object> config = new GenericObjectPoolConfig<>();
+    config.setMaxTotal(1);
+    config.setBlockWhenExhausted(false);
+
+    Pool<Object> pool = new Pool<>(config, factory);
+    try {
+      Object resource = pool.getResource();
+      assertEquals(1, factory.created.get());
+      assertEquals(1, pool.getNumActive());
+
+      assertDoesNotThrow(() -> pool.returnBrokenResource(resource));
+
+      assertEquals(0, pool.getNumActive());
+      assertEquals(0, pool.getNumIdle());
+      // destroy succeeded; only the replacement makeObject failed
+      assertEquals(1, factory.destroyed.get());
+      assertEquals(2, factory.created.get());
+
+      JedisException thrown = assertThrows(JedisException.class, pool::getResource);
+      assertEquals("Could not get a resource from the pool", thrown.getMessage());
+    } finally {
+      pool.close();
+    }
+  }
+
+  @Test
+  public void returnBrokenResourceReplacesObjectWhenFactorySucceeds() {
+    CountingFactory factory = new CountingFactory();
+    GenericObjectPoolConfig<Object> config = new GenericObjectPoolConfig<>();
+    config.setMaxTotal(1);
+
+    Pool<Object> pool = new Pool<>(config, factory);
+    try {
+      Object resource = pool.getResource();
+      pool.returnBrokenResource(resource);
+
+      assertEquals(0, pool.getNumActive());
+      assertEquals(1, pool.getNumIdle());
+      assertEquals(2, factory.created.get());
+      assertEquals(1, factory.destroyed.get());
+    } finally {
+      pool.close();
+    }
+  }
+
+  private static class CountingFactory extends BasePooledObjectFactory<Object> {
+
+    final AtomicInteger created = new AtomicInteger();
+    final AtomicInteger destroyed = new AtomicInteger();
+
+    @Override
+    public Object create() {
+      created.incrementAndGet();
+      return new Object();
+    }
+
+    @Override
+    public PooledObject<Object> wrap(Object obj) {
+      return new DefaultPooledObject<>(obj);
+    }
+
+    @Override
+    public void destroyObject(PooledObject<Object> p) {
+      destroyed.incrementAndGet();
+    }
+  }
+
+  private static class FailingReplacementFactory extends CountingFactory {
+
+    @Override
+    public Object create() {
+      if (created.getAndIncrement() > 0) {
+        throw new RuntimeException("server unavailable");
+      }
+      return new Object();
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4690

`Jedis.close()` currently throws when returning a broken connection to the pool if commons-pool2 cannot create a replacement (`invalidateObject` → `addObject`). That is unexpected: close should only release the broken resource, not surface pool replenishment failures.

This is a commons-pool2 2.13.x behaviour change ([POOL-431](https://issues.apache.org/jira/browse/POOL-431)): `invalidateObject()` always calls `addObject()`. Upstream [apache/commons-pool#454](https://github.com/apache/commons-pool/pull/454) is still pending, so this is the Jedis-side mitigation discussed on the issue.

### Change
In `Pool.returnBrokenResource`, catch the exception from `invalidateObject` and log it instead of wrapping it as a `JedisException`. The broken object has already been destroyed/removed from the pool; a failed replacement must not escape `close()`. This also covers the older 2.12 waiter-aware `addObject()` path.

### Tests
- `PoolTest.returnBrokenResourceDoesNotThrowWhenReplacementFails` — factory succeeds once, then fails on replenishment; `returnBrokenResource` does not throw, and a later `getResource` still fails.
- `PoolTest.returnBrokenResourceReplacesObjectWhenFactorySucceeds` — happy path still replenishes.
- `UnavailableConnectionTest` now asserts `close()` does not throw when the server is unreachable.

```
mvn -Dtest=redis.clients.jedis.util.PoolTest test
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pool error handling on the close path: failures after invalidating a broken resource are swallowed and logged, which is the intended close() contract but could hide genuine invalidate/destroy issues.
> 
> **Overview**
> Stops `Jedis.close()` / `returnBrokenResource` from throwing when commons-pool2 2.13+ fails to create a replacement after invalidating a broken connection (POOL-431 / #4690). The broken object is already destroyed; replenishment errors are now logged as a warning instead of wrapped as `JedisException`.
> 
> Adds unit coverage for both failed and successful replacement, and updates the unavailable-server integration test so `close()` is expected not to throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699a2184109fbca8fc33470080a58f65ef2268e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->