### PR TITLE
Update version references in README and docs for 8.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To get started with Jedis, first add it as a dependency in your Java project. If
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>8.0.0</version>
+    <version>8.0.1</version>
 </dependency>
 ```
 

--- a/docs/jedis-maven.md
+++ b/docs/jedis-maven.md
@@ -6,7 +6,7 @@
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>8.0.0</version>
+    <version>8.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Post-release step for 8.0.1 (#4714): 8.0.1 is the latest release — bump the Maven dependency examples in `README.md` and `docs/jedis-maven.md` from 8.0.0 to 8.0.1. Snapshot example (8.1.0-SNAPSHOT) untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only version string updates with no runtime or API impact.
> 
> **Overview**
> Post-release housekeeping for **8.0.1**: the official Maven dependency snippets in `README.md` and `docs/jedis-maven.md` now use `<version>8.0.1</version>` instead of `8.0.0`.
> 
> Snapshot documentation (e.g. `8.1.0-SNAPSHOT`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 364f10e8d62ec4b96ce4f23887ae434dfa1d15e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->