### PR TITLE
Bump snapshot version to 8.0.2

### DIFF
--- a/docs/jedis-maven.md
+++ b/docs/jedis-maven.md
@@ -34,7 +34,7 @@ and
     <dependency>
         <groupId>redis.clients</groupId>
         <artifactId>jedis</artifactId>
-        <version>8.0.1-SNAPSHOT</version>
+        <version>8.0.2-SNAPSHOT</version>
     </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<packaging>jar</packaging>
 	<groupId>redis.clients</groupId>
 	<artifactId>jedis</artifactId>
-	<version>8.0.1-SNAPSHOT</version>
+	<version>8.0.2-SNAPSHOT</version>
 	<name>Jedis</name>
 	<description>Jedis is a blazingly small and sane Redis java client.</description>
 	<url>https://github.com/redis/jedis</url>


### PR DESCRIPTION
Post-release step for 8.0.1 (#4714): bump `8.x` to `8.0.2-SNAPSHOT` and update the snapshot example in `docs/jedis-maven.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime or API impact.
> 
> **Overview**
> **Post-8.0.1 release housekeeping:** advances the Maven project version from `8.0.1-SNAPSHOT` to `8.0.2-SNAPSHOT` in `pom.xml`, so the next development cycle publishes under the new snapshot coordinate.
> 
> The **Snapshots** example in `docs/jedis-maven.md` is updated to match, so copy-paste Maven snippets stay aligned with the repo version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bf80271b5e4cbd78dd8f3959035cb815699451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->