### PR TITLE
[scenario tests stability] Pipeline ClusterTopologyRefreshIT verification to fit the test timeout

### DIFF
--- a/src/test/java/redis/clients/jedis/scenario/ClusterTopologyRefreshIT.java
+++ b/src/test/java/redis/clients/jedis/scenario/ClusterTopologyRefreshIT.java
@@ -12,6 +12,8 @@ import redis.clients.jedis.providers.ClusterConnectionProvider;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -96,8 +98,20 @@ public class ClusterTopologyRefreshIT {
       assertTrue(fakeApp.capturedExceptions().isEmpty());
 
       log.info("Commands executed: {}", commandsExecuted.get());
-      for (long i = 0; i < commandsExecuted.get(); i++) {
-        assertTrue(client.exists(String.valueOf(i)));
+      // pipelined verification: one exists() round-trip per key does not fit the global test
+      // timeout (n grows with the fault-injection action's duration)
+      try (AbstractPipeline pipe = client.pipelined()) {
+        Map<Long, Response<Boolean>> pending = new LinkedHashMap<>();
+        for (long i = 0; i < commandsExecuted.get(); i++) {
+          pending.put(i, pipe.exists(String.valueOf(i)));
+          if (pending.size() == 500) {
+            pipe.sync();
+            pending.forEach((key, response) -> assertTrue(response.get(), "missing key " + key));
+            pending.clear();
+          }
+        }
+        pipe.sync();
+        pending.forEach((key, response) -> assertTrue(response.get(), "missing key " + key));
       }
 
       Set<String> afterReshardNodes = client.getClusterNodes().keySet();


### PR DESCRIPTION
# Pipeline ClusterTopologyRefreshIT verification to fit the test timeout

## What

Replaces `ClusterTopologyRefreshIT.testWithPool`'s sequential per-key `exists()` verification loop with pipelined batches (500 keys per `sync()`), keeping an exact per-key failure message.

## Why

The test writes one key per round trip while the fault-injection `reshard+failover` sequence runs, then verified every key with a sequential `exists()` — another full round trip per key. Both phases scale linearly with the action's duration, so the total test time is roughly twice the action duration and exceeds the 300 s global test timeout (`junit-platform.properties`) whenever the action takes ~150 s or more.

The nightly scenario runs fail consistently on this:

```
ClusterTopologyRefreshIT.testWithPool » Timeout testWithPool() timed out after 300 seconds
```

Measured on the scheduled runs: a passing run spent 120 s in the action and 116 s verifying 2180 keys (237 s total, 79% of the budget); a failing run spent 174 s in the action, leaving the ~156 s verification no room.

With pipelined verification the phase collapses from `n × RTT` (~2 minutes at ~3000 keys) to a few round trips, so the test time tracks the action duration alone.

## Notes

- The multi-key `EXISTS key [key ...]` form is not an option in cluster mode (cross-slot); the per-key `Response<Boolean>` also keeps the exact missing key in the failure message.
- Test-only change; no client behavior affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to verification timing; no production client behavior is modified.
> 
> **Overview**
> **`ClusterTopologyRefreshIT.testWithPool`** no longer verifies written keys with a sequential `exists()` per key. It batches `exists()` through a pipeline, **`sync()`ing every 500 keys**, and still asserts each key with a **`missing key {i}`** message on failure.
> 
> This shortens the post–fault-injection verification phase so nightly runs stay under the **300 s** JUnit timeout when resharding/failover runs long and thousands of keys were written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511017c204e0ba49f442f4245fd5d08597803091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->