### PR TITLE
[maintenance events] Add maintenance-notification scenario tests driven by the fault injector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,7 @@
 						<include>**/ConnectionRegistry.java</include>
 						<include>**/MovingOperations.java</include>
 						<include>src/test/java/com/redis/test/fi/*.java</include>
+						<include>**/MaintNotificationsIT.java</include>
 						<include>**/MaintNotificationsTestSupport.java</include>
 						<include>**/MaintNotificationsScenarioBase.java</include>
 						<include>**/MaintNotificationsReceptionIT.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,9 @@
 						<include>**/ConnectionRegistry.java</include>
 						<include>**/MovingOperations.java</include>
 						<include>src/test/java/com/redis/test/fi/*.java</include>
+						<include>**/MaintNotificationsTestSupport.java</include>
+						<include>**/MaintNotificationsScenarioBase.java</include>
+						<include>**/MaintNotificationsReceptionIT.java</include>
 						<include>**/SocketAddress*.java</include>
 						<include>**/sch/*.java</include>
 						<include>**/ConnectionFactoryRebindTest.java</include>

--- a/pom.xml
+++ b/pom.xml
@@ -446,7 +446,10 @@
 						</goals>
 						<configuration>
 							<skip>${skipScenarioTests}</skip>
-							<argLine>@{failsafeScenarioArgLine} ${JVM_OPTS}</argLine>
+							<!-- short JVM DNS cache: scenario tests reconnect across endpoint rebinds
+							     (default 30s positive cache can outlive the DNS repoint) and await
+							     fresh, not-yet-propagated database names (default 10s negative cache) -->
+							<argLine>@{failsafeScenarioArgLine} ${JVM_OPTS} -Dsun.net.inetaddr.ttl=2 -Dsun.net.inetaddr.negative.ttl=2</argLine>
 							<groups>scenario</groups>
 							<excludedGroups>integration,unit</excludedGroups>
 							<includes>

--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,7 @@
 						<include>**/Maintenance*.java</include>
 						<include>**/ConnectionRegistry.java</include>
 						<include>**/MovingOperations.java</include>
+						<include>src/test/java/com/redis/test/fi/*.java</include>
 						<include>**/SocketAddress*.java</include>
 						<include>**/sch/*.java</include>
 						<include>**/ConnectionFactoryRebindTest.java</include>

--- a/src/main/java/redis/clients/jedis/Connection.java
+++ b/src/main/java/redis/clients/jedis/Connection.java
@@ -400,7 +400,7 @@ public class Connection implements Closeable {
     applyCurrentTimeout();
   }
 
