### PR TITLE
Bump redis-authx dependencies 1.0.1-beta2 -> version 0.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
 		<dependency>
 			<groupId>redis.clients.authentication</groupId>
 			<artifactId>redis-authx-core</artifactId>
-			<version>0.1.1-beta2</version>
+			<version>0.2.0</version>
 		</dependency>
 
 		<!-- Optional dependencies -->
@@ -202,7 +202,7 @@
 		<dependency>
 			<groupId>redis.clients.authentication</groupId>
 			<artifactId>redis-authx-entraid</artifactId>
-			<version>0.1.1-beta2</version>
+			<version>0.2.0</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Bumps authentication libraries that Jedis wires into connection/token handling; a minor semver jump from beta could change behavior or APIs even without local code edits.
> 
> **Overview**
> Updates **`redis-authx-core`** (compile) and **`redis-authx-entraid`** (test) in `pom.xml` from **`0.1.1-beta2`** to **`0.2.0`**. There are no Java or config changes in this PR—only the pinned versions Jedis uses for token-based authentication and Entra ID test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7592367a013100cc77329ef50b988f2007eaeb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->