### PR TITLE
parse StreamEntryID components as unsigned 64-bit integers

### DIFF
--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -26,8 +26,12 @@ components as unsigned 64-bit integers (`Long.parseUnsignedLong` /
 `Long.toUnsignedString` / `Long.compareUnsigned`). A stream ID above `2^63-1`
 (a valid `XADD` id, e.g. a max-sequence entry `<ms>-18446744073709551615`)
 previously threw `NumberFormatException` in the reply builder, making the stream
-unreadable; it now round-trips. Every ID in the signed range parses, prints and
-orders exactly as before.
+unreadable; it now round-trips. `XAddParams.id(long, long)` and
+`XAddParams.id(long)` likewise format their components unsigned instead of
+serialising upper-half values as negative decimals the server rejects. Every ID
+in the signed range parses, prints and orders exactly as before. Note that
+`StreamEntryID.getTime()`/`getSequence()` return the raw unsigned bits, so
+upper-half values appear negative under signed interpretation.
 
 **Action required:** none.
 

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -19,6 +19,18 @@ This guide helps you upgrade from Jedis 8.0.0.
 Changes that may affect existing applications even though they are
 not breaking API changes.
 
+### Stream IDs parsed as unsigned 64-bit ([#4711](https://github.com/redis/jedis/pull/4711))
+
+`StreamEntryID` now parses, formats and compares its `ms` and `sequence`
+components as unsigned 64-bit integers (`Long.parseUnsignedLong` /
+`Long.toUnsignedString` / `Long.compareUnsigned`). A stream ID above `2^63-1`
+(a valid `XADD` id, e.g. a max-sequence entry `<ms>-18446744073709551615`)
+previously threw `NumberFormatException` in the reply builder, making the stream
+unreadable; it now round-trips. Every ID in the signed range parses, prints and
+orders exactly as before.
+
+**Action required:** none.
+
 ### Key pre-processor applied to all key arguments ([#4675](https://github.com/redis/jedis/pull/4675))
 
 The source key of `ZRANGESTORE`/`GEOSEARCHSTORE` and the script `KEYS` passed to