-  private int currentTimeout() {
+  int currentTimeout() {
     return isBlocking ? defaultTimeoutSource.get().blockingTimeout : defaultTimeoutSource.get().timeout;
   }
 

--- a/src/test/java/com/redis/test/fi/Effect.java
+++ b/src/test/java/com/redis/test/fi/Effect.java
@@ -1,0 +1,59 @@
+package com.redis.test.fi;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A client-observable outcome of {@code topology_change_standalone} with the triggers that produce
+ * it — the typed, read-only envelope of one discovery response. Dbconfigs inside stay opaque maps;
+ * their schema belongs to the FI / Redis Enterprise.
+ */
+public final class Effect {
+
+  private final StandaloneEffect type;
+  private final int clusterNodes;
+  private final List<Trigger> triggers;
+
+  private Effect(StandaloneEffect type, int clusterNodes, List<Trigger> triggers) {
+    this.type = type;
+    this.clusterNodes = clusterNodes;
+    this.triggers = Collections.unmodifiableList(triggers);
+  }
+
+  @SuppressWarnings("unchecked")
+  static Effect parse(StandaloneEffect type, Map<String, Object> response) {
+    Map<String, Object> cluster = (Map<String, Object>) response.get("cluster");
+    int nodes = cluster == null ? 0 : ((Number) cluster.get("nodes")).intValue();
+
+    List<Trigger> triggers = new ArrayList<>();
+    for (Object t : (List<Object>) response.get("triggers")) {
+      triggers.add(Trigger.parse(type, (Map<String, Object>) t));
+    }
+    return new Effect(type, nodes, triggers);
+  }
+
+  public StandaloneEffect type() {
+    return type;
+  }
+
+  public int clusterNodes() {
+    return clusterNodes;
+  }
+
+  public List<Trigger> triggers() {
+    return triggers;
+  }
+
+  /** The named trigger; fails loudly when the FI does not offer it for this effect. */
+  public Trigger trigger(String name) {
+    for (Trigger trigger : triggers) {
+      if (trigger.name().equals(name)) {
+        return trigger;
+      }
+    }
+    throw new IllegalArgumentException(
+        "FI offers no trigger '" + name + "' for " + type + "; available: " + triggers);
+  }
+}

--- a/src/test/java/com/redis/test/fi/FaultInjectorClient.java
+++ b/src/test/java/com/redis/test/fi/FaultInjectorClient.java
@@ -1,0 +1,192 @@
+package com.redis.test.fi;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Minimal client for the Redis fault-injector service: two HTTP primitives, one poll helper, and
+ * the four operations the maintenance-notification scenario tests need. The read-only discovery
+ * envelope is typed ({@link StandaloneTriggerCatalog}); everything round-tripped — dbconfigs and
+ * action outputs — stays an opaque map, the FI owns those schemas. Framework-free (JDK HTTP + gson,
+ * no jedis imports) and JDK 8 compatible so it can be extracted and reused by other JVM clients.
+ */
+public final class FaultInjectorClient {
+
+  public static final String BASE_URL_ENV = "FAULT_INJECTION_API_URL";
+  private static final String DEFAULT_BASE_URL = "http://127.0.0.1:20324";
+
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(300);
+  private static final Duration DATABASE_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration EFFECT_TIMEOUT = Duration.ofSeconds(180);
+  private static final int HTTP_TIMEOUT_MILLIS = 10_000;
+
+  private final String baseUrl;
+  /**
+   * Integral numbers must parse as Long, not gson's default Double: discovered dbconfigs are
+   * re-serialized verbatim for create_database, and 2.0 for shards_count would corrupt the payload.
+   */
+  private final Gson gson = new GsonBuilder()
+      .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
+
+  /** Base URL from the {@value #BASE_URL_ENV} env var, defaulting to a local fault injector. */
+  public FaultInjectorClient() {
+    this(System.getenv().getOrDefault(BASE_URL_ENV, DEFAULT_BASE_URL));
+  }
+
+  public FaultInjectorClient(String baseUrl) {
+    this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+  }
+
+  // --- HTTP primitives + poll helper ---
+
+  /** {@code GET {base}{path}}; the JSON response as an opaque map. */
+  public Map<String, Object> get(String path) {
+    return parseObject(request("GET", path, null));
+  }
+
+  /** {@code POST /action {"type", "parameters"}}; the id to poll with {@link #awaitAction}. */
+  public String postAction(String type, Map<String, Object> parameters) {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("type", type);
+    payload.put("parameters", parameters);
+
+    Object actionId = parseObject(request("POST", "/action", gson.toJson(payload)))
+        .get("action_id");
+    if (actionId == null) {
+      throw new FaultInjectorException("No action_id in response for action " + type);
+    }
+    return actionId.toString();
+  }
+
+  /**
+   * Polls the action every ~300 ms and returns the status response once it succeeds. Throws on
+   * {@code failed}, or on {@code timeout} — checked after each poll, so a completion during the
+   * final interval is not discarded.
+   */
+  public Map<String, Object> awaitAction(String actionId, Duration timeout) {
+    Instant deadline = Instant.now().plus(timeout);
+    while (true) {
+      Map<String, Object> response = get("/action/" + actionId);
+      Object status = response.get("status");
+      if ("success".equals(status)) {
+        return response;
+      }
+      if ("failed".equals(status)) {
+        throw new FaultInjectorException("Action " + actionId + " failed: " + response);
+      }
+      if (!Instant.now().isBefore(deadline)) {
+        throw new FaultInjectorException(
+            "Timeout after " + timeout + " waiting for action " + actionId);
+      }
+      try {
+        Thread.sleep(POLL_INTERVAL.toMillis());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new FaultInjectorException("Interrupted waiting for action " + actionId, e);
+      }
+    }
+  }
+
+  // --- operations ---
+
+  /**
+   * Discovers the triggers producing {@code effect}, each with the requirements (dbconfigs) it can
+   * run under. The envelope is typed; the dbconfigs inside stay opaque maps.
+   */
+  public Effect getStandaloneTriggers(StandaloneEffect effect) {
+    return Effect.parse(effect,
+      get("/topology-change-standalone?effect=" + effect.wireName() + "&cluster_index=0"));
+  }
+
+  /**
+   * Creates a database from a discovery-provided dbconfig (passed verbatim) and returns the action
+   * output: {@code {"bdb_id", "username", "password", "tls", "endpoints": ["redis://host:port"]}}.
+   */
+  public Map<String, Object> createDatabase(Map<String, Object> dbConfig) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("database_config", dbConfig);
+    Map<String, Object> response = awaitAction(postAction("create_database", parameters),
+      DATABASE_TIMEOUT);
+    return asObject(response.get("output"));
+  }
+
+  public void deleteDatabase(long bdbId) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("bdb_id", bdbId);
+    awaitAction(postAction("delete_database", parameters), DATABASE_TIMEOUT);
+  }
+
+  /** Fires {@code effect} via {@code trigger} on the database and waits for it to complete. */
+  public Map<String, Object> triggerEffect(long bdbId, StandaloneEffect effect, String trigger) {
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("bdb_id", bdbId);
+    parameters.put("cluster_index", 0);
+    parameters.put("effect", effect.wireName());
+    parameters.put("trigger", trigger);
+    return awaitAction(postAction("topology_change_standalone", parameters), EFFECT_TIMEOUT);
+  }
+
+  // --- http/json plumbing ---
+
+  private String request(String method, String path, String jsonBody) {
+    try {
+      HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + path).openConnection();
+      conn.setConnectTimeout(HTTP_TIMEOUT_MILLIS);
+      conn.setReadTimeout(HTTP_TIMEOUT_MILLIS);
+      conn.setRequestMethod(method);
+      if (jsonBody != null) {
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setDoOutput(true);
+        try (OutputStream out = conn.getOutputStream()) {
+          out.write(jsonBody.getBytes(StandardCharsets.UTF_8));
+        }
+      }
+
+      int status = conn.getResponseCode();
+      InputStream stream = status >= 400 ? conn.getErrorStream() : conn.getInputStream();
+      String body = stream == null ? "" : readAll(stream);
+      if (status >= 400) {
+        throw new FaultInjectorException(
+            method + " " + path + " failed with HTTP " + status + ": " + body);
+      }
+      return body;
+    } catch (IOException e) {
+      throw new FaultInjectorException(method + " " + path + " failed", e);
+    }
+  }
+
+  private static String readAll(InputStream in) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    byte[] buffer = new byte[4096];
+    int n;
+    while ((n = in.read(buffer)) != -1) {
+      out.write(buffer, 0, n);
+    }
+    return new String(out.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  private Map<String, Object> parseObject(String json) {
+    Map<String, Object> parsed = gson.fromJson(json, new TypeToken<Map<String, Object>>() {
+    }.getType());
+    return parsed == null ? new HashMap<>() : parsed;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> asObject(Object value) {
+    return value instanceof Map ? (Map<String, Object>) value : new HashMap<>();
+  }
+}

--- a/src/test/java/com/redis/test/fi/FaultInjectorClient.java
+++ b/src/test/java/com/redis/test/fi/FaultInjectorClient.java
@@ -108,8 +108,8 @@ public final class FaultInjectorClient {
    * run under. The envelope is typed; the dbconfigs inside stay opaque maps.
    */
   public Effect getStandaloneTriggers(StandaloneEffect effect) {
-    return Effect.parse(effect,
-      get("/topology-change-standalone?effect=" + effect.wireName() + "&cluster_index=0"));
+    return Effect.parse(effect, get("/topology-change-standalone?effect=" + effect.wireName()
+        + "&cluster_index=0&include_tls=true"));
   }
 
   /**

--- a/src/test/java/com/redis/test/fi/FaultInjectorClientTest.java
+++ b/src/test/java/com/redis/test/fi/FaultInjectorClientTest.java
@@ -1,6 +1,7 @@
 package com.redis.test.fi;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -125,7 +126,8 @@ public class FaultInjectorClientTest {
     Effect effect = client.getStandaloneTriggers(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP);
 
     assertEquals("GET", requests.get(0)[0]);
-    assertEquals("/topology-change-standalone?effect=data_movement_no_conn_drop&cluster_index=0",
+    assertEquals(
+      "/topology-change-standalone?effect=data_movement_no_conn_drop&cluster_index=0&include_tls=true",
       requests.get(0)[1]);
     assertEquals("m-standard", effect.trigger("migrate").requirement().dbConfig().get("name"));
   }
@@ -219,6 +221,9 @@ public class FaultInjectorClientTest {
     assertEquals("single_tls", maintenance.requirements().get(1).config());
     assertEquals("single", maintenance.requirement().config());
     assertEquals("tcs-mm-tls-1-a", maintenance.requirement("single_tls").dbConfig().get("name"));
+    assertEquals("single_tls", maintenance.scenario("single_tls").requirement().config());
+    assertTrue(maintenance.offers("single_tls"));
+    assertFalse(maintenance.offers("no_such_config"));
     assertThrows(IllegalArgumentException.class, () -> maintenance.requirement("no_such_config"));
 
     assertEquals(6, catalog.effect(StandaloneEffect.CONN_DROP).clusterNodes());

--- a/src/test/java/com/redis/test/fi/FaultInjectorClientTest.java
+++ b/src/test/java/com/redis/test/fi/FaultInjectorClientTest.java
@@ -1,0 +1,269 @@
+package com.redis.test.fi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Wire-format and parsing tests for {@link FaultInjectorClient} against a scripted in-process HTTP
+ * server standing in for the fault injector.
+ */
+public class FaultInjectorClientTest {
+
+  private static final Gson GSON = new Gson();
+
+  private HttpServer server;
+  private FaultInjectorClient client;
+
+  /** Recorded requests: method, path+query, body. Thread-safe: written on the server thread. */
+  private final List<String[]> requests = Collections.synchronizedList(new ArrayList<>());
+  /** Scripted responses served in order; the last one repeats. Polled on the server thread. */
+  private final Queue<String> responses = new ConcurrentLinkedQueue<>();
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    server.createContext("/", exchange -> {
+      requests.add(new String[] { exchange.getRequestMethod(), exchange.getRequestURI().toString(),
+          readBody(exchange) });
+      String body = responses.size() > 1 ? responses.poll() : responses.peek();
+      respond(exchange, body == null ? "{}" : body);
+    });
+    server.start();
+    client = new FaultInjectorClient("http://127.0.0.1:" + server.getAddress().getPort());
+  }
+
+  @AfterEach
+  public void tearDown() {
+    server.stop(0);
+    requests.clear();
+    responses.clear();
+  }
+
+  @Test
+  public void postActionSendsTypeAndParameters() {
+    responses.add("{\"action_id\": \"a1\"}");
+
+    Map<String, Object> parameters = new HashMap<>();
+    parameters.put("bdb_id", 7);
+    String actionId = client.postAction("failover", parameters);
+
+    assertEquals("a1", actionId);
+    assertEquals("POST", requests.get(0)[0]);
+    assertEquals("/action", requests.get(0)[1]);
+    Map<String, Object> payload = parse(requests.get(0)[2]);
+    assertEquals("failover", payload.get("type"));
+    assertEquals(7, ((Number) ((Map<?, ?>) payload.get("parameters")).get("bdb_id")).intValue());
+  }
+
+  @Test
+  public void postActionWithoutActionIdThrows() {
+    responses.add("{}");
+
+    FaultInjectorException e = assertThrows(FaultInjectorException.class,
+      () -> client.postAction("failover", new HashMap<>()));
+    assertTrue(e.getMessage().contains("No action_id"));
+  }
+
+  @Test
+  public void awaitActionPollsUntilSuccess() {
+    responses.add("{\"status\": \"running\"}");
+    responses.add("{\"status\": \"running\"}");
+    responses.add("{\"status\": \"success\", \"output\": {\"bdb_id\": 5}}");
+
+    Map<String, Object> response = client.awaitAction("a1", Duration.ofSeconds(5));
+
+    assertEquals("success", response.get("status"));
+    assertTrue(requests.size() >= 3, "polled until terminal status");
+    assertEquals("/action/a1", requests.get(0)[1]);
+  }
+
+  @Test
+  public void awaitActionThrowsOnFailed() {
+    responses.add("{\"status\": \"failed\", \"error\": \"boom\"}");
+
+    FaultInjectorException e = assertThrows(FaultInjectorException.class,
+      () -> client.awaitAction("a1", Duration.ofSeconds(2)));
+    assertTrue(e.getMessage().contains("boom"));
+  }
+
+  @Test
+  public void awaitActionTimesOut() {
+    responses.add("{\"status\": \"running\"}");
+
+    assertThrows(FaultInjectorException.class,
+      () -> client.awaitAction("a1", Duration.ofMillis(400)));
+  }
+
+  @Test
+  public void getStandaloneTriggersRequestsEffectAndTypesTheEnvelope() {
+    responses.add("{\"triggers\": [{\"name\": \"migrate\","
+        + " \"requirements\": [{\"dbconfig\": {\"name\": \"m-standard\"}}]}]}");
+
+    Effect effect = client.getStandaloneTriggers(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP);
+
+    assertEquals("GET", requests.get(0)[0]);
+    assertEquals("/topology-change-standalone?effect=data_movement_no_conn_drop&cluster_index=0",
+      requests.get(0)[1]);
+    assertEquals("m-standard", effect.trigger("migrate").requirement().dbConfig().get("name"));
+  }
+
+  @Test
+  public void createDatabasePassesDbconfigVerbatimAndReturnsOutput() {
+    responses.add("{\"triggers\": [{\"name\": \"migrate\","
+        + " \"requirements\": [{\"dbconfig\": {\"name\": \"m-standard\", \"shards_count\": 2,"
+        + " \"memory_size\": 134217728}}]}]}");
+    responses.add("{\"action_id\": \"a6\"}");
+    responses.add("{\"status\": \"success\", \"output\": {\"bdb_id\": 42,"
+        + " \"endpoints\": [\"redis://db.example:12000\"]}}");
+
+    Map<String, Object> dbConfig = client
+        .getStandaloneTriggers(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP).trigger("migrate")
+        .requirement().dbConfig();
+    Map<String, Object> output = client.createDatabase(dbConfig);
+
+    assertEquals(42L, output.get("bdb_id"));
+    assertEquals("redis://db.example:12000", ((List<?>) output.get("endpoints")).get(0));
+    Map<String, Object> payload = parse(requests.get(1)[2]);
+    assertEquals("create_database", payload.get("type"));
+    String createBody = requests.get(1)[2];
+    assertTrue(createBody.contains("\"shards_count\":2,"),
+      "integral dbconfig fields must round-trip unchanged, got: " + createBody);
+    assertTrue(createBody.contains("\"memory_size\":134217728"),
+      "integral dbconfig fields must round-trip unchanged, got: " + createBody);
+  }
+
+  @Test
+  public void deleteDatabaseSendsBdbId() {
+    responses.add("{\"action_id\": \"a4\"}");
+    responses.add("{\"status\": \"success\"}");
+
+    client.deleteDatabase(42);
+
+    Map<String, Object> payload = parse(requests.get(0)[2]);
+    assertEquals("delete_database", payload.get("type"));
+    assertEquals(42, ((Number) ((Map<?, ?>) payload.get("parameters")).get("bdb_id")).intValue());
+  }
+
+  @Test
+  public void triggerEffectSendsParametersAndAwaitsCompletion() {
+    responses.add("{\"action_id\": \"a9\"}");
+    responses.add("{\"status\": \"running\"}");
+    responses.add("{\"status\": \"success\"}");
+
+    Map<String, Object> response = client.triggerEffect(42,
+      StandaloneEffect.DATA_MOVEMENT_CONN_DROP, "endpoint_rebind");
+
+    assertEquals("success", response.get("status"));
+    Map<String, Object> payload = parse(requests.get(0)[2]);
+    assertEquals("topology_change_standalone", payload.get("type"));
+    Map<?, ?> parameters = (Map<?, ?>) payload.get("parameters");
+    assertEquals(42, ((Number) parameters.get("bdb_id")).intValue());
+    assertEquals("data_movement_conn_drop", parameters.get("effect"));
+    assertEquals("endpoint_rebind", parameters.get("trigger"));
+  }
+
+  @Test
+  public void catalogResolvesEffectsTriggersAndRequirements() {
+    // one response per effect, in StandaloneEffect declaration order
+    responses.add("{\"cluster\": {\"index\": 0, \"nodes\": 6}, \"triggers\": ["
+        + " {\"name\": \"maintenance_mode\", \"description\": \"evacuate\","
+        + "  \"requirements\": [{\"dbconfig\": {\"name\": \"tcs-mm-1-a\"},"
+        + "   \"cluster\": {\"min_nodes\": 3, \"actual_nodes\": 6},"
+        + "   \"config\": \"single\", \"description\": \"Standalone config (single)\"},"
+        + "  {\"dbconfig\": {\"name\": \"tcs-mm-tls-1-a\"},"
+        + "   \"cluster\": {\"min_nodes\": 3, \"actual_nodes\": 6},"
+        + "   \"config\": \"single_tls\", \"description\": \"Standalone config (single_tls)\"}]}]}");
+    responses.add("{\"cluster\": {\"index\": 0, \"nodes\": 6}, \"triggers\": ["
+        + " {\"name\": \"migrate\", \"description\": \"move shards\","
+        + "  \"requirements\": [{\"dbconfig\": {\"name\": \"tcs-mig-1-a\"},"
+        + "   \"cluster\": {\"min_nodes\": 3, \"actual_nodes\": 6},"
+        + "   \"config\": \"single\", \"description\": \"Standalone config (single)\"}]}]}");
+    responses.add("{\"cluster\": {\"index\": 0, \"nodes\": 6}, \"triggers\": []}");
+    responses.add("{\"cluster\": {\"index\": 0, \"nodes\": 6}, \"triggers\": []}");
+
+    StandaloneTriggerCatalog catalog = StandaloneTriggerCatalog.resolve(client);
+
+    assertEquals(2, catalog.allTriggers().size());
+    Trigger migrate = catalog.effect(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP)
+        .trigger("migrate");
+    assertEquals("move shards", migrate.description());
+    assertEquals("tcs-mig-1-a", migrate.requirement().dbConfig().get("name"));
+    assertEquals(3, migrate.requirement().minNodes());
+
+    Trigger maintenance = catalog.effect(StandaloneEffect.DATA_MOVEMENT_CONN_DROP)
+        .trigger("maintenance_mode");
+    assertEquals(2, maintenance.requirements().size());
+    assertEquals("single_tls", maintenance.requirements().get(1).config());
+    assertEquals("single", maintenance.requirement().config());
+    assertEquals("tcs-mm-tls-1-a", maintenance.requirement("single_tls").dbConfig().get("name"));
+    assertThrows(IllegalArgumentException.class, () -> maintenance.requirement("no_such_config"));
+
+    assertEquals(6, catalog.effect(StandaloneEffect.CONN_DROP).clusterNodes());
+    assertThrows(IllegalArgumentException.class,
+      () -> catalog.effect(StandaloneEffect.CONN_DROP).trigger("no_such_trigger"));
+  }
+
+  @Test
+  public void httpErrorSurfacesBody() {
+    server.removeContext("/");
+    server.createContext("/", exchange -> {
+      byte[] body = "{\"detail\": \"Validation Error\"}".getBytes(StandardCharsets.UTF_8);
+      exchange.sendResponseHeaders(422, body.length);
+      try (OutputStream out = exchange.getResponseBody()) {
+        out.write(body);
+      }
+    });
+
+    FaultInjectorException e = assertThrows(FaultInjectorException.class,
+      () -> client.get("/action/a1"));
+    assertTrue(e.getMessage().contains("422"));
+    assertTrue(e.getMessage().contains("Validation Error"));
+  }
+
+  private static Map<String, Object> parse(String json) {
+    return GSON.fromJson(json, new TypeToken<Map<String, Object>>() {
+    }.getType());
+  }
+
+  private static String readBody(HttpExchange exchange) throws IOException {
+    java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    byte[] buffer = new byte[4096];
+    int n;
+    while ((n = exchange.getRequestBody().read(buffer)) != -1) {
+      out.write(buffer, 0, n);
+    }
+    return new String(out.toByteArray(), StandardCharsets.UTF_8);
+  }
+
+  private static void respond(HttpExchange exchange, String body) throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json");
+    exchange.sendResponseHeaders(200, bytes.length);
+    try (OutputStream out = exchange.getResponseBody()) {
+      out.write(bytes);
+    }
+  }
+}

