### PR TITLE
[maintenance events] Ignore MOVING delivered on retired connections

### DIFF
--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -152,6 +152,13 @@ final class MaintenanceEventController
     if (affectedPeer == null) {
       return; // receiver socket already closed; no peer to register
     }
+    if (c.isRetired()) {
+      // A retired connection was already covered by an admitted MOVING: anything read from it now
+      // is a stale buffered copy, and admitting it would re-open an expired window.
+      logger.debug("Ignoring MOVING on retired connection (seq={}) conn={}", e.seq,
+        c.toIdentityString());
+      return;
+    }
     MovingOperation applied = movingOperations.process(e, affectedPeer);
     if (applied == null) {
       long retireAt = getRetirementFor(affectedPeer);

--- a/src/test/java/redis/clients/jedis/MaintenanceMarkingTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceMarkingTest.java
@@ -79,6 +79,40 @@ public class MaintenanceMarkingTest {
     return conn;
   }
 
+  /**
+   * A MOVING copy buffered on a connection that outlived its grace must not re-open a window: the
+   * first apply retires every same-peer connection, the window expires, and the stale copy is
+   * finally read from the retired connection.
+   */
+  @Test
+  public void staleMovingOnRetiredConnectionIsNotReadmitted() throws Exception {
+    AtomicLong now = installTestClock();
+    Connection other = connect(mockServer); // same peer as receiver
+    try {
+      moving(1, TARGET_B, 15); // real target: retires all same-peer connections immediately
+      assertTrue(controller.isRebindActive());
+      assertTrue(other.isRetired());
+
+      now.addAndGet(TimeUnit.SECONDS.toNanos(16)); // grace expired; store prunes lazily
+      assertFalse(controller.isRebindActive());
+
+      // the same event's buffered copy, finally read on the other (retired) connection
+      controller.onMoving(new MovingEvent(1, 15, TARGET_B), other);
+      assertFalse(controller.isRebindActive(), "stale MOVING re-opened an expired window");
+    } finally {
+      other.close();
+    }
+  }
+
+  /** A future retirement deadline ('none'-style) must not block admission of a new MOVING. */
+  @Test
+  public void movingOnConnectionRetiringInFutureIsAdmitted() {
+    AtomicLong now = installTestClock();
+    receiver.retireAt(now.get() + TimeUnit.SECONDS.toNanos(10));
+    moving(1, TARGET_B, 15);
+    assertTrue(controller.isRebindActive());
+  }
+
   private void movingNone(long seq, long gracePeriodSeconds) {
     controller.onMoving(new MovingEvent(seq, gracePeriodSeconds, null), receiver);
   }


### PR DESCRIPTION
### What

`MaintenanceEventController.onMoving` now ignores MOVING events read from retired connections, instead of admitting them as new operations.

### Why

A MOVING push buffered on a connection that is not being read (e.g. an application-pinned connection) can be consumed after the grace period has expired — the server's FIN preserves buffered frames, so the copy survives until the next read. By then the original operation has been pruned from `MovingOperations`, so the stale copy was re-admitted as a fresh operation (same seq/target, sources=1) with a new full window: timeout relaxation re-opened, and for `none` targets the re-admission can churn healthy same-peer connections. Observed live during scenario testing.

Ignoring retired connections is loss-free: admitting a MOVING retires every connection toward the affected peer, so by the time a connection is retired, any MOVING it still has buffered is a copy of an event that was already applied — it can neither be the first legitimate source nor add information to an active operation.

### Tests

- `MaintenanceMarkingTest#staleMovingOnRetiredConnectionIsNotReadmitted` — reproduces the stale re-admission with a frozen clock; fails without the gate.
- `MaintenanceMarkingTest#movingOnConnectionRetiringInFutureIsAdmitted` — future retire-at still admits a fresh MOVING.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes maintenance MOVING admission on a timing-sensitive path; incorrect gating could drop legitimate events or still admit stale ones, but scope is narrow and covered by new tests.
> 
> **Overview**
> **`MaintenanceEventController.onMoving`** now returns early when the receiving connection is already **retired** (`isRetired()`), so a **stale buffered MOVING** read after the grace window expires cannot be admitted again and **re-open** timeout relaxation or churn same-peer connections.
> 
> Two tests in **`MaintenanceMarkingTest`**: one reproduces the stale re-admission after grace expiry on a second same-peer connection; one confirms a connection with a **future** `retireAt` still admits a new MOVING.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ef624b896c5c84573bc4b2371a171722eb68a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->