--- a/src/main/java/redis/clients/jedis/StreamEntryID.java
+++ b/src/main/java/redis/clients/jedis/StreamEntryID.java
@@ -21,8 +21,8 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
 
   public StreamEntryID(String id) {
     String[] split = id.split("-");
-    this.time = Long.parseLong(split[0]);
-    this.sequence = Long.parseLong(split[1]);
+    this.time = Long.parseUnsignedLong(split[0]);
+    this.sequence = Long.parseUnsignedLong(split[1]);
   }
 
   public StreamEntryID(long time) {
@@ -36,7 +36,7 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
 
   @Override
   public String toString() {
-    return time + "-" + sequence;
+    return Long.toUnsignedString(time) + "-" + Long.toUnsignedString(sequence);
   }
 
   @Override
@@ -55,8 +55,8 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
 
   @Override
   public int compareTo(StreamEntryID other) {
-    int timeCompare = Long.compare(this.time, other.time);
-    return timeCompare != 0 ? timeCompare : Long.compare(this.sequence, other.sequence);
+    int timeCompare = Long.compareUnsigned(this.time, other.time);
+    return timeCompare != 0 ? timeCompare : Long.compareUnsigned(this.sequence, other.sequence);
   }
 
   public long getTime() {

--- a/src/main/java/redis/clients/jedis/StreamEntryID.java
+++ b/src/main/java/redis/clients/jedis/StreamEntryID.java
@@ -59,10 +59,22 @@ public class StreamEntryID implements Comparable<StreamEntryID>, Serializable {
     return timeCompare != 0 ? timeCompare : Long.compareUnsigned(this.sequence, other.sequence);
   }
 
+  /**
+   * Returns the milliseconds part of the ID as the raw bits of an unsigned 64-bit integer. Values
+   * above {@code 2^63-1} appear negative under signed interpretation; use
+   * {@link Long#toUnsignedString(long)}, {@link Long#compareUnsigned(long, long)} and
+   * {@link Long#divideUnsigned(long, long)} for arithmetic covering the full range.
+   */
   public long getTime() {
     return time;
   }
 
+  /**
+   * Returns the sequence part of the ID as the raw bits of an unsigned 64-bit integer. Values above
+   * {@code 2^63-1} appear negative under signed interpretation; use
+   * {@link Long#toUnsignedString(long)}, {@link Long#compareUnsigned(long, long)} and
+   * {@link Long#divideUnsigned(long, long)} for arithmetic covering the full range.
+   */
   public long getSequence() {
     return sequence;
   }

--- a/src/main/java/redis/clients/jedis/params/XAddParams.java
+++ b/src/main/java/redis/clients/jedis/params/XAddParams.java
@@ -60,11 +60,11 @@ public class XAddParams implements IParams {
   }
 
   public XAddParams id(long time, long sequence) {
-    return id(time + "-" + sequence);
+    return id(Long.toUnsignedString(time) + "-" + Long.toUnsignedString(sequence));
   }
 
   public XAddParams id(long time) {
-    return id(time + "-*");
+    return id(Long.toUnsignedString(time) + "-*");
   }
 
   public XAddParams maxLen(long maxLen) {

--- a/src/test/java/redis/clients/jedis/StreamEntryIDTest.java
+++ b/src/test/java/redis/clients/jedis/StreamEntryIDTest.java
@@ -1,0 +1,46 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class StreamEntryIDTest {
+
+  // Redis stream IDs are two unsigned 64-bit integers; values in the upper half
+  // of the range must round-trip unchanged.
+  @Test
+  public void maxSequenceRoundTrips() {
+    StreamEntryID id = new StreamEntryID("0-18446744073709551615");
+    assertEquals(0L, id.getTime());
+    assertEquals(-1L, id.getSequence()); // 2^64-1 stored as raw bits
+    assertEquals("0-18446744073709551615", id.toString());
+  }
+
+  @Test
+  public void maxTimeRoundTrips() {
+    StreamEntryID id = new StreamEntryID("18446744073709551615-0");
+    assertEquals("18446744073709551615-0", id.toString());
+  }
+
+  @Test
+  public void ordersHighValuesAsUnsigned() {
+    StreamEntryID low = new StreamEntryID("0-1");
+    StreamEntryID high = new StreamEntryID("0-9223372036854775808"); // 2^63
+    assertTrue(high.compareTo(low) > 0);
+    assertTrue(low.compareTo(high) < 0);
+
+    StreamEntryID smallTime = new StreamEntryID("1-0");
+    StreamEntryID bigTime = new StreamEntryID("9223372036854775808-0");
+    assertTrue(bigTime.compareTo(smallTime) > 0);
+  }
+
+  @Test
+  public void commonIdsUnchanged() {
+    StreamEntryID a = new StreamEntryID("1526919030474-55");
+    assertEquals("1526919030474-55", a.toString());
+    StreamEntryID b = new StreamEntryID("1526919030474-56");
+    assertTrue(b.compareTo(a) > 0);
+    assertEquals(a, new StreamEntryID("1526919030474-55"));
+  }
+}

--- a/src/test/java/redis/clients/jedis/StreamEntryIDUnsignedIT.java
+++ b/src/test/java/redis/clients/jedis/StreamEntryIDUnsignedIT.java
@@ -1,0 +1,80 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.params.XAddParams;
+import redis.clients.jedis.params.XReadParams;
+import redis.clients.jedis.resps.StreamEntry;
+
+/**
+ * Server round-trip tests for stream IDs in the upper half of the unsigned 64-bit range. The reply
+ * builders funnel every echoed ID through {@link StreamEntryID#StreamEntryID(String)}, which used
+ * to throw {@link NumberFormatException} for values above {@code 2^63-1}.
+ */
+public class StreamEntryIDUnsignedIT {
+
+  private static final String KEY = "stream-entry-id-unsigned";
+
+  private static EndpointConfig endpoint;
+  private RedisClient client;
+
+  @BeforeAll
+  public static void setUpClass() {
+    endpoint = Endpoints.getRedisEndpoint("standalone0");
+  }
+
+  @BeforeEach
+  public void setUp() {
+    client = RedisClient.builder().hostAndPort(endpoint.getHostAndPort())
+        .clientConfig(endpoint.getClientConfigBuilder().build()).build();
+    client.del(KEY);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    client.del(KEY);
+    client.close();
+  }
+
+  @Test
+  public void upperHalfIdRoundTripsThroughReplyBuilders() {
+    StreamEntryID id = new StreamEntryID("0-18446744073709551615"); // sequence 2^64-1
+    Map<String, String> hash = Collections.singletonMap("field", "value");
+
+    StreamEntryID echoed = client.xadd(KEY, XAddParams.xAddParams().id(id), hash);
+    assertEquals(id, echoed);
+
+    List<StreamEntry> range = client.xrange(KEY, "-", "+");
+    assertEquals(1, range.size());
+    assertEquals("0-18446744073709551615", range.get(0).getID().toString());
+    assertEquals(hash, range.get(0).getFields());
+
+    List<Map.Entry<String, List<StreamEntry>>> read = client.xread(
+      XReadParams.xReadParams().count(1),
+      Collections.singletonMap(KEY, new StreamEntryID("0-9223372036854775807")));
+    assertEquals(1, read.size());
+    assertEquals(id, read.get(0).getValue().get(0).getID());
+  }
+
+  @Test
+  public void xAddParamsLongComponentsFormatUnsigned() {
+    long sequence = Long.parseUnsignedLong("9223372036854775808"); // 2^63, negative as signed
+    Map<String, String> hash = Collections.singletonMap("field", "value");
+
+    StreamEntryID echoed = client.xadd(KEY, XAddParams.xAddParams().id(0L, sequence), hash);
+    assertEquals("0-9223372036854775808", echoed.toString());
+
+    List<StreamEntry> range = client.xrange(KEY, "-", "+");
+    assertEquals(1, range.size());
+    assertEquals(echoed, range.get(0).getID());
+  }
+}


### PR DESCRIPTION
    java.lang.NumberFormatException: For input string: "18446744073709551615"
        at java.base/java.lang.Long.parseLong(Long.java:721)
        at redis.clients.jedis.StreamEntryID.<init>(StreamEntryID.java:24)

Redis stream IDs are two unsigned 64-bit integers, but the `String` constructor parses them with signed `Long.parseLong`, and `toString`/`compareTo` carry the same signed assumption. An entry whose `ms` or `sequence` is above `2^63-1` is a valid write (`XADD key <id>`), yet every stream reply builder funnels the echoed ID back through this constructor, so once such an entry exists the stream is unreadable from Jedis and a high ID also re-serialises negative and sorts wrong.

`Long.parseUnsignedLong`/`Long.toUnsignedString`/`Long.compareUnsigned` cover the whole range; every ID in the signed half parses, prints and orders exactly as before, so the change is a strict superset. Regression test added.

Closes #4710.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized streams ID handling with backward-compatible behavior for typical IDs; callers comparing or printing upper-half `long` values need unsigned APIs, which is documented.
> 
> **Overview**
> Fixes streams becoming unreadable in Jedis when an entry ID has an `ms` or sequence above `2^63-1` (valid in Redis but previously blew up in reply parsing with `NumberFormatException`).
> 
> **`StreamEntryID`** now treats both components as unsigned 64-bit values: string parsing uses `Long.parseUnsignedLong`, `toString()` uses `Long.toUnsignedString`, and `compareTo` uses `Long.compareUnsigned`. Javadoc on `getTime()` / `getSequence()` clarifies they return raw unsigned bits (upper-half values look negative as signed `long`). IDs in the normal signed range behave the same as before.
> 
> **`XAddParams.id(long, long)`** and **`id(long)`** format components unsigned so `XADD` does not send negative decimal IDs Redis rejects.
> 
> Release notes document the behavior change for 8.1.0. Unit tests cover round-trip, ordering, and common IDs; integration tests cover `XADD` / `XRANGE` / `XREAD` round-trips through reply builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1095f65f34e95baae8aeb73f788c3cebccc405be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->