### PR TITLE
Do not fail close() when a broken resource cannot be replaced

### DIFF
--- a/src/main/java/redis/clients/jedis/util/Pool.java
+++ b/src/main/java/redis/clients/jedis/util/Pool.java
@@ -3,9 +3,13 @@ package redis.clients.jedis.util;
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import redis.clients.jedis.exceptions.JedisException;
 
 public class Pool<T> extends GenericObjectPool<T> {
+
+  private static final Logger log = LoggerFactory.getLogger(Pool.class);
 
   // Legacy
   public Pool(GenericObjectPoolConfig<T> poolConfig, PooledObjectFactory<T> factory) {
@@ -60,8 +64,15 @@ public class Pool<T> extends GenericObjectPool<T> {
     }
     try {
       super.invalidateObject(resource);
-    } catch (Exception e) {
+    } catch (IllegalStateException e) {
+      // The resource is not part of this pool, so nothing was invalidated and the caller
+      // has to hear about it.
       throw new JedisException("Could not return the broken resource to the pool", e);
+    } catch (Exception e) {
+      // The broken resource is already destroyed and removed here: the pool destroys it
+      // before it opens a replacement, and only that replacement can fail this late. Closing
+      // a broken connection must not fail just because the server is still unreachable.
+      log.debug("Could not open a replacement while returning a broken resource to the pool", e);
     }
   }
 

--- a/src/test/java/redis/clients/jedis/util/PoolTest.java
+++ b/src/test/java/redis/clients/jedis/util/PoolTest.java
@@ -1,0 +1,100 @@
+package redis.clients.jedis.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.exceptions.JedisException;
+
+public class PoolTest {
+
+  /**
+   * Creates plain objects while the "server" is up and fails to create anything once it is down,
+   * which is what a pool sees when Redis becomes unreachable.
+   */
+  private static class ServerBackedFactory extends BasePooledObjectFactory<Object> {
+
+    private final AtomicInteger destroyed = new AtomicInteger();
+    private volatile boolean serverUp = true;
+
+    @Override
+    public Object create() {
+      if (!serverUp) {
+        throw new JedisConnectionException("Failed to connect to localhost:6379.");
+      }
+      return new Object();
+    }
+
+    @Override
+    public PooledObject<Object> wrap(Object obj) {
+      return new DefaultPooledObject<>(obj);
+    }
+
+    @Override
+    public void destroyObject(PooledObject<Object> pooledObject) {
+      destroyed.incrementAndGet();
+    }
+  }
+
+  private static GenericObjectPoolConfig<Object> config() {
+    GenericObjectPoolConfig<Object> config = new GenericObjectPoolConfig<>();
+    config.setMaxTotal(4);
+    return config;
+  }
+
+  @Test
+  public void returnBrokenResourceSucceedsWhenTheReplacementCannotBeCreated() {
+    ServerBackedFactory factory = new ServerBackedFactory();
+    try (Pool<Object> pool = new Pool<>(factory, config())) {
+      Object resource = pool.getResource();
+      factory.serverUp = false;
+
+      pool.returnBrokenResource(resource);
+
+      assertEquals(0, pool.getNumActive());
+      assertEquals(0, pool.getNumIdle());
+      assertEquals(1, factory.destroyed.get());
+    }
+  }
+
+  @Test
+  public void returnBrokenResourceDestroysTheResourceWhileTheServerIsUp() {
+    ServerBackedFactory factory = new ServerBackedFactory();
+    try (Pool<Object> pool = new Pool<>(factory, config())) {
+      Object resource = pool.getResource();
+
+      pool.returnBrokenResource(resource);
+
+      assertEquals(0, pool.getNumActive());
+      assertEquals(1, factory.destroyed.get());
+    }
+  }
+
+  @Test
+  public void returnBrokenResourceRejectsAResourceThatIsNotPooled() {
+    try (Pool<Object> pool = new Pool<>(new ServerBackedFactory(), config())) {
+      JedisException e = assertThrows(JedisException.class,
+        () -> pool.returnBrokenResource(new Object()));
+
+      assertInstanceOf(IllegalStateException.class, e.getCause());
+    }
+  }
+
+  @Test
+  public void returnBrokenResourceIgnoresNull() {
+    try (Pool<Object> pool = new Pool<>(new ServerBackedFactory(), config())) {
+      pool.returnBrokenResource(null);
+
+      assertEquals(0, pool.getNumActive());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closing a connection that broke while the server is down throws out of `close()` (#4690).
commons-pool2 2.13.x destroys the object and then opens a replacement unconditionally (POOL-431);
with the server unreachable that replacement fails and escapes as `JedisException`.

## Key Decisions

Only the replacement failure is dropped, logged at debug: the broken object is already destroyed
and removed by then, since the pool destroys before it replaces. `IllegalStateException` still
surfaces as `JedisException`, because it is raised before anything is invalidated and means the
resource is not pooled. `returnResource` is untouched, as commons-pool2 already swallows factory
failures there.

## Testing

A new unit test reproduces the reported stack trace on master. Full suite: 3300 tests, 0 failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling on a core pooling path used by connection close; behavior is narrower (only post-destroy replacement failures) but could hide factory errors that previously surfaced to callers.
> 
> **Overview**
> Fixes **#4690**: closing a Jedis connection after Redis is unreachable no longer throws from `close()` when commons-pool2 invalidates a broken connection and then fails to create a replacement.
> 
> `Pool.returnBrokenResource` now treats **`IllegalStateException`** (resource not in the pool) as before—wrapped in **`JedisException`**. Other failures during invalidation (typically replacement **`create()`** while the server is down) are **logged at debug** and swallowed, on the assumption the broken object is already destroyed.
> 
> Adds **`PoolTest`** with a server-up/down factory to cover replacement failure, normal destroy, non-pooled rejection, and null handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40672757c7be44f751ab2e351cc400de312e5894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->