--- a/src/test/java/com/redis/test/fi/FaultInjectorException.java
+++ b/src/test/java/com/redis/test/fi/FaultInjectorException.java
@@ -1,0 +1,13 @@
+package com.redis.test.fi;
+
+/** Failure talking to the fault injector, or a fault-injector operation that did not succeed. */
+public class FaultInjectorException extends RuntimeException {
+
+  public FaultInjectorException(String message) {
+    super(message);
+  }
+
+  public FaultInjectorException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/com/redis/test/fi/Requirement.java
+++ b/src/test/java/com/redis/test/fi/Requirement.java
@@ -1,0 +1,53 @@
+package com.redis.test.fi;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** One way to satisfy a {@link Trigger}: a ready-to-create dbconfig plus its preconditions. */
+public final class Requirement {
+
+  private final String config;
+  private final String description;
+  private final int minNodes;
+  private final Map<String, Object> dbConfig;
+
+  private Requirement(String config, String description, int minNodes,
+      Map<String, Object> dbConfig) {
+    this.config = config;
+    this.description = description;
+    this.minNodes = minNodes;
+    this.dbConfig = Collections.unmodifiableMap(dbConfig);
+  }
+
+  @SuppressWarnings("unchecked")
+  static Requirement parse(Map<String, Object> requirement) {
+    Map<String, Object> cluster = (Map<String, Object>) requirement.get("cluster");
+    int minNodes = cluster == null ? 0 : ((Number) cluster.get("min_nodes")).intValue();
+    return new Requirement((String) requirement.get("config"),
+        (String) requirement.get("description"), minNodes,
+        (Map<String, Object>) requirement.get("dbconfig"));
+  }
+
+  /** Catalog entry name: single, single_tls, scaled_single, mtls. */
+  public String config() {
+    return config;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public int minNodes() {
+    return minNodes;
+  }
+
+  /** The dbconfig to pass verbatim to {@link FaultInjectorClient#createDatabase}. */
+  public Map<String, Object> dbConfig() {
+    return dbConfig;
+  }
+
+  @Override
+  public String toString() {
+    return "Requirement[" + config + "]";
+  }
+}

--- a/src/test/java/com/redis/test/fi/Scenario.java
+++ b/src/test/java/com/redis/test/fi/Scenario.java
@@ -1,0 +1,33 @@
+package com.redis.test.fi;
+
+/**
+ * One runnable test combination: a {@link Trigger} under one of its {@link Requirement}s. The
+ * effect is derived from the trigger, never stored — a scenario cannot be inconsistent.
+ */
+public final class Scenario {
+
+  private final Trigger trigger;
+  private final Requirement requirement;
+
+  Scenario(Trigger trigger, Requirement requirement) {
+    this.trigger = trigger;
+    this.requirement = requirement;
+  }
+
+  public StandaloneEffect effect() {
+    return trigger.effect();
+  }
+
+  public Trigger trigger() {
+    return trigger;
+  }
+
+  public Requirement requirement() {
+    return requirement;
+  }
+
+  @Override
+  public String toString() {
+    return trigger + "[" + requirement.config() + "]";
+  }
+}

--- a/src/test/java/com/redis/test/fi/StandaloneEffect.java
+++ b/src/test/java/com/redis/test/fi/StandaloneEffect.java
@@ -1,0 +1,29 @@
+package com.redis.test.fi;
+
+/**
+ * Client-observable outcomes of the fault injector's {@code topology_change_standalone} action.
+ * Each effect is produced by one or more named triggers; see
+ * {@link FaultInjectorClient#getStandaloneTriggers(StandaloneEffect)}.
+ */
+public enum StandaloneEffect {
+
+  /** Data moves and the endpoint rebinds (connection drop). */
+  DATA_MOVEMENT_CONN_DROP("data_movement_conn_drop"),
+  /** Data moves while the endpoint stays (hitless). */
+  DATA_MOVEMENT_NO_CONN_DROP("data_movement_no_conn_drop"),
+  /** The endpoint rebinds without moving data. */
+  CONN_DROP("conn_drop"),
+  /** The endpoint policy changes, altering what its DNS name resolves to. */
+  DNS_RESOLUTION_CHANGE("dns_resolution_change");
+
+  private final String wireName;
+
+  StandaloneEffect(String wireName) {
+    this.wireName = wireName;
+  }
+
+  /** The effect name as the fault injector API expects it. */
+  public String wireName() {
+    return wireName;
+  }
+}

--- a/src/test/java/com/redis/test/fi/StandaloneTriggerCatalog.java
+++ b/src/test/java/com/redis/test/fi/StandaloneTriggerCatalog.java
@@ -1,0 +1,41 @@
+package com.redis.test.fi;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Preloaded topology-change-standalone catalog: every {@link StandaloneEffect} resolved to its
+ * {@link Effect} in one discovery pass. The catalog is static per FI instance.
+ */
+public final class StandaloneTriggerCatalog {
+
+  private final Map<StandaloneEffect, Effect> effects;
+
+  private StandaloneTriggerCatalog(Map<StandaloneEffect, Effect> effects) {
+    this.effects = effects;
+  }
+
+  public static StandaloneTriggerCatalog resolve(FaultInjectorClient client) {
+    Map<StandaloneEffect, Effect> effects = new LinkedHashMap<>();
+    for (StandaloneEffect type : StandaloneEffect.values()) {
+      effects.put(type, client.getStandaloneTriggers(type));
+    }
+    return new StandaloneTriggerCatalog(effects);
+  }
+
+  public Effect effect(StandaloneEffect type) {
+    return effects.get(type);
+  }
+
+  /** All triggers of all effects, in discovery order. */
+  public List<Trigger> allTriggers() {
+    List<Trigger> all = new ArrayList<>();
+    for (Effect effect : effects.values()) {
+      all.addAll(effect.triggers());
+    }
+    return all;
+  }
+
+}

--- a/src/test/java/com/redis/test/fi/Trigger.java
+++ b/src/test/java/com/redis/test/fi/Trigger.java
@@ -1,0 +1,71 @@
+package com.redis.test.fi;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** A cluster recipe producing its {@link Effect}, with the requirements it can run under. */
+public final class Trigger {
+
+  private final StandaloneEffect effect;
+  private final String name;
+  private final String description;
+  private final List<Requirement> requirements;
+
+  private Trigger(StandaloneEffect effect, String name, String description,
+      List<Requirement> requirements) {
+    this.effect = effect;
+    this.name = name;
+    this.description = description;
+    this.requirements = Collections.unmodifiableList(requirements);
+  }
+
+  @SuppressWarnings("unchecked")
+  static Trigger parse(StandaloneEffect effect, Map<String, Object> trigger) {
+    List<Requirement> requirements = new ArrayList<>();
+    for (Object r : (List<Object>) trigger.get("requirements")) {
+      requirements.add(Requirement.parse((Map<String, Object>) r));
+    }
+    return new Trigger(effect, (String) trigger.get("name"), (String) trigger.get("description"),
+        requirements);
+  }
+
+  public StandaloneEffect effect() {
+    return effect;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  /** The requirement with the given catalog config name; fails loudly if absent. */
+  public Requirement requirement(String config) {
+    return requirements.stream().filter(r -> config.equals(r.config())).findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+            "Trigger " + name + " has no requirement config '" + config + "': " + requirements));
+  }
+
+  public List<Requirement> requirements() {
+    return requirements;
+  }
+
+  /** The base 'single' variant — requirements[0]; TLS/scaled variants are FI-flag opt-ins. */
+  public Requirement requirement() {
+    return requirements.get(0);
+  }
+
+  /** This trigger under its base requirement. */
+  public Scenario scenario() {
+    return new Scenario(this, requirement());
+  }
+
+  @Override
+  public String toString() {
+    return effect + "/" + name;
+  }
+}

--- a/src/test/java/com/redis/test/fi/Trigger.java
+++ b/src/test/java/com/redis/test/fi/Trigger.java
@@ -43,6 +43,16 @@ public final class Trigger {
     return description;
   }
 
+  /** A scenario running this trigger under the named requirement config; fails loudly if absent. */
+  public Scenario scenario(String config) {
+    return new Scenario(this, requirement(config));
+  }
+
+  /** Whether the FI environment offers the named requirement config for this trigger. */
+  public boolean offers(String config) {
+    return requirements.stream().anyMatch(r -> config.equals(r.config()));
+  }
+
   /** The requirement with the given catalog config name; fails loudly if absent. */
   public Requirement requirement(String config) {
     return requirements.stream().filter(r -> config.equals(r.config())).findFirst()

--- a/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
+++ b/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
@@ -1,7 +1,6 @@
 package redis.clients.jedis;
 
 import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -15,14 +14,9 @@ public final class MaintNotificationsTestSupport {
   private MaintNotificationsTestSupport() {
   }
 
-  /** The connection's live socket peer as {@code host:port}, comparable to a MOVING target. */
-  public static String remoteAddress(Connection connection) {
-    SocketAddress peer = connection.getRemoteSocketAddress();
-    if (peer instanceof InetSocketAddress) {
-      InetSocketAddress inet = (InetSocketAddress) peer;
-      return inet.getHostString() + ":" + inet.getPort();
-    }
-    return String.valueOf(peer);
+  /** The connection's live socket peer. */
+  public static InetSocketAddress remotePeer(Connection connection) {
+    return (InetSocketAddress) connection.getRemoteSocketAddress();
   }
 
   /**

--- a/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
+++ b/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
@@ -1,0 +1,118 @@
+package redis.clients.jedis;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Test bridge to package-private maintenance-notification internals of {@link Connection}:
+ * recording dispatched events.
+ */
+public final class MaintNotificationsTestSupport {
+
+  private MaintNotificationsTestSupport() {
+  }
+
+  /** Registers a recorder for every maintenance event dispatched on {@code connection}. */
+  public static ReceivedEvents record(Connection connection) {
+    ReceivedEvents events = new ReceivedEvents();
+    connection.addMaintenanceEventListener(events);
+    return events;
+  }
+
+  /** One received maintenance event with its parsed payload, as dispatched to the connection. */
+  public static final class ReceivedEvent {
+
+    /** One of the maintenance {@link PushMessageTypes} constants. */
+    public final String type;
+    public final long seq;
+    /** MOVING grace period or opening lead time, in seconds; -1 for closings, which carry none. */
+    public final long timeSeconds;
+    /** Affected shard ids; null for MOVING. */
+    public final String shardIds;
+    /** MOVING target ("host:port"); null for a 'none' rebind and for non-MOVING events. */
+    public final String target;
+    public final long atNanos = System.nanoTime();
+
+    ReceivedEvent(String type, long seq, long timeSeconds, String shardIds, String target) {
+      this.type = type;
+      this.seq = seq;
+      this.timeSeconds = timeSeconds;
+      this.shardIds = shardIds;
+      this.target = target;
+    }
+
+    @Override
+    public String toString() {
+      return type + "(seq=" + seq + (timeSeconds >= 0 ? ", time=" + timeSeconds : "")
+          + (shardIds != null ? ", shards=" + shardIds : "")
+          + (target != null ? ", target=" + target : "") + ")";
+    }
+  }
+
+  /** All maintenance events received by one connection, in dispatch order, with payloads. */
+  public static final class ReceivedEvents implements MaintenanceEventListener {
+
+    private final List<ReceivedEvent> events = new CopyOnWriteArrayList<>();
+
+    public List<ReceivedEvent> all() {
+      return new CopyOnWriteArrayList<>(events);
+    }
+
+    public boolean movingReceived() {
+      return received(PushMessageTypes.MOVING);
+    }
+
+    /** MIGRATING or FAILING_OVER — maintenance started, timeouts relaxed. */
+    public boolean openingReceived() {
+      return received(PushMessageTypes.MIGRATING) || received(PushMessageTypes.FAILING_OVER);
+    }
+
+    /** MIGRATED or FAILED_OVER — maintenance finished, timeouts restored. */
+    public boolean closingReceived() {
+      return received(PushMessageTypes.MIGRATED) || received(PushMessageTypes.FAILED_OVER);
+    }
+
+    private boolean received(String type) {
+      for (ReceivedEvent event : events) {
+        if (type.equals(event.type)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /** Nanos of the most recent event, or -1 when none arrived yet. */
+    public long lastEventAtNanos() {
+      return events.isEmpty() ? -1 : events.get(events.size() - 1).atNanos;
+    }
+
+    @Override
+    public void onMoving(MovingEvent e, Connection c) {
+      events.add(new ReceivedEvent(PushMessageTypes.MOVING, e.seq, e.gracePeriodSeconds, null,
+          e.target == null ? null : e.target.toString()));
+    }
+
+    @Override
+    public void onMigrating(MigratingEvent e, Connection c) {
+      events.add(
+        new ReceivedEvent(PushMessageTypes.MIGRATING, e.seq, e.startsInSeconds, e.shardIds, null));
+    }
+
+    @Override
+    public void onMigrated(MigratedEvent e, Connection c) {
+      events.add(new ReceivedEvent(PushMessageTypes.MIGRATED, e.seq, -1, e.shardIds, null));
+    }
+
+    @Override
+    public void onFailingOver(FailingOverEvent e, Connection c) {
+      events.add(new ReceivedEvent(PushMessageTypes.FAILING_OVER, e.seq, e.startsInSeconds,
+          e.shardIds, null));
+    }
+
+    @Override
+    public void onFailedOver(FailedOverEvent e, Connection c) {
+      events.add(new ReceivedEvent(PushMessageTypes.FAILED_OVER, e.seq, -1, e.shardIds, null));
+    }
+  }
+
+}

--- a/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
+++ b/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
@@ -5,11 +5,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Test bridge to package-private maintenance-notification internals of {@link Connection}:
- * recording dispatched events.
+ * recording dispatched events and reading the effective (relaxed-aware) socket timeout.
  */
 public final class MaintNotificationsTestSupport {
 
   private MaintNotificationsTestSupport() {
+  }
+
+  /**
+   * The effective socket timeout in millis for non-blocking commands: the relaxed value while a
+   * maintenance relaxation window is open, the configured value otherwise.
+   */
+  public static int effectiveTimeoutMillis(Connection connection) {
+    return connection.currentTimeout();
   }
 
   /** Registers a recorder for every maintenance event dispatched on {@code connection}. */

--- a/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
+++ b/src/test/java/redis/clients/jedis/MaintNotificationsTestSupport.java
@@ -1,5 +1,8 @@
 package redis.clients.jedis;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -10,6 +13,16 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public final class MaintNotificationsTestSupport {
 
   private MaintNotificationsTestSupport() {
+  }
+
+  /** The connection's live socket peer as {@code host:port}, comparable to a MOVING target. */
+  public static String remoteAddress(Connection connection) {
+    SocketAddress peer = connection.getRemoteSocketAddress();
+    if (peer instanceof InetSocketAddress) {
+      InetSocketAddress inet = (InetSocketAddress) peer;
+      return inet.getHostString() + ":" + inet.getPort();
+    }
+    return String.valueOf(peer);
   }
 
   /**

--- a/src/test/java/redis/clients/jedis/scenario/DnsDiagnostics.java
+++ b/src/test/java/redis/clients/jedis/scenario/DnsDiagnostics.java
@@ -1,0 +1,74 @@
+package redis.clients.jedis.scenario;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Properties;
+
+import javax.naming.directory.InitialDirContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Follows an endpoint's DNS resolution on a daemon thread, sampling once per second from two views:
+ * the JVM's {@link InetAddress} (subject to the JVM cache) and a direct query to the system
+ * resolver (JNDI, JVM cache bypassed). A diverging pair of samples is direct evidence of stale
+ * client-side resolution around an endpoint rebind.
+ * <p>
+ * Messages log at TRACE and {@link #follow} is a no-op unless TRACE is enabled for this class —
+ * enable it in the logging configuration to trigger the diagnostics.
+ */
+final class DnsDiagnostics implements AutoCloseable {
+
+  private static final Logger logger = LoggerFactory.getLogger(DnsDiagnostics.class);
+  private static final DnsDiagnostics DISABLED = new DnsDiagnostics(null);
+
+  private final Thread sampler;
+
+  private DnsDiagnostics(Thread sampler) {
+    this.sampler = sampler;
+  }
+
+  /** Starts following {@code host}; no-op unless TRACE is enabled for this logger. */
+  static DnsDiagnostics follow(String host) {
+    if (!logger.isTraceEnabled()) {
+      return DISABLED;
+    }
+    Thread thread = new Thread(() -> {
+      while (!Thread.currentThread().isInterrupted()) {
+        sample(host);
+        try {
+          Thread.sleep(1_000);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, "dns-diag");
+    thread.setDaemon(true);
+    thread.start();
+    return new DnsDiagnostics(thread);
+  }
+
+  private static void sample(String host) {
+    try {
+      logger.trace("jvm {} -> {}", host, Arrays.toString(InetAddress.getAllByName(host)));
+    } catch (Exception e) {
+      logger.trace("jvm {} -> {}", host, e.toString());
+    }
+    try {
+      Properties env = new Properties();
+      env.put("java.naming.factory.initial", "com.sun.jndi.dns.DnsContextFactory");
+      logger.trace("dns {} -> {}", host,
+        new InitialDirContext(env).getAttributes(host, new String[] { "A" }).get("A"));
+    } catch (Exception e) {
+      logger.trace("dns {} -> {}", host, e.toString());
+    }
+  }
+
+  @Override
+  public void close() {
+    if (sampler != null) {
+      sampler.interrupt();
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/LagAwareStrategySslIT.java
@@ -23,16 +23,8 @@ import redis.clients.jedis.mcf.LagAwareStrategy;
 import redis.clients.jedis.util.TlsUtil;
 
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-import java.io.FileOutputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.KeyStore;
-import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.function.Supplier;
 
@@ -48,14 +40,13 @@ public class LagAwareStrategySslIT {
   private static EndpointConfig crdb;
   private static Endpoint restEndpoint;
   private static Supplier<RedisCredentials> credentialsSupplier;
-  private static final String certificateAlias = "redis-enterprise";
   private static final char[] trustStorePassword = "changeit".toCharArray();
 
   // truststore with certificate from REST API endpoint
   private static final String trustStorePfx = LagAwareStrategySslIT.class.getSimpleName();
-  private static final Path crdbTrustStore = Paths.get(trustStorePfx + "-crdb.jks");
+  private static final Path crdbTrustStore = TlsUtil.testTruststorePath(trustStorePfx + "-crdb");
   // empty truststore to test untrusted cert
-  private static final Path dummyTrustStore = Paths.get(trustStorePfx + "-dummy.jks");
+  private static final Path dummyTrustStore = TlsUtil.testTruststorePath(trustStorePfx + "-dummy");
 
   private SSLSocketFactory origSslSocketFactory;
 
@@ -68,7 +59,7 @@ public class LagAwareStrategySslIT {
     try {
       TlsUtil.createEmptyTruststore(dummyTrustStore, trustStorePassword);
       createTrustedTruststore(crdbTrustStore, restEndpoint.getHost(), restEndpoint.getPort(),
-        certificateAlias, trustStorePassword);
+        trustStorePassword);
     } catch (Exception e) {
       fail("Failed to create test truststore", e);
     }
@@ -198,47 +189,18 @@ public class LagAwareStrategySslIT {
   }
 
   /**
-   * Downloads the server certificate from a host and stores it as a JKS file.
-   * @param jks path where the JKS file will be created
+   * Downloads the server certificate from a host and pins it into a truststore.
+   * @param truststore path where the truststore will be created
    * @param host host to connect to (e.g., redis.example.com)
    * @param port TLS port (e.g., 9443)
-   * @param alias alias to store the certificate under
-   * @param password password for the JKS
+   * @param password password for the truststore
    */
-  static void createTrustedTruststore(Path jks, String host, int port, String alias,
-      char[] password) throws Exception {
-    // Use SSL socket to fetch server cert
-    // Disable certificate verification
-    TrustManager[] trustAll = new TrustManager[] { new X509TrustManager() {
-      public void checkClientTrusted(X509Certificate[] chain, String authType) {
-      }
+  static void createTrustedTruststore(Path truststore, String host, int port, char[] password)
+      throws Exception {
+    X509Certificate[] serverCerts = TlsUtil.captureServerChain(host, port);
 
-      public void checkServerTrusted(X509Certificate[] chain, String authType) {
-      }
-
-      public X509Certificate[] getAcceptedIssuers() {
-        return new X509Certificate[0];
-      }
-    } };
-    SSLContext sslContext = SSLContext.getInstance("TLS");
-    sslContext.init(null, trustAll, new java.security.SecureRandom());
-    SSLSocketFactory factory = sslContext.getSocketFactory();
-
-    try (SSLSocket socket = (SSLSocket) factory.createSocket(host, port)) {
-      socket.startHandshake();
-      Certificate[] serverCerts = socket.getSession().getPeerCertificates();
-
-      // Create an empty KeyStore
-      KeyStore ks = KeyStore.getInstance("JKS");
-      ks.load(null, password);
-
-      // Add server certificate (first in chain)
-      ks.setCertificateEntry(alias, serverCerts[0]);
-
-      // Write KeyStore to disk
-      try (FileOutputStream fos = new FileOutputStream(jks.toFile())) {
-        ks.store(fos, password);
-      }
-    }
+    // Pin server certificate (first in chain)
+    TlsUtil.createAndSaveTruststore(new X509Certificate[] { serverCerts[0] }, truststore,
+      new String(password));
   }
 }

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.awaitility.core.ConditionTimeoutException;
@@ -30,8 +31,10 @@ import redis.clients.jedis.BuilderFactory;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.CommandObject;
 import redis.clients.jedis.MaintNotificationsTestSupport;
+import redis.clients.jedis.MaintNotificationsTestSupport.ReceivedEvent;
 import redis.clients.jedis.MaintNotificationsTestSupport.ReceivedEvents;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.PushMessageTypes;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 /**
@@ -64,6 +67,12 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
   static Stream<Scenario> noConnDropScenarios() {
     return CATALOG.effect(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP).triggers().stream()
         .map(Trigger::scenario);
+  }
+
+  static Stream<Scenario> movingScenarios() {
+    // conn_drop/endpoint_rebind emits exactly [MOVING]
+    return Stream
+        .of(CATALOG.effect(StandaloneEffect.CONN_DROP).trigger("endpoint_rebind").scenario());
   }
 
   /**
@@ -103,6 +112,61 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
 
     // base restored behaviorally for non-blocking and blocking commands, in parallel
     assertProbesTimeOutAtBase("after close");
+    releasePinned();
+  }
+
+  /**
+   * T.1.2 Timeout Handling During Notifications — covers:
+   * <ul>
+   * <li>timeoutRelaxedOnMovingTest — send MOVING, send commands/traffic: commands complete without
+   * timeout during the grace period (no timeout exceptions during handoff).</li>
+   * <li>timeoutUnrelaxedAfterMovingDelayTest — wait for handoff completion, send commands/traffic:
+   * normal timeout behavior restored (timeout exceptions occur as expected).</li>
+   * </ul>
+   * MOVING has no closing notification: receiving it on any pool connection relaxes timeouts on all
+   * connections toward the affected node, until the MOVING ttl window expires.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("movingScenarios")
+  @Timeout(300)
+  void timeoutRelaxedWithinMovingWindow(Scenario scenario) {
+    setUpDatabaseAndClient(scenario);
+    warmUpPool();
+    pinned = pinConnection();
+    ReceivedEvents received = MaintNotificationsTestSupport.record(pinned);
+
+    assertProbesTimeOutAtBase("baseline");
+
+    startEffect(scenario);
+
+    awaitPush(received::movingReceived, "MOVING", received);
+    ReceivedEvent moving = received.all().stream()
+        .filter(e -> PushMessageTypes.MOVING.equals(e.type)).findFirst().get();
+    assertEquals(RELAXED_TIMEOUT_MS, MaintNotificationsTestSupport.effectiveTimeoutMillis(pinned),
+      "MOVING must relax the observer socket timeout");
+
+    // pool-wide relaxation: the probes run on other pool connections (the pool recreates the
+    // retired ones toward the MOVING target) and must survive to the server delay
+    runProbes().join().forEach(probe -> assertProbeSucceededAtServerDelay(probe, received));
+
+    assertEquals(RELAXED_TIMEOUT_MS, MaintNotificationsTestSupport.effectiveTimeoutMillis(pinned),
+      "no closing notification: relaxation holds until the window expires");
+
+    // un-relaxation happens only by expiry of the MOVING ttl window
+    await().atMost(Duration.ofSeconds(moving.timeSeconds + 10)).pollInterval(Duration.ofMillis(100))
+        .until(() -> MaintNotificationsTestSupport
+            .effectiveTimeoutMillis(pinned) == CLIENT_SOCKET_TIMEOUT_MS);
+    long relaxedForMillis = (System.nanoTime() - moving.atNanos) / 1_000_000;
+    assertTrue(relaxedForMillis >= TimeUnit.SECONDS.toMillis(moving.timeSeconds) - 100,
+      "relaxation ended " + relaxedForMillis + " ms after MOVING, before its " + moving.timeSeconds
+          + " s window expired");
+
+    joinEffectThreads();
+    assertEffectSucceeded();
+
+    // the observer's socket toward the old endpoint may be dead after the rebind, so probe
+    // without pumping it
+    runProbes().join().forEach(probe -> assertProbeTimedOutAtBase(probe, "after expiry"));
     releasePinned();
   }
 

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
@@ -29,6 +29,7 @@ import com.redis.test.fi.Trigger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -205,6 +206,24 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
   @MethodSource("handoffScenarios")
   @Timeout(300)
   void connectionHandoffOnMoving(Scenario scenario, EndpointType endpointType) {
+    assertConnectionHandoffLifecycle(scenario, endpointType);
+  }
+
+  /**
+   * connectionHandoffWithStaticExternalNameTest over TLS: the same handoff lifecycle on a rediss
+   * endpoint with the default FULL verification (pinned truststore + hostname verification) —
+   * validates the TLS handshake against the MOVING target (redis/jedis#4708).
+   */
+  @Test
+  @Timeout(300)
+  void connectionHandoffOnMovingOverTls() {
+    Trigger trigger = CATALOG.effect(StandaloneEffect.CONN_DROP).trigger("endpoint_rebind");
+    assumeTrue(trigger.offers("single_tls"),
+      "single_tls requirement not offered by this FI environment");
+    assertConnectionHandoffLifecycle(trigger.scenario("single_tls"), EndpointType.EXTERNAL_FQDN);
+  }
+
+  private void assertConnectionHandoffLifecycle(Scenario scenario, EndpointType endpointType) {
     setUpDatabaseAndClient(scenario, endpointType);
     warmUpPool();
     pinned = pinConnection();

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
@@ -1,0 +1,219 @@
+package redis.clients.jedis.scenario;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Stream;
+
+import org.awaitility.core.ConditionTimeoutException;
+
+import com.redis.test.fi.Scenario;
+import com.redis.test.fi.StandaloneEffect;
+import com.redis.test.fi.Trigger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.MaintNotificationsTestSupport;
+import redis.clients.jedis.MaintNotificationsTestSupport.ReceivedEvents;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+/**
+ * Verifies timeouts are relaxed while a maintenance window (MIGRATING/FAILING_OVER ..
+ * MIGRATED/FAILED_OVER) is open and restored after it closes — behaviorally, for non-blocking and
+ * blocking commands, through the public client: the server-side BLPOP delay (3 s) only survives a 1
+ * s base socket timeout when relaxation is in effect. MIGRATING/FAILING_OVER announce the operation
+ * ~2 s ahead (ttl), so probes launched on the opening always complete inside the window. A
+ * timed-out probe is protocol-desynced and its connection discarded by the pool, so window state
+ * rides on a pinned observer connection the probes never touch.
+ */
+@Tag("scenario")
+public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
+
+  private static final int PROBE_DELAY_SECONDS = 3;
+  /** Relaxed probes succeed at the server delay, never at the base timeout. */
+  private static final long RELAXED_SUCCESS_FLOOR_MS = 2_500;
+  private static final Duration PUSH_WAIT_TIMEOUT = Duration.ofSeconds(60);
+
+  private static final CommandObject<List<String>> REGULAR_PROBE = new CommandObject<>(
+      new CommandArguments(Protocol.Command.BLPOP).key("missing{probe}").add(PROBE_DELAY_SECONDS),
+      BuilderFactory.STRING_LIST); // -> socketTimeout / relaxedTimeout
+  private static final CommandObject<List<String>> BLOCKING_PROBE = new CommandObject<>(
+      new CommandArguments(Protocol.Command.BLPOP).key("missing{probe}").add(PROBE_DELAY_SECONDS)
+          .blocking(),
+      BuilderFactory.STRING_LIST); // -> blockingSocketTimeout / relaxedBlockingTimeout
+
+  private ExecutorService probeExecutor;
+
+  static Stream<Scenario> noConnDropScenarios() {
+    return CATALOG.effect(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP).triggers().stream()
+        .map(Trigger::scenario);
+  }
+
+  /**
+   * T.1.2 Timeout Handling During Notifications — covers timeoutRelaxedOnMigratingTest,
+   * timeoutUnrelaxedOnMigratedTest, timeoutRelaxedOnFailoverTest, timeoutUnrelaxedOnFailedoverTest.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("noConnDropScenarios")
+  @Timeout(300)
+  void timeoutRelaxedWithinMaintenanceWindow(Scenario scenario) {
+    setUpDatabaseAndClient(scenario);
+    warmUpPool();
+    pinned = pinConnection();
+    ReceivedEvents received = MaintNotificationsTestSupport.record(pinned);
+
+    // base timeouts enforced for non-blocking and blocking commands, in parallel
+    assertProbesTimeOutAtBase("baseline");
+
+    startEffect(scenario);
+
+    // the opening announces the operation ~2s ahead: the window is open from here to the closing
+    awaitPush(received::openingReceived, "opening (MIGRATING/FAILING_OVER)", received);
+    assertEquals(RELAXED_TIMEOUT_MS, MaintNotificationsTestSupport.effectiveTimeoutMillis(pinned),
+      "opening notification must relax the observer socket timeout");
+
+    // relaxation enforced behaviorally for non-blocking and blocking commands, in parallel
+    observeAndAwait(runProbes())
+        .forEach(probe -> assertProbeSucceededAtServerDelay(probe, received));
+
+    awaitPush(received::closingReceived, "closing (MIGRATED/FAILED_OVER)", received);
+    assertEquals(CLIENT_SOCKET_TIMEOUT_MS,
+      MaintNotificationsTestSupport.effectiveTimeoutMillis(pinned),
+      "closing notification must restore the observer socket timeout");
+
+    joinEffectThreads();
+    assertEffectSucceeded();
+
+    // base restored behaviorally for non-blocking and blocking commands, in parallel
+    assertProbesTimeOutAtBase("after close");
+    releasePinned();
+  }
+
+  // --- probes ---
+
+  /** Starts the non-blocking and blocking command probes in parallel. */
+  private CompletableFuture<List<ProbeContext>> runProbes() {
+    CompletableFuture<ProbeContext> regular = CompletableFuture
+        .supplyAsync(() -> runProbe(REGULAR_PROBE), probeExecutor());
+    CompletableFuture<ProbeContext> blocking = CompletableFuture
+        .supplyAsync(() -> runProbe(BLOCKING_PROBE), probeExecutor());
+    return regular.thenCombine(blocking, Arrays::asList);
+  }
+
+  private static void assertProbeSucceededAtServerDelay(ProbeContext probe,
+      ReceivedEvents received) {
+    if (probe.error != null || probe.durationMillis < RELAXED_SUCCESS_FLOOR_MS) {
+      fail(probe + " must survive to the server delay inside the relaxation window; events: "
+          + received.all());
+    }
+  }
+
+  /**
+   * Both probes must fail at their own base timeout: the non-blocking probe at socketTimeout (1s),
+   * the blocking probe at blockingSocketTimeout (2s) — the distinct values prove the blocking flag
+   * routed to the right timeout.
+   */
+  private void assertProbesTimeOutAtBase(String phase) {
+    observeAndAwait(runProbes()).forEach(probe -> assertProbeTimedOutAtBase(probe, phase));
+  }
+
+  private static void assertProbeTimedOutAtBase(ProbeContext probe, String phase) {
+    long atLeast = probe.blocking() ? CLIENT_BLOCKING_SOCKET_TIMEOUT_MS : CLIENT_SOCKET_TIMEOUT_MS;
+    assertTrue(probe.error instanceof JedisConnectionException,
+      phase + ": expected a base-timeout failure, got " + probe);
+    // a timeout never fires earlier than configured; it can fire later when a push arrives
+    // before the reply — that read returns the push, and the reply wait restarts its own window
+    assertTrue(probe.durationMillis >= atLeast,
+      phase + ": timed out earlier than the configured " + atLeast + " ms: " + probe);
+    // staying under the blocking base proves the non-blocking timeout was in force
+    if (!probe.blocking()) {
+      assertTrue(probe.durationMillis < CLIENT_BLOCKING_SOCKET_TIMEOUT_MS,
+        phase + ": outlived the non-blocking timeout — wrong timeout in force: " + probe);
+    }
+  }
+
+  private ProbeContext runProbe(CommandObject<List<String>> probe) {
+    long start = System.nanoTime();
+    try {
+      client.executeCommand(probe);
+      return new ProbeContext(probe, start, null, elapsedMillis(start));
+    } catch (RuntimeException e) {
+      return new ProbeContext(probe, start, e, elapsedMillis(start));
+    }
+  }
+
+  /** One executed probe: the command it ran, when it started, and its outcome. */
+  private static final class ProbeContext {
+    final CommandObject<List<String>> probe;
+    final long startedAtNanos;
+    final Throwable error;
+    final long durationMillis;
+
+    ProbeContext(CommandObject<List<String>> probe, long startedAtNanos, Throwable error,
+        long durationMillis) {
+      this.probe = probe;
+      this.startedAtNanos = startedAtNanos;
+      this.error = error;
+      this.durationMillis = durationMillis;
+    }
+
+    boolean blocking() {
+      return probe.getArguments().isBlocking();
+    }
+
+    @Override
+    public String toString() {
+      return (blocking() ? "blocking" : "non-blocking") + " probe "
+          + (error == null ? "success" : "failure(" + error + ")") + " after " + durationMillis
+          + " ms";
+    }
+  }
+
+  private ExecutorService probeExecutor() {
+    if (probeExecutor == null) {
+      probeExecutor = Executors.newFixedThreadPool(2);
+    }
+    return probeExecutor;
+  }
+
+  /**
+   * Observes the pinned connection until {@code received} turns true; see
+   * {@link MaintNotificationsScenarioBase#observe()} for why a command round-trip is used.
+   */
+  private void awaitPush(Callable<Boolean> received, String description, ReceivedEvents events) {
+    try {
+      await().atMost(PUSH_WAIT_TIMEOUT).pollInterval(Duration.ofMillis(100)).until(() -> {
+        observe();
+        return received.call();
+      });
+    } catch (ConditionTimeoutException e) {
+      fail("Timed out waiting for " + description + " notification; received so far: "
+          + events.all() + ", effect failures: " + effectFailures);
+    }
+  }
+
+  @AfterEach
+  void shutdownProbeExecutor() {
+    if (probeExecutor != null) {
+      probeExecutor.shutdownNow();
+      probeExecutor = null;
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
@@ -2,9 +2,15 @@ package redis.clients.jedis.scenario;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -26,13 +32,17 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Arguments;
 
 import redis.clients.jedis.BuilderFactory;
 import redis.clients.jedis.CommandArguments;
 import redis.clients.jedis.CommandObject;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.MaintNotificationsTestSupport;
 import redis.clients.jedis.MaintNotificationsTestSupport.ReceivedEvent;
 import redis.clients.jedis.MaintNotificationsTestSupport.ReceivedEvents;
+import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointType;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.PushMessageTypes;
 import redis.clients.jedis.exceptions.JedisConnectionException;
@@ -73,6 +83,12 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
     // conn_drop/endpoint_rebind emits exactly [MOVING]
     return Stream
         .of(CATALOG.effect(StandaloneEffect.CONN_DROP).trigger("endpoint_rebind").scenario());
+  }
+
+  static Stream<Arguments> handoffScenarios() {
+    return movingScenarios().flatMap(scenario -> Stream.of(EndpointType.EXTERNAL_IP,
+      EndpointType.INTERNAL_IP, EndpointType.EXTERNAL_FQDN, EndpointType.INTERNAL_FQDN)
+        .map(type -> Arguments.of(scenario, type)));
   }
 
   /**
@@ -168,6 +184,104 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
     // without pumping it
     runProbes().join().forEach(probe -> assertProbeTimedOutAtBase(probe, "after expiry"));
     releasePinned();
+  }
+
+  /**
+   * T.2.1 New Connection Establishment — covers newConnectionEstablishedTest,
+   * connectionHandedOffToNewEndpointExternalIPTest, connectionHandedOffToNewEndpointInternalIPTest,
+   * connectionHandoffWithStaticExternalNameTest, connectionHandoffWithStaticInternalNameTest. On an
+   * endpoint_rebind MOVING:
+   * <ul>
+   * <li>a connection borrowed before MOVING completes its in-flight commands gracefully and is
+   * destroyed when returned to the pool;</li>
+   * <li>new connections are created toward the notification's target and get the relaxed timeout
+   * like the rest of the pool; old- and new-endpoint connections work concurrently;</li>
+   * <li>after the window expires, a connection that outlived it throws JedisConnectionException and
+   * is destroyed on return, while the client keeps working through fresh connections to the
+   * configured endpoint name.</li>
+   * </ul>
+   */
+  @ParameterizedTest(name = "{0} [{1}]")
+  @MethodSource("handoffScenarios")
+  @Timeout(300)
+  void connectionHandoffOnMoving(Scenario scenario, EndpointType endpointType) {
+    setUpDatabaseAndClient(scenario, endpointType);
+    warmUpPool();
+    pinned = pinConnection();
+
+    Connection inflight = client.getPool().getResource(); // borrowed before MOVING
+    ReceivedEvents inflightEvents = MaintNotificationsTestSupport.record(inflight);
+
+    startEffect(scenario);
+
+    // continuous commands on the pre-MOVING connection: the read that consumes MOVING mid-command
+    // must still complete gracefully — an exception here fails the test
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(120);
+    while (!inflightEvents.movingReceived()) {
+      assertTrue(System.nanoTime() < deadline, "no MOVING within 120 s; received: "
+          + inflightEvents.all() + ", effect failures: " + effectFailures);
+      inflight.executeCommand(Protocol.Command.PING);
+    }
+    ReceivedEvent moving = inflightEvents.all().stream()
+        .filter(e -> PushMessageTypes.MOVING.equals(e.type)).findFirst().get();
+    assertNotNull(moving.target, "endpoint_rebind MOVING must carry a target");
+    // a long in-flight command on the old endpoint still completes inside the grace window
+    inflight.executeCommand(REGULAR_PROBE);
+
+    assumeTargetReachable(moving.target, endpointType);
+
+    // new connections are created toward the notification's endpoint, relaxed like the rest
+    Connection handedOff = client.getPool().getResource();
+    assertEquals(moving.target, MaintNotificationsTestSupport.remoteAddress(handedOff),
+      "new connection must target the MOVING endpoint");
+    assertEquals(RELAXED_TIMEOUT_MS,
+      MaintNotificationsTestSupport.effectiveTimeoutMillis(handedOff),
+      "new connection must comply with the relaxed timeout");
+    // two active connections during handoff: old and new endpoint usable concurrently
+    handedOff.executeCommand(Protocol.Command.PING);
+    inflight.executeCommand(Protocol.Command.PING);
+
+    // the pre-MOVING connection is discarded on return, never handed out again
+    long destroyedBefore = client.getPool().getDestroyedCount();
+    inflight.close();
+    assertTrue(client.getPool().getDestroyedCount() > destroyedBefore,
+      "returning a connection borrowed before MOVING must destroy it");
+    Connection next = client.getPool().getResource();
+    assertEquals(moving.target, MaintNotificationsTestSupport.remoteAddress(next),
+      "replacement for the discarded connection must target the MOVING endpoint");
+    next.close();
+    handedOff.close();
+
+    joinEffectThreads();
+    assertEffectSucceeded();
+
+    // the client keeps working after the grace window expires: new connections can be created
+    // toward the configured endpoint name (repointed by the rebind) and used
+    long windowLeftMillis = TimeUnit.SECONDS.toMillis(moving.timeSeconds)
+        - elapsedMillis(moving.atNanos);
+    if (windowLeftMillis > 0) {
+      sleepQuietly(windowLeftMillis + 1_000);
+    }
+    // a borrowed connection that outlived the rebind window has been disconnected by the server
+    assertThrows(JedisConnectionException.class, () -> pinned.executeCommand(Protocol.Command.PING),
+      "using a connection to the departed endpoint must throw after the rebind window");
+
+    client.getPool().clear(); // drop window-era connections: the next borrow must connect fresh
+    assertEquals("PONG", client.ping(), "client must keep working after the MOVING window expires");
+    releasePinned();
+  }
+
+  /** Internal targets may not be routable/resolvable from the test host; skip, do not fail. */
+  private static void assumeTargetReachable(String target, EndpointType endpointType) {
+    if (endpointType != EndpointType.INTERNAL_IP && endpointType != EndpointType.INTERNAL_FQDN) {
+      return;
+    }
+    HostAndPort hostAndPort = HostAndPort.from(target);
+    try (Socket socket = new Socket()) {
+      socket.connect(new InetSocketAddress(hostAndPort.getHost(), hostAndPort.getPort()), 2_000);
+    } catch (IOException e) {
+      assumeTrue(false, "MOVING target " + target + " is not routable from the test host: " + e);
+    }
   }
 
   // --- probes ---

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsIT.java
@@ -9,16 +9,20 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.awaitility.core.ConditionTimeoutException;
@@ -251,7 +255,7 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
 
     // new connections are created toward the notification's endpoint, relaxed like the rest
     Connection handedOff = client.getPool().getResource();
-    assertEquals(moving.target, MaintNotificationsTestSupport.remoteAddress(handedOff),
+    assertConnectedToTarget(handedOff, moving.target,
       "new connection must target the MOVING endpoint");
     assertEquals(RELAXED_TIMEOUT_MS,
       MaintNotificationsTestSupport.effectiveTimeoutMillis(handedOff),
@@ -266,7 +270,7 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
     assertTrue(client.getPool().getDestroyedCount() > destroyedBefore,
       "returning a connection borrowed before MOVING must destroy it");
     Connection next = client.getPool().getResource();
-    assertEquals(moving.target, MaintNotificationsTestSupport.remoteAddress(next),
+    assertConnectedToTarget(next, moving.target,
       "replacement for the discarded connection must target the MOVING endpoint");
     next.close();
     handedOff.close();
@@ -288,6 +292,27 @@ public class MaintNotificationsIT extends MaintNotificationsScenarioBase {
     client.getPool().clear(); // drop window-era connections: the next borrow must connect fresh
     assertEquals("PONG", client.ping(), "client must keep working after the MOVING window expires");
     releasePinned();
+  }
+
+  /**
+   * Asserts the connection's live peer is the MOVING target, comparing resolved IPs — works for IP
+   * and FQDN targets, whether the connection was routed by the mapper or by already-updated DNS.
+   */
+  private static void assertConnectedToTarget(Connection connection, String target,
+      String message) {
+    InetSocketAddress peer = MaintNotificationsTestSupport.remotePeer(connection);
+    HostAndPort expected = HostAndPort.from(target);
+    Set<String> targetIps;
+    try {
+      targetIps = Arrays.stream(InetAddress.getAllByName(expected.getHost()))
+          .map(InetAddress::getHostAddress).collect(Collectors.toSet());
+    } catch (UnknownHostException e) {
+      fail(message + ": MOVING target " + target + " does not resolve: " + e);
+      return;
+    }
+    assertEquals(expected.getPort(), peer.getPort(), message + ": port of " + peer);
+    assertTrue(targetIps.contains(peer.getAddress().getHostAddress()), message + ": peer " + peer
+        + " is not among the target addresses " + targetIps + " of " + target);
   }
 
   /** Internal targets may not be routable/resolvable from the test host; skip, do not fail. */

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsReceptionIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsReceptionIT.java
@@ -1,0 +1,168 @@
+package redis.clients.jedis.scenario;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import com.redis.test.fi.Scenario;
+import com.redis.test.fi.StandaloneEffect;
+import com.redis.test.fi.Trigger;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.MaintNotificationsTestSupport;
+import redis.clients.jedis.PushMessageTypes;
+import redis.clients.jedis.MaintNotificationsTestSupport.ReceivedEvent;
+import redis.clients.jedis.MaintNotificationsTestSupport.ReceivedEvents;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+/**
+ * Basic push-notification reception: verifies the client receives and processes every supported
+ * maintenance notification type — MIGRATING, MIGRATED, FAILING_OVER, FAILED_OVER, MOVING — with a
+ * parseable payload, each delivered by a real cluster operation.
+ */
+@Tag("scenario")
+public class MaintNotificationsReceptionIT extends MaintNotificationsScenarioBase {
+
+  private static final Logger log = LoggerFactory.getLogger(MaintNotificationsReceptionIT.class);
+
+  /** No new event and effect finished for this long = the notification stream is drained. */
+  private static final long SETTLE_MILLIS = 3_000;
+  private static final long PUMP_DEADLINE_MILLIS = 240_000;
+
+  /** Expected notification sequence per trigger, covering every supported type. */
+  // dns_resolution_change is excluded: it drops connections without any notification
+  // (RE emits MOVING only when a proxy is removed)
+  private static final Map<Trigger, List<String>> EXPECTATIONS = new LinkedHashMap<>();
+  static {
+    EXPECTATIONS.put(CATALOG.effect(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP).trigger("migrate"),
+      Arrays.asList(PushMessageTypes.MIGRATING, PushMessageTypes.MIGRATED));
+    EXPECTATIONS.put(
+      CATALOG.effect(StandaloneEffect.DATA_MOVEMENT_NO_CONN_DROP).trigger("failover"),
+      Arrays.asList(PushMessageTypes.FAILING_OVER, PushMessageTypes.FAILED_OVER));
+    EXPECTATIONS.put(CATALOG.effect(StandaloneEffect.CONN_DROP).trigger("endpoint_rebind"),
+      Arrays.asList(PushMessageTypes.MOVING));
+  }
+
+  static Stream<Scenario> oneTriggerPerNotificationType() {
+    return EXPECTATIONS.keySet().stream().map(Trigger::scenario);
+  }
+
+  /**
+   * T.1 Push Notification Handling / T.1.1 Basic Push Notification Reception — verify clients can
+   * receive and process different types of push notifications. Covers
+   * receive{Migrating,Migrated,FailingOver,FailedOver,Moving}PushNotificationTest.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("oneTriggerPerNotificationType")
+  @Timeout(300)
+  void receivesExpectedNotificationSequence(Scenario scenario) {
+    List<String> expected = EXPECTATIONS.get(scenario.trigger());
+
+    setUpDatabaseAndClient(scenario);
+    pinned = pinConnection();
+    ReceivedEvents received = MaintNotificationsTestSupport.record(pinned);
+
+    startEffect(scenario);
+    observeUntilDrained(received);
+
+    joinEffectThreads();
+    assertEffectSucceeded();
+
+    List<ReceivedEvent> events = received.all();
+    log.info("{} received: {}", scenario, events);
+    events.forEach(MaintNotificationsReceptionIT::validatePayload);
+    validateWindowShardIds(events);
+
+    List<String> notifications = new ArrayList<>();
+    events.forEach(event -> notifications.add(event.type));
+    assertEquals(expected, notifications);
+  }
+
+  /**
+   * Observes the pinned connection until the stream is drained: MOVING is always terminal (the
+   * server disconnects the old endpoint afterwards, so a connection error after MOVING is the
+   * expected end of stream); otherwise until the effect finished and no event arrived for a settle
+   * period.
+   */
+  private void observeUntilDrained(ReceivedEvents received) {
+    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(PUMP_DEADLINE_MILLIS);
+    while (System.nanoTime() < deadline) {
+      try {
+        observe();
+      } catch (JedisConnectionException e) {
+        if (received.movingReceived()) {
+          return; // rebound endpoint dropped the old connection — expected after MOVING
+        }
+        fail("pinned connection dropped before the expected sequence completed; received: "
+            + received.all() + ", cause: " + e);
+      }
+      if (received.movingReceived()) {
+        return;
+      }
+      if (effectDone() && drainedFor(received, SETTLE_MILLIS)) {
+        return;
+      }
+      sleepQuietly(100);
+    }
+    fail("notification stream did not drain within " + PUMP_DEADLINE_MILLIS + " ms; received: "
+        + received.all());
+  }
+
+  private boolean drainedFor(ReceivedEvents received, long settleMillis) {
+    long last = received.lastEventAtNanos();
+    return last >= 0 && elapsedMillis(last) >= settleMillis;
+  }
+
+  /** Payload sanity of one event, independent of its position in the sequence. */
+  private static void validatePayload(ReceivedEvent event) {
+    switch (event.type) {
+      case PushMessageTypes.MIGRATING:
+      case PushMessageTypes.FAILING_OVER:
+        assertTrue(event.timeSeconds > 0, "opening without a lead time: " + event);
+        assertNotNull(event.shardIds, "opening without shard ids: " + event);
+        break;
+      case PushMessageTypes.MIGRATED:
+      case PushMessageTypes.FAILED_OVER:
+        assertNotNull(event.shardIds, "closing without shard ids: " + event);
+        break;
+      case PushMessageTypes.MOVING:
+        assertTrue(event.timeSeconds > 0, "MOVING without a grace period: " + event);
+        assertNotNull(event.target, "MOVING without a target endpoint: " + event);
+        break;
+      default:
+        fail("unknown event type: " + event);
+    }
+  }
+
+  /**
+   * Windows are never nested, so a closing always directly follows its opening — and the codec
+   * guarantees shard ids on closings, so they must match the opening's.
+   */
+  private static void validateWindowShardIds(List<ReceivedEvent> events) {
+    for (int i = 1; i < events.size(); i++) {
+      ReceivedEvent event = events.get(i);
+      if (PushMessageTypes.MIGRATED.equals(event.type)
+          || PushMessageTypes.FAILED_OVER.equals(event.type)) {
+        assertEquals(events.get(i - 1).shardIds, event.shardIds, "closing " + event
+            + " for different shards than " + events.get(i - 1) + "; events: " + events);
+      }
+    }
+  }
+
+}

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
@@ -146,6 +147,31 @@ abstract class MaintNotificationsScenarioBase {
    */
   void observe() {
     pinned.executeCommand(Protocol.Command.PING);
+  }
+
+  /**
+   * Creates every pool connection up front — holding maxTotal borrows simultaneously forces
+   * distinct creations, so tests measure command time, not handshakes.
+   */
+  void warmUpPool() {
+    int size = client.getPool().getMaxTotal();
+    List<Connection> borrowed = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      borrowed.add(client.getPool().getResource());
+    }
+    borrowed.forEach(Connection::close);
+  }
+
+  /**
+   * Observes the pinned connection until {@code future} completes, then returns its value — the
+   * test thread keeps reading pushes (events, timeout changes stay current) while it waits.
+   */
+  <T> T observeAndAwait(CompletableFuture<T> future) {
+    while (!future.isDone()) {
+      observe();
+      sleepQuietly(100);
+    }
+    return future.join();
   }
 
   /** Runs the effect on a background thread so it is in flight while the test body observes. */

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.AfterEach;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.MaintenanceNotificationsConfig;
+import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointType;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.RedisProtocol;
@@ -62,12 +63,17 @@ abstract class MaintNotificationsScenarioBase {
    * database gets its own endpoint DNS name.
    */
   void setUpDatabaseAndClient(Scenario scenario) {
+    setUpDatabaseAndClient(scenario, null);
+  }
+
+  /** As {@link #setUpDatabaseAndClient(Scenario)}, requesting a fixed MOVING endpoint type. */
+  void setUpDatabaseAndClient(Scenario scenario, EndpointType endpointType) {
     Map<String, Object> dbConfig = faultInjector.getStandaloneTriggers(scenario.effect())
         .trigger(scenario.trigger().name()).requirement(scenario.requirement().config()).dbConfig();
     Map<String, Object> output = faultInjector.createDatabase(dbConfig);
     bdbId = ((Number) output.get("bdb_id")).longValue();
     awaitEndpointConnectable(URI.create((String) ((List<?>) output.get("endpoints")).get(0)));
-    client = buildClient(output);
+    client = buildClient(output, endpointType);
   }
 
   /**
@@ -89,7 +95,7 @@ abstract class MaintNotificationsScenarioBase {
     throw new IllegalStateException("Endpoint " + endpoint + " not connectable within 60 s", last);
   }
 
-  private static RedisClient buildClient(Map<String, Object> output) {
+  private static RedisClient buildClient(Map<String, Object> output, EndpointType endpointType) {
     URI endpoint = URI.create((String) ((List<?>) output.get("endpoints")).get(0));
 
     DefaultJedisClientConfig.Builder config = DefaultJedisClientConfig.builder()
@@ -111,6 +117,9 @@ abstract class MaintNotificationsScenarioBase {
     MaintenanceNotificationsConfig.Builder maintenance = MaintenanceNotificationsConfig.builder()
         .mode(MaintenanceNotificationsConfig.Mode.ENABLED).relaxedTimeout(RELAXED_TIMEOUT_MS)
         .relaxedBlockingTimeout(RELAXED_TIMEOUT_MS);
+    if (endpointType != null) {
+      maintenance.endpointType(endpointType); // null: auto-resolve from connection characteristics
+    }
 
     // Standalone RedisClient runs commands without retries, so timeouts stay observable.
     return RedisClient.builder().hostAndPort(endpoint.getHost(), endpoint.getPort())

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
@@ -1,0 +1,225 @@
+package redis.clients.jedis.scenario;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import com.redis.test.fi.FaultInjectorClient;
+import com.redis.test.fi.Scenario;
+import com.redis.test.fi.StandaloneTriggerCatalog;
+
+import org.junit.jupiter.api.AfterEach;
+
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.DefaultJedisClientConfig;
+import redis.clients.jedis.MaintenanceNotificationsConfig;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.RedisClient;
+import redis.clients.jedis.RedisProtocol;
+
+/**
+ * Shared environment for maintenance-notification scenario tests. The FI is the single source of
+ * truth: each test creates its own database from a discovery-provided dbconfig, builds the client
+ * from the create output, and deletes the database on teardown.
+ */
+abstract class MaintNotificationsScenarioBase {
+
+  /** Base socket timeout kept low so relaxed/restored timeouts are directly observable. */
+  static final int CLIENT_SOCKET_TIMEOUT_MS = 1_000;
+  /** Deliberately different from the non-blocking base, so probes prove which timeout applied. */
+  static final int CLIENT_BLOCKING_SOCKET_TIMEOUT_MS = 2_000;
+  static final int RELAXED_TIMEOUT_MS = 30_000;
+  static final long EFFECT_JOIN_TIMEOUT_MS = 200_000;
+
+  /** One FI client for parameter collection and test execution. */
+  static final FaultInjectorClient faultInjector = new FaultInjectorClient();
+
+  RedisClient client;
+  Connection pinned;
+  long bdbId = -1;
+  final List<Thread> effectThreads = new ArrayList<>();
+  final List<Throwable> effectFailures = Collections.synchronizedList(new ArrayList<>());
+
+  /**
+   * The full topology-change-standalone catalog, resolved once: effect -> triggers -> requirements.
+   */
+  static final StandaloneTriggerCatalog CATALOG = StandaloneTriggerCatalog.resolve(faultInjector);
+
+  /**
+   * Creates the scenario's test database and builds the client from the create output. The dbconfig
+   * comes from a fresh discovery call: the FI generates a unique name and port per call, so every
+   * database gets its own endpoint DNS name.
+   */
+  void setUpDatabaseAndClient(Scenario scenario) {
+    Map<String, Object> dbConfig = faultInjector.getStandaloneTriggers(scenario.effect())
+        .trigger(scenario.trigger().name()).requirement(scenario.requirement().config()).dbConfig();
+    Map<String, Object> output = faultInjector.createDatabase(dbConfig);
+    bdbId = ((Number) output.get("bdb_id")).longValue();
+    awaitEndpointConnectable(URI.create((String) ((List<?>) output.get("endpoints")).get(0)));
+    client = buildClient(output);
+  }
+
+  /**
+   * A fresh endpoint's DNS record may not have propagated yet (or a negative lookup may be cached)
+   * — wait until the endpoint accepts connections before building the client.
+   */
+  private static void awaitEndpointConnectable(URI endpoint) {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+    IOException last = null;
+    while (System.nanoTime() < deadline) {
+      try (Socket socket = new Socket()) {
+        socket.connect(new InetSocketAddress(endpoint.getHost(), endpoint.getPort()), 2_000);
+        return;
+      } catch (IOException e) {
+        last = e;
+        sleepQuietly(1_000);
+      }
+    }
+    throw new IllegalStateException("Endpoint " + endpoint + " not connectable within 60 s", last);
+  }
+
+  private static RedisClient buildClient(Map<String, Object> output) {
+    URI endpoint = URI.create((String) ((List<?>) output.get("endpoints")).get(0));
+
+    DefaultJedisClientConfig.Builder config = DefaultJedisClientConfig.builder()
+        .protocol(RedisProtocol.RESP3) // push notifications require RESP3
+        .socketTimeoutMillis(CLIENT_SOCKET_TIMEOUT_MS)
+        // finite (default 0 = infinite would hang blocking probes) and distinct from the
+        // non-blocking base, so a probe's failure time identifies the timeout that fired
+        .blockingSocketTimeoutMillis(CLIENT_BLOCKING_SOCKET_TIMEOUT_MS)
+        .ssl("rediss".equals(endpoint.getScheme())).password((String) output.get("password"));
+    String username = (String) output.get("username");
+    if (username != null && !"default".equals(username)) {
+      config.user(username);
+    }
+
+    // one pinned observer + two parallel probe slots
+    GenericObjectPoolConfig<Connection> poolConfig = new GenericObjectPoolConfig<>();
+    poolConfig.setMaxTotal(3);
+
+    MaintenanceNotificationsConfig.Builder maintenance = MaintenanceNotificationsConfig.builder()
+        .mode(MaintenanceNotificationsConfig.Mode.ENABLED).relaxedTimeout(RELAXED_TIMEOUT_MS)
+        .relaxedBlockingTimeout(RELAXED_TIMEOUT_MS);
+
+    // Standalone RedisClient runs commands without retries, so timeouts stay observable.
+    return RedisClient.builder().hostAndPort(endpoint.getHost(), endpoint.getPort())
+        .clientConfig(config.build()).poolConfig(poolConfig)
+        .maintenanceNotifications(maintenance.build()).build();
+  }
+
+  /**
+   * Borrows (and keeps) a pool connection of the tested client, so maintenance pushes arrive on a
+   * connection the test controls — the handshake enables CLIENT MAINT_NOTIFICATIONS before the
+   * effect fires.
+   */
+  Connection pinConnection() {
+    return client.getPool().getResource();
+  }
+
+  /**
+   * Returns the pinned connection to the pool. Releasing is never an error, also mid- or
+   * post-rebind: a broken return destroys the connection and the pool creates the replacement
+   * toward the MOVING target (window open) or the configured endpoint (window expired).
+   */
+  void releasePinned() {
+    if (pinned != null) {
+      pinned.close();
+      pinned = null;
+    }
+  }
+
+  /**
+   * Observes the pinned connection via a PING round-trip: buffered pushes are consumed inline
+   * during the reply read, dispatching maintenance events on this thread. A command round-trip is
+   * the only reliable way to read pushes — the commandless push read is a no-op on plain
+   * connections and cannot see TLS-buffered pushes (SSLSocket available() stays 0).
+   */
+  void observe() {
+    pinned.executeCommand(Protocol.Command.PING);
+  }
+
+  /** Runs the effect on a background thread so it is in flight while the test body observes. */
+  void startEffect(Scenario scenario) {
+    long id = bdbId;
+    Thread thread = new Thread(() -> {
+      try {
+        faultInjector.triggerEffect(id, scenario.effect(), scenario.trigger().name());
+      } catch (Throwable e) {
+        effectFailures.add(e);
+      }
+    }, "fi-effect-" + scenario.trigger().name());
+    thread.start();
+    effectThreads.add(thread);
+  }
+
+  boolean effectDone() {
+    for (Thread thread : effectThreads) {
+      if (thread.isAlive()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void joinEffectThreads() {
+    for (Thread thread : effectThreads) {
+      try {
+        thread.join(EFFECT_JOIN_TIMEOUT_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+      if (thread.isAlive()) {
+        thread.interrupt();
+      }
+    }
+  }
+
+  void assertEffectSucceeded() {
+    assertTrue(effectFailures.isEmpty(), "fault-injector effect failed: " + effectFailures);
+  }
+
+  @AfterEach
+  void tearDownScenario() {
+    try {
+      // close the pool before releasing a still-pinned connection: a closed pool destroys the
+      // returned connection without creating a replacement, which on aborted runs could target
+      // a rebind endpoint that is unroutable from this host
+      if (client != null) {
+        client.close();
+        client = null;
+      }
+      releasePinned();
+      joinEffectThreads();
+    } finally {
+      effectThreads.clear();
+      effectFailures.clear();
+      if (bdbId >= 0) {
+        faultInjector.deleteDatabase(bdbId);
+        bdbId = -1;
+      }
+    }
+  }
+
+  static long elapsedMillis(long startNanos) {
+    return TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+  }
+
+  static void sleepQuietly(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
@@ -47,6 +47,17 @@ abstract class MaintNotificationsScenarioBase {
   private static final Logger logger = LoggerFactory
       .getLogger(MaintNotificationsScenarioBase.class);
 
+  // Short JVM DNS cache: these tests reconnect across endpoint rebinds, where the default 30s
+  // positive cache can outlive the DNS repoint, and await fresh database names, where the
+  // default 10s negative cache delays convergence. The JVM reads these once, at its first name
+  // lookup — this block must run before that (it does under the surefire fork; an IDE may
+  // resolve earlier, in which case pass -Dsun.net.inetaddr.ttl=2 and
+  // -Dsun.net.inetaddr.negative.ttl=2 in the run configuration).
+  static {
+    java.security.Security.setProperty("networkaddress.cache.ttl", "2");
+    java.security.Security.setProperty("networkaddress.cache.negative.ttl", "2");
+  }
+
   /** Base socket timeout kept low so relaxed/restored timeouts are directly observable. */
   static final int CLIENT_SOCKET_TIMEOUT_MS = 1_000;
   /** Deliberately different from the non-blocking base, so probes prove which timeout applied. */
@@ -61,6 +72,8 @@ abstract class MaintNotificationsScenarioBase {
   RedisClient client;
   Connection pinned;
   Path serverTruststore;
+  URI endpoint;
+  private DnsDiagnostics dnsDiag;
   long bdbId = -1;
   final List<Thread> effectThreads = new ArrayList<>();
   final List<Throwable> effectFailures = Collections.synchronizedList(new ArrayList<>());
@@ -85,8 +98,9 @@ abstract class MaintNotificationsScenarioBase {
         .trigger(scenario.trigger().name()).requirement(scenario.requirement().config()).dbConfig();
     Map<String, Object> output = faultInjector.createDatabase(dbConfig);
     bdbId = ((Number) output.get("bdb_id")).longValue();
-    URI endpoint = URI.create((String) ((List<?>) output.get("endpoints")).get(0));
+    endpoint = URI.create((String) ((List<?>) output.get("endpoints")).get(0));
     awaitEndpointConnectable(endpoint);
+    dnsDiag = DnsDiagnostics.follow(endpoint.getHost());
     SslOptions sslOptions = null;
     if (Boolean.TRUE.equals(output.get("tls"))) {
       serverTruststore = createServerTruststore(endpoint);
@@ -205,6 +219,7 @@ abstract class MaintNotificationsScenarioBase {
    */
   void releasePinned() {
     if (pinned != null) {
+      logger.trace("releasing pinned: {}", pinned.toIdentityString());
       pinned.close();
       pinned = null;
     }
@@ -301,6 +316,10 @@ abstract class MaintNotificationsScenarioBase {
     } finally {
       effectThreads.clear();
       effectFailures.clear();
+      if (dnsDiag != null) {
+        dnsDiag.close();
+        dnsDiag = null;
+      }
       deleteServerTruststore();
       if (bdbId >= 0) {
         faultInjector.deleteDatabase(bdbId);

--- a/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
+++ b/src/test/java/redis/clients/jedis/scenario/MaintNotificationsScenarioBase.java
@@ -10,10 +10,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.cert.X509Certificate;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.redis.test.fi.FaultInjectorClient;
 import com.redis.test.fi.Scenario;
@@ -28,6 +34,8 @@ import redis.clients.jedis.MaintenanceNotificationsConfig.EndpointType;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.RedisProtocol;
+import redis.clients.jedis.SslOptions;
+import redis.clients.jedis.util.TlsUtil;
 
 /**
  * Shared environment for maintenance-notification scenario tests. The FI is the single source of
@@ -36,18 +44,23 @@ import redis.clients.jedis.RedisProtocol;
  */
 abstract class MaintNotificationsScenarioBase {
 
+  private static final Logger logger = LoggerFactory
+      .getLogger(MaintNotificationsScenarioBase.class);
+
   /** Base socket timeout kept low so relaxed/restored timeouts are directly observable. */
   static final int CLIENT_SOCKET_TIMEOUT_MS = 1_000;
   /** Deliberately different from the non-blocking base, so probes prove which timeout applied. */
   static final int CLIENT_BLOCKING_SOCKET_TIMEOUT_MS = 2_000;
   static final int RELAXED_TIMEOUT_MS = 30_000;
   static final long EFFECT_JOIN_TIMEOUT_MS = 200_000;
+  static final String TRUSTSTORE_PASSWORD = "changeit";
 
   /** One FI client for parameter collection and test execution. */
   static final FaultInjectorClient faultInjector = new FaultInjectorClient();
 
   RedisClient client;
   Connection pinned;
+  Path serverTruststore;
   long bdbId = -1;
   final List<Thread> effectThreads = new ArrayList<>();
   final List<Throwable> effectFailures = Collections.synchronizedList(new ArrayList<>());
@@ -72,8 +85,53 @@ abstract class MaintNotificationsScenarioBase {
         .trigger(scenario.trigger().name()).requirement(scenario.requirement().config()).dbConfig();
     Map<String, Object> output = faultInjector.createDatabase(dbConfig);
     bdbId = ((Number) output.get("bdb_id")).longValue();
-    awaitEndpointConnectable(URI.create((String) ((List<?>) output.get("endpoints")).get(0)));
-    client = buildClient(output, endpointType);
+    URI endpoint = URI.create((String) ((List<?>) output.get("endpoints")).get(0));
+    awaitEndpointConnectable(endpoint);
+    SslOptions sslOptions = null;
+    if (Boolean.TRUE.equals(output.get("tls"))) {
+      serverTruststore = createServerTruststore(endpoint);
+      sslOptions = sslOptionsFor(serverTruststore);
+    }
+    client = buildClient(output, endpointType, sslOptions);
+  }
+
+  /**
+   * Bootstraps client trust for an endpoint whose CA is not available to the test: downloads the
+   * certificate chain the server presents and saves a truststore containing only that chain, so the
+   * client trusts exactly this server and nothing else. The store is a temp file under the test
+   * work folder, deleted when the test completes.
+   */
+  private static Path createServerTruststore(URI endpoint) {
+    try {
+      X509Certificate[] chain = TlsUtil.captureServerChain(endpoint.getHost(), endpoint.getPort());
+      logger.info("Pinning server chain of {}: subject={}, SANs={}", endpoint,
+        chain[0].getSubjectX500Principal(), chain[0].getSubjectAlternativeNames());
+      return TlsUtil.createAndSaveTruststore(chain, TlsUtil.tempTruststorePath("sch-pinned"),
+        TRUSTSTORE_PASSWORD);
+    } catch (Exception e) {
+      throw new IllegalStateException("TLS trust bootstrap failed for " + endpoint, e);
+    }
+  }
+
+  /**
+   * All {@link SslOptions} defaults except the truststore are kept, so the client under test
+   * performs full certificate-chain and hostname verification.
+   */
+  private static SslOptions sslOptionsFor(Path truststore) {
+    return SslOptions.builder().truststore(truststore.toFile(), TRUSTSTORE_PASSWORD.toCharArray())
+        .build();
+  }
+
+  private void deleteServerTruststore() {
+    if (serverTruststore == null) {
+      return;
+    }
+    try {
+      Files.deleteIfExists(serverTruststore);
+    } catch (IOException e) {
+      logger.warn("Failed to delete truststore {}", serverTruststore, e);
+    }
+    serverTruststore = null;
   }
 
   /**
@@ -95,7 +153,8 @@ abstract class MaintNotificationsScenarioBase {
     throw new IllegalStateException("Endpoint " + endpoint + " not connectable within 60 s", last);
   }
 
-  private static RedisClient buildClient(Map<String, Object> output, EndpointType endpointType) {
+  private static RedisClient buildClient(Map<String, Object> output, EndpointType endpointType,
+      SslOptions sslOptions) {
     URI endpoint = URI.create((String) ((List<?>) output.get("endpoints")).get(0));
 
     DefaultJedisClientConfig.Builder config = DefaultJedisClientConfig.builder()
@@ -104,7 +163,10 @@ abstract class MaintNotificationsScenarioBase {
         // finite (default 0 = infinite would hang blocking probes) and distinct from the
         // non-blocking base, so a probe's failure time identifies the timeout that fired
         .blockingSocketTimeoutMillis(CLIENT_BLOCKING_SOCKET_TIMEOUT_MS)
-        .ssl("rediss".equals(endpoint.getScheme())).password((String) output.get("password"));
+        .ssl(Boolean.TRUE.equals(output.get("tls"))).password((String) output.get("password"));
+    if (sslOptions != null) {
+      config.sslOptions(sslOptions);
+    }
     String username = (String) output.get("username");
     if (username != null && !"default".equals(username)) {
       config.user(username);
@@ -239,6 +301,7 @@ abstract class MaintNotificationsScenarioBase {
     } finally {
       effectThreads.clear();
       effectFailures.clear();
+      deleteServerTruststore();
       if (bdbId >= 0) {
         faultInjector.deleteDatabase(bdbId);
         bdbId = -1;

--- a/src/test/java/redis/clients/jedis/util/TlsUtil.java
+++ b/src/test/java/redis/clients/jedis/util/TlsUtil.java
@@ -2,6 +2,8 @@ package redis.clients.jedis.util;
 
 import javax.net.ssl.*;
 import java.io.*;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.*;
@@ -122,8 +124,28 @@ public class TlsUtil {
         return Paths.get(TEST_WORK_FOLDER, certLocation.toString(), clientName + ".p12");
     }
 
+    /**
+     * Creates an empty uniquely-named file for a truststore under the test work folder. The caller
+     * owns the file's lifecycle and should delete it when done.
+     */
+    public static Path tempTruststorePath(String prefix) {
+        try {
+            Path folder = Paths.get(TEST_WORK_FOLDER);
+            Files.createDirectories(folder);
+            return Files.createTempFile(folder, prefix + '-', ".jks");
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temp truststore in " + TEST_WORK_FOLDER, e);
+        }
+    }
+
     public static Path testTruststorePath(String name) {
-        return Paths.get(TEST_WORK_FOLDER, name  + '-' + TEST_TRUSTSTORE);
+        Path path = Paths.get(TEST_WORK_FOLDER, name  + '-' + TEST_TRUSTSTORE);
+        try {
+            Files.createDirectories(path.getParent());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create test work folder " + path.getParent(), e);
+        }
+        return path;
     }
 
     public static Path createAndSaveTestTruststore(String trustStoreName, List<Path> certificateLocations, String truststorePassword) {
@@ -156,19 +178,6 @@ public class TlsUtil {
     }
 
     /**
-     * Adds a trusted certificate to the given truststore.
-     *
-     * @param trustStore The KeyStore object.
-     * @param alias      Alias for the certificate.
-     * @param certPath   Path to the certificate file.
-     * @throws Exception If there's an error adding the certificate.
-     */
-    private static void addTrustedCertificate(KeyStore trustStore, String alias, Path certPath) throws Exception {
-        X509Certificate cert = loadCertificate(certPath);
-        trustStore.setCertificateEntry(alias, cert);
-    }
-
-    /**
      * Loads an X.509 certificate from the given file path.
      *
      * @param certPath Path to the certificate file.
@@ -192,10 +201,38 @@ public class TlsUtil {
      */
     public static Path createAndSaveTruststore(List<Path> trustedCertPaths, Path truststorePath, String truststorePassword) {
         try {
-            KeyStore trustStore = createTruststore();
-
+            List<X509Certificate> certs = new ArrayList<>();
             for (Path certPath : trustedCertPaths) {
-                addTrustedCertificate(trustStore, "trusted-cert-" + UUID.randomUUID(), certPath);
+                certs.add(loadCertificate(certPath));
+            }
+            return saveTruststore(TRUST_STORE_TYPE, certs.toArray(new X509Certificate[0]), truststorePath, truststorePassword);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create and save truststore: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Creates a truststore from already-loaded certificates and saves it to the specified path.
+     * Uses the JKS format: the one format readable both by the default KeyStore type (dual-format
+     * PKCS12/JKS) and by the JCEKS type forced by {@link #setCustomTrustStore}, so callers can
+     * load it without setting an explicit truststore type.
+     *
+     * @param trustedCerts       Certificates to add to the truststore.
+     * @param truststorePath     Path to save the generated truststore.
+     * @param truststorePassword Password for the truststore.
+     * @return Path to the saved truststore file.
+     */
+    public static Path createAndSaveTruststore(X509Certificate[] trustedCerts, Path truststorePath, String truststorePassword) {
+        return saveTruststore("JKS", trustedCerts, truststorePath, truststorePassword);
+    }
+
+    private static Path saveTruststore(String storeType, X509Certificate[] trustedCerts, Path truststorePath, String truststorePassword) {
+        try {
+            KeyStore trustStore = KeyStore.getInstance(storeType);
+            trustStore.load(null, null);
+
+            for (X509Certificate cert : trustedCerts) {
+                trustStore.setCertificateEntry("trusted-cert-" + UUID.randomUUID(), cert);
             }
 
             try (FileOutputStream fos = new FileOutputStream(truststorePath.toFile())) {
@@ -227,7 +264,8 @@ public class TlsUtil {
         KeyStore trustStore = null;
         try {
             trustStore = createTruststore();
-            addTrustedCertificate(trustStore, "trusted-cert-" + UUID.randomUUID(), trustedCertPath.toAbsolutePath());
+            trustStore.setCertificateEntry("trusted-cert-" + UUID.randomUUID(),
+                loadCertificate(trustedCertPath.toAbsolutePath()));
 
             TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("PKIX");
             trustManagerFactory.init(trustStore);
@@ -264,6 +302,38 @@ public class TlsUtil {
         SSLContext sslContext = SSLContext.getInstance("TLS");
         sslContext.init(null, unTrustManagers, new SecureRandom());
         return sslContext.getSocketFactory();
+    }
+
+    /**
+     * Captures the certificate chain a TLS server presents, over a throwaway handshake that trusts
+     * anything. Intended for pinning the captured chain into a test truststore; never use the
+     * capturing connection for the client under test.
+     */
+    public static X509Certificate[] captureServerChain(String host, int port) throws Exception {
+        final X509Certificate[][] captured = new X509Certificate[1][];
+        TrustManager capturing = new X509TrustManager() {
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            }
+
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                captured[0] = chain;
+            }
+
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, new TrustManager[]{capturing}, null);
+        try (SSLSocket socket = (SSLSocket) context.getSocketFactory().createSocket()) {
+            socket.connect(new InetSocketAddress(host, port), 5_000);
+            socket.setSoTimeout(5_000);
+            socket.startHandshake();
+        }
+        if (captured[0] == null || captured[0].length == 0) {
+            throw new IllegalStateException("No server certificate chain captured from " + host);
+        }
+        return captured[0];
     }
 
     public static void createEmptyTruststore(Path emptyTrustStore, char[] trustStorePassword) throws Exception {


### PR DESCRIPTION
## What
Adds end-to-end scenario tests for the maintenance-notifications feature, exercised against a live
Redis Enterprise cluster through the fault-injector service, together with the minimal FI client
they run on.

## Why
The existing unit tests stub the push frames. These tests validate the client against real cluster
operations — shard migration, failover, endpoint rebind — covering the test plan:
T.1.1 push-notification reception, T.1.2 timeout handling (including MOVING), and
T.2.1 new-connection establishment / handoff.

## Changes
- `com.redis.test.fi` — framework-free fault-injector client (JDK HTTP + gson, no jedis imports):
  two HTTP primitives, a poll helper, and the operations the tests need (discovery,
  create/delete database, trigger effect). Discovery is typed
  (`Effect → Trigger → Requirement → Scenario`); dbconfigs round-trip as opaque maps
  (integral fields preserved via `LONG_OR_DOUBLE`). Wire format covered by unit tests against an
  in-process HTTP stub.
- `MaintNotificationsScenarioBase` — each test creates its own database from a fresh discovery
  call (unique name and port per call, so consecutive rebind scenarios never share an endpoint DNS
  name), waits for the endpoint to accept connections, builds the client from the create output,
  and deletes the database on teardown. Push delivery is observed on a pinned pool connection via
  PING round-trips.
- `MaintNotificationsReceptionIT` (T.1.1) — asserts the exact received sequence and payloads for
  MIGRATING/MIGRATED, FAILING_OVER/FAILED_OVER, and MOVING, each produced by a real operation
  (migrate, failover, conn_drop/endpoint_rebind).
- `MaintNotificationsIT` (T.1.2) — BLPOP probes with a 3 s server-side delay prove relaxation
  behaviorally: at base timeouts (1 s non-blocking / 2 s blocking, distinct so the blocking flag's
  routing is visible) probes time out; inside a maintenance window they survive to the server
  delay; base behavior is restored after the closing notification. The MOVING variant verifies
  pool-wide relaxation with no closing notification, ending only when the grace window expires.
- `MaintNotificationsIT#connectionHandoffOnMoving` (T.2.1) — across an endpoint rebind,
  parameterized over external/internal IP endpoint types: in-flight commands on a pre-MOVING
  connection complete gracefully; new connections target the notification's endpoint and inherit
  the relaxed timeout; pre-MOVING connections are destroyed on return; a connection that outlives
  the window throws on use; the client keeps serving traffic through fresh connections afterwards.
  The internal-IP variant skips when the target is not routable from the test host.
- `MaintNotificationsTestSupport` — test bridge recording dispatched maintenance events and
  reading the effective socket timeout; the only main-code change is widening
  `Connection.currentTimeout()` to package-private for it.
- Tests are tagged `scenario`; the FI endpoint comes from `FAULT_INJECTION_API_URL`.

All tests verified green against a live env0 fault-injector setup across repeated runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are overwhelmingly test-only; the sole library tweak exposes package-private timeout introspection on Connection with no altered timeout logic.
> 
> **Overview**
> Adds **end-to-end `@Tag("scenario")` tests** for maintenance push notifications against Redis Enterprise via a new **`com.redis.test.fi` fault-injector HTTP client** (discovery, create/delete DB, trigger topology effects), with wire-format covered by an in-process stub test.
> 
> **Scenario harness:** `MaintNotificationsScenarioBase` provisions a fresh FI database per test, builds a RESP3 client with maintenance notifications enabled, observes pushes on a pinned connection (PING round-trips), and tears down. **`MaintNotificationsReceptionIT`** asserts expected notification sequences and payloads from real migrate/failover/rebind operations. **`MaintNotificationsIT`** uses parallel BLPOP probes to prove socket timeouts relax during MIGRATING/FAILING_OVER/MOVING windows and restore afterward, plus **MOVING connection handoff** (pool discard, new peers toward the target, post-window behavior), including a TLS `single_tls` variant.
> 
> **Build/test infra:** Scenario Failsafe runs pass **short JVM DNS cache TTLs** (Maven `argLine` + security properties in the base class) so rebind and new endpoint names converge faster. **`TlsUtil`** gains **`captureServerChain`**, cert-array truststore creation, and temp truststore paths—reused by maintenance TLS setup and refactored **`LagAwareStrategySslIT`**.
> 
> **Production touch:** `Connection.currentTimeout()` is widened to **package-private** so **`MaintNotificationsTestSupport`** can read the effective relaxed-aware timeout; no intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45ab55a8871902b94a28945edf590d5b370f304a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->