### PR TITLE
Route keyless cluster commands to any node instead of throwing

### DIFF
--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -73,9 +73,11 @@ the current topology, falling back to a primary when that topology records no re
 
 The replica path also no longer throws `NullPointerException` for a client that leaves
 `readOnlyForRedisClusterReplicas` at its default. Replicas are only recorded in the slot
-cache when that option is enabled, and `JedisClusterInfoCache.getSlotReplicaPools(int)` now
-returns `null` for a client that does not record them instead of reading an absent slot
-array.
+cache when that option is enabled, so `JedisClusterInfoCache.getSlotReplicaPools(int)` now
+returns `null` for a client that records none, and an empty list for a recorded slot whose
+replicas are not known yet, instead of reading an absent slot array. A keyed replica command
+on a client that records no replica goes straight to the slot's primary rather than renewing
+the slot cache first, since that renewal cannot produce a replica.
 
 **Action required:** none. Code that caught `NoSuchElementException` around keyless cluster
 commands can drop that handling.

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -61,3 +61,16 @@ pub/sub frames from a connection without going through the `JedisPubSub`/
 `JedisShardedPubSub` loops (e.g. hand-rolled `sendCommand(SUBSCRIBE)` +
 `getUnflushedObject()`) will no longer receive those frames; use the pub/sub APIs or
 register a custom `PushConsumer` that propagates them.
+
+### Keyless commands on a cluster no longer throw `NoSuchElementException` ([#4719](https://github.com/redis/jedis/pull/4719))
+
+`ClusterConnectionProvider.getConnection(CommandArguments)` and
+`getReplicaConnection(CommandArguments)` took the first element of the command's hash slot
+set without checking that the set was non-empty, so a command that carries no key, such as
+`PING` or `INFO`, threw `NoSuchElementException` before a connection was acquired. Keyless
+commands now run on an arbitrary node, and on the replica path on an arbitrary replica,
+falling back to a primary when the cluster reports no replica. That replica pick is also
+available on its own as `ClusterConnectionProvider.getReplicaConnection()`.
+
+**Action required:** none. Code that caught `NoSuchElementException` around keyless cluster
+commands can drop that handling.

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -68,8 +68,14 @@ register a custom `PushConsumer` that propagates them.
 `getReplicaConnection(CommandArguments)` took the first element of the command's hash slot
 set without checking that the set was non-empty, so a command that carries no key, such as
 `PING` or `INFO`, threw `NoSuchElementException` before a connection was acquired. Keyless
-commands now run on an arbitrary node, and on the replica path on an arbitrary replica,
-falling back to a primary when the cluster reports no replica.
+commands now run on an arbitrary node, and on the replica path on an arbitrary replica of
+the current topology, falling back to a primary when that topology records no replica.
+
+The replica path also no longer throws `NullPointerException` for a client that leaves
+`readOnlyForRedisClusterReplicas` at its default. Replicas are only recorded in the slot
+cache when that option is enabled, and `JedisClusterInfoCache.getSlotReplicaPools(int)` now
+returns `null` for a client that does not record them instead of reading an absent slot
+array.
 
 **Action required:** none. Code that caught `NoSuchElementException` around keyless cluster
 commands can drop that handling.

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -69,8 +69,7 @@ register a custom `PushConsumer` that propagates them.
 set without checking that the set was non-empty, so a command that carries no key, such as
 `PING` or `INFO`, threw `NoSuchElementException` before a connection was acquired. Keyless
 commands now run on an arbitrary node, and on the replica path on an arbitrary replica,
-falling back to a primary when the cluster reports no replica. That replica pick is also
-available on its own as `ClusterConnectionProvider.getReplicaConnection()`.
+falling back to a primary when the cluster reports no replica.
 
 **Action required:** none. Code that caught `NoSuchElementException` around keyless cluster
 commands can drop that handling.

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -43,6 +43,7 @@ public class JedisClusterInfoCache {
   private final ConnectionPool[] slots = new ConnectionPool[Protocol.CLUSTER_HASHSLOTS];
   private final HostAndPort[] slotNodes = new HostAndPort[Protocol.CLUSTER_HASHSLOTS];
   private final List<ConnectionPool>[] replicaSlots;
+  private final Map<String, ConnectionPool> replicaNodesCache = new HashMap<>();
 
   private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
   private final Lock r = rwl.readLock();
@@ -369,6 +370,7 @@ public class JedisClusterInfoCache {
     w.lock();
     try {
       ConnectionPool targetPool = setupNodeIfNotExist(targetNode);
+      replicaNodesCache.put(getNodeKey(targetNode), targetPool);
       for (Integer slot : targetSlots) {
         if (replicaSlots[slot] == null) {
           replicaSlots[slot] = new ArrayList<>();
@@ -411,10 +413,30 @@ public class JedisClusterInfoCache {
     }
   }
 
+  /**
+   * Returns the pools of the replicas that serve the given slot, or {@code null} when none is
+   * known. Replicas are only recorded for a client configured with
+   * {@link JedisClientConfig#isReadOnlyForRedisClusterReplicas()}, so this is always {@code null}
+   * for a client that does not track them.
+   */
   public List<ConnectionPool> getSlotReplicaPools(int slot) {
     r.lock();
     try {
-      return replicaSlots[slot];
+      return replicaSlots == null ? null : replicaSlots[slot];
+    } finally {
+      r.unlock();
+    }
+  }
+
+  /**
+   * Returns the pool of every node that the current topology records as a replica. Empty for a
+   * client that does not track replicas, see {@link #getSlotReplicaPools(int)}.
+   * @since 8.1
+   */
+  public Map<String, ConnectionPool> getReplicaNodes() {
+    r.lock();
+    try {
+      return new HashMap<>(replicaNodesCache);
     } finally {
       r.unlock();
     }
@@ -480,6 +502,7 @@ public class JedisClusterInfoCache {
   }
 
   private void resetReplicaSlots() {
+    replicaNodesCache.clear();
     if (replicaSlots == null) {
       return;
     }

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -414,15 +414,20 @@ public class JedisClusterInfoCache {
   }
 
   /**
-   * Returns the pools of the replicas that serve the given slot, or {@code null} when none is
-   * known. Replicas are only recorded for a client configured with
-   * {@link JedisClientConfig#isReadOnlyForRedisClusterReplicas()}, so this is always {@code null}
-   * for a client that does not track them.
+   * Returns the pools of the replicas that serve the given slot, or {@code null} when this client
+   * does not record replicas at all. Replicas are only recorded for a client configured with
+   * {@link JedisClientConfig#isReadOnlyForRedisClusterReplicas()}. With that option a slot whose
+   * replicas are not known yet returns an empty list, which a slot cache renewal can still fill;
+   * without it the result is always {@code null}, and no renewal can change that.
    */
   public List<ConnectionPool> getSlotReplicaPools(int slot) {
     r.lock();
     try {
-      return replicaSlots == null ? null : replicaSlots[slot];
+      if (replicaSlots == null) {
+        return null;
+      }
+      List<ConnectionPool> replicaPools = replicaSlots[slot];
+      return replicaPools == null ? Collections.emptyList() : replicaPools;
     } finally {
       r.unlock();
     }

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -3,6 +3,7 @@ package redis.clients.jedis.providers;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -131,8 +132,11 @@ public class ClusterConnectionProvider implements ConnectionProvider {
       throw new JedisClusterOperationException("Cannot get connection for command with multiple hash slots");
     }
 
-    int slot = slots.iterator().next();
-    return slot >= 0 ? getConnectionFromSlot(slot) : getConnection();
+    if (slots.isEmpty()) {
+      return getConnection(); // a keyless command can run on any node
+    }
+
+    return getConnectionFromSlot(slots.iterator().next());
   }
 
   public Connection getReplicaConnection(CommandArguments args) {
@@ -142,8 +146,29 @@ public class ClusterConnectionProvider implements ConnectionProvider {
       throw new JedisClusterOperationException("Cannot get connection for command with multiple hash slots");
     }
 
-    int slot = slots.iterator().next();
-    return slot >= 0 ? getReplicaConnectionFromSlot(slot) : getConnection();
+    if (slots.isEmpty()) {
+      return getReplicaConnection(); // a keyless command can run on any replica
+    }
+
+    return getReplicaConnectionFromSlot(slots.iterator().next());
+  }
+
+  /**
+   * Returns a connection to a randomly picked replica, falling back to a primary when the cluster
+   * reports no replica, the same way {@link #getReplicaConnectionFromSlot(int)} does for a slot
+   * whose replicas are unknown.
+   *
+   * @since 8.1
+   */
+  public Connection getReplicaConnection() {
+    Map<String, ConnectionPool> replicas = new HashMap<>(getNodes());
+    replicas.keySet().removeAll(getPrimaryNodes().keySet());
+    if (replicas.isEmpty()) {
+      return getConnection();
+    }
+
+    List<ConnectionPool> pools = new ArrayList<>(replicas.values());
+    return pools.get(ThreadLocalRandom.current().nextInt(pools.size())).getResource();
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -119,6 +119,10 @@ public class ClusterConnectionProvider implements ConnectionProvider {
     return cache.getReplicaNodes();
   }
 
+  List<ConnectionPool> getSlotReplicaPools(int slot) {
+    return cache.getSlotReplicaPools(slot);
+  }
+
   public HostAndPort getNode(int slot) {
     return slot >= 0 ? cache.getSlotNode(slot) : null;
   }
@@ -228,16 +232,21 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   }
 
   public Connection getReplicaConnectionFromSlot(int slot) {
-    List<ConnectionPool> connectionPools = cache.getSlotReplicaPools(slot);
+    List<ConnectionPool> connectionPools = getSlotReplicaPools(slot);
+    if (connectionPools == null) {
+      // This client records no replica, so renewing the slot cache cannot produce one.
+      return getConnectionFromSlot(slot);
+    }
+
     ThreadLocalRandom random = ThreadLocalRandom.current();
-    if (connectionPools != null && !connectionPools.isEmpty()) {
+    if (!connectionPools.isEmpty()) {
       // pick up randomly a connection
       int idx = random.nextInt(connectionPools.size());
       return connectionPools.get(idx).getResource();
     }
 
     renewSlotCache();
-    connectionPools = cache.getSlotReplicaPools(slot);
+    connectionPools = getSlotReplicaPools(slot);
     if (connectionPools != null && !connectionPools.isEmpty()) {
       int idx = random.nextInt(connectionPools.size());
       return connectionPools.get(idx).getResource();

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -157,10 +157,8 @@ public class ClusterConnectionProvider implements ConnectionProvider {
    * Returns a connection to a randomly picked replica, falling back to a primary when the cluster
    * reports no replica, the same way {@link #getReplicaConnectionFromSlot(int)} does for a slot
    * whose replicas are unknown.
-   *
-   * @since 8.1
    */
-  public Connection getReplicaConnection() {
+  private Connection getReplicaConnection() {
     Map<String, ConnectionPool> replicas = new HashMap<>(getNodes());
     replicas.keySet().removeAll(getPrimaryNodes().keySet());
     if (replicas.isEmpty()) {

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -3,7 +3,6 @@ package redis.clients.jedis.providers;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -116,6 +115,10 @@ public class ClusterConnectionProvider implements ConnectionProvider {
     return cache.getPrimaryNodes();
   }
 
+  Map<String, ConnectionPool> getReplicaNodes() {
+    return cache.getReplicaNodes();
+  }
+
   public HostAndPort getNode(int slot) {
     return slot >= 0 ? cache.getSlotNode(slot) : null;
   }
@@ -147,38 +150,26 @@ public class ClusterConnectionProvider implements ConnectionProvider {
     }
 
     if (slots.isEmpty()) {
-      return getReplicaConnection(); // a keyless command can run on any replica
+      return getAnyReplicaConnection(); // a keyless command can run on any replica
     }
 
     return getReplicaConnectionFromSlot(slots.iterator().next());
   }
 
   /**
-   * Returns a connection to a randomly picked replica. A cluster that reports no replica may just
-   * have a stale topology here, so the slot cache is renewed once before falling back to a primary,
-   * the same way {@link #getReplicaConnectionFromSlot(int)} does for a slot whose replicas are
-   * unknown.
+   * Returns a connection to a randomly picked replica of the current topology, or a primary
+   * connection when that topology records no replica. Replicas are recorded only for a client
+   * configured with {@link JedisClientConfig#isReadOnlyForRedisClusterReplicas()}, so a client
+   * that does not track them falls back right away instead of renewing the slot cache, which is
+   * an expensive operation, on every keyless call.
    */
-  private Connection getReplicaConnection() {
-    Connection replica = getAnyReplicaConnection();
-    if (replica != null) {
-      return replica;
-    }
-
-    renewSlotCache();
-    replica = getAnyReplicaConnection();
-    return replica != null ? replica : getConnection();
-  }
-
   private Connection getAnyReplicaConnection() {
-    Map<String, ConnectionPool> replicas = new HashMap<>(getNodes());
-    replicas.keySet().removeAll(getPrimaryNodes().keySet());
+    List<ConnectionPool> replicas = new ArrayList<>(getReplicaNodes().values());
     if (replicas.isEmpty()) {
-      return null;
+      return getConnection();
     }
 
-    List<ConnectionPool> pools = new ArrayList<>(replicas.values());
-    return pools.get(ThreadLocalRandom.current().nextInt(pools.size())).getResource();
+    return replicas.get(ThreadLocalRandom.current().nextInt(replicas.size())).getResource();
   }
 
   @Override

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -154,15 +154,27 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   }
 
   /**
-   * Returns a connection to a randomly picked replica, falling back to a primary when the cluster
-   * reports no replica, the same way {@link #getReplicaConnectionFromSlot(int)} does for a slot
-   * whose replicas are unknown.
+   * Returns a connection to a randomly picked replica. A cluster that reports no replica may just
+   * have a stale topology here, so the slot cache is renewed once before falling back to a primary,
+   * the same way {@link #getReplicaConnectionFromSlot(int)} does for a slot whose replicas are
+   * unknown.
    */
   private Connection getReplicaConnection() {
+    Connection replica = getAnyReplicaConnection();
+    if (replica != null) {
+      return replica;
+    }
+
+    renewSlotCache();
+    replica = getAnyReplicaConnection();
+    return replica != null ? replica : getConnection();
+  }
+
+  private Connection getAnyReplicaConnection() {
     Map<String, ConnectionPool> replicas = new HashMap<>(getNodes());
     replicas.keySet().removeAll(getPrimaryNodes().keySet());
     if (replicas.isEmpty()) {
-      return getConnection();
+      return null;
     }
 
     List<ConnectionPool> pools = new ArrayList<>(replicas.values());

--- a/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
@@ -200,6 +201,18 @@ public class JedisClusterInfoCacheTest {
   }
 
   @Test
+  public void replicaPoolsOfAnUnknownSlotAreEmptyWhenReplicaTrackingIsEnabled() {
+    JedisClusterInfoCache cache = createCacheWithReplicasEnabled();
+
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS"))))
+        .thenReturn(masterOnlySlotsResponse());
+    cache.discoverClusterNodesAndSlots(mockConnection);
+
+    // a later renewal can still record a replica for this slot, unlike a client that tracks none
+    assertThat(cache.getSlotReplicaPools(TEST_SLOT), empty());
+  }
+
+  @Test
   public void replicaNodesFollowTheDiscoveredTopology() {
     JedisClusterInfoCache cache = createCacheWithReplicasEnabled();
 
@@ -244,8 +257,9 @@ public class JedisClusterInfoCacheTest {
   }
 
   private void assertNoReplicasAvailable(JedisClusterInfoCache cache) {
+    // the client records replicas, so an unknown slot is an empty list and not a null
     List<ConnectionPool> caheReplicaNodePools = cache.getSlotReplicaPools(TEST_SLOT);
-    assertNull(caheReplicaNodePools);
+    assertThat(caheReplicaNodePools, empty());
   }
 
   private void assertReplicasAvailable(JedisClusterInfoCache cache, HostAndPort... replicaNodes) {

--- a/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
+++ b/src/test/java/redis/clients/jedis/JedisClusterInfoCacheTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
@@ -181,6 +182,39 @@ public class JedisClusterInfoCacheTest {
             hasEntry(equalTo(getNodeKey(REPLICA_1_HOST)), equalTo(cache.getNode(REPLICA_1_HOST))));
     assertThat(cache.getShuffledPrimaryNodesPool(), equalTo(
             Collections.singletonList(cache.getNode(REPLICA_1_HOST))));
+  }
+
+  @Test
+  public void replicaLookupsAreEmptyWhenReplicaTrackingIsDisabled() {
+    // readOnlyForRedisClusterReplicas defaults to false, so no replica is recorded at all
+    JedisClusterInfoCache cache = new JedisClusterInfoCache(
+        DefaultJedisClientConfig.builder().build(),
+        new HashSet<>(Collections.singletonList(MASTER_HOST)));
+
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS"))))
+        .thenReturn(masterReplicaSlotsResponse(MASTER_HOST, REPLICA_1_HOST));
+    cache.discoverClusterNodesAndSlots(mockConnection);
+
+    assertNull(cache.getSlotReplicaPools(TEST_SLOT));
+    assertThat(cache.getReplicaNodes(), anEmptyMap());
+  }
+
+  @Test
+  public void replicaNodesFollowTheDiscoveredTopology() {
+    JedisClusterInfoCache cache = createCacheWithReplicasEnabled();
+
+    when(mockConnection.executeCommand(argThat(commandWithArgs(CLUSTER, "SLOTS"))))
+        .thenReturn(masterReplicaSlotsResponse(MASTER_HOST, REPLICA_1_HOST))
+        .thenReturn(masterOnlySlotsResponse());
+
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertThat(cache.getReplicaNodes(), aMapWithSize(1));
+    assertThat(cache.getReplicaNodes(), hasEntry(equalTo(getNodeKey(REPLICA_1_HOST)),
+      equalTo(cache.getNode(REPLICA_1_HOST))));
+
+    // the replica is gone from the topology, so it must be gone from the replica nodes too
+    cache.discoverClusterNodesAndSlots(mockConnection);
+    assertThat(cache.getReplicaNodes(), anEmptyMap());
   }
 
   private List<Object> masterReplicaSlotsResponse(HostAndPort masterHost, HostAndPort replicaHost) {

--- a/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
@@ -1,0 +1,94 @@
+package redis.clients.jedis.providers;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import redis.clients.jedis.CommandArguments;
+import redis.clients.jedis.Connection;
+import redis.clients.jedis.ConnectionPool;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.util.JedisClusterCRC16;
+
+public class ClusterConnectionProviderTest {
+
+  @Test
+  public void keylessCommandGetsAConnectionFromAnyNode() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection anyNode = mock(Connection.class);
+    doReturn(anyNode).when(provider).getConnection();
+
+    assertSame(anyNode, provider.getConnection(new CommandArguments(Protocol.Command.PING)));
+  }
+
+  @Test
+  public void keylessCommandGetsAReplicaConnectionFromAnyReplica() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection anyReplica = mock(Connection.class);
+    doReturn(anyReplica).when(provider).getReplicaConnection();
+
+    assertSame(anyReplica,
+      provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
+  }
+
+  @Test
+  public void anyReplicaConnectionSkipsThePrimaryNodes() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection replicaConnection = mock(Connection.class);
+    ConnectionPool primaryPool = mock(ConnectionPool.class);
+    ConnectionPool replicaPool = mock(ConnectionPool.class);
+    doReturn(replicaConnection).when(replicaPool).getResource();
+
+    Map<String, ConnectionPool> nodes = new HashMap<>();
+    nodes.put("127.0.0.1:7000", primaryPool);
+    nodes.put("127.0.0.1:7001", replicaPool);
+    doReturn(nodes).when(provider).getNodes();
+    doReturn(Collections.singletonMap("127.0.0.1:7000", primaryPool)).when(provider)
+        .getPrimaryNodes();
+
+    assertSame(replicaConnection, provider.getReplicaConnection());
+  }
+
+  @Test
+  public void anyReplicaConnectionFallsBackToAPrimaryWhenTheClusterHasNoReplica() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection anyNode = mock(Connection.class);
+    ConnectionPool primaryPool = mock(ConnectionPool.class);
+    Map<String, ConnectionPool> nodes = Collections.singletonMap("127.0.0.1:7000", primaryPool);
+    doReturn(nodes).when(provider).getNodes();
+    doReturn(nodes).when(provider).getPrimaryNodes();
+    doReturn(anyNode).when(provider).getConnection();
+
+    assertSame(anyNode, provider.getReplicaConnection());
+  }
+
+  @Test
+  public void keyedCommandGetsTheConnectionForItsSlot() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection slotOwner = mock(Connection.class);
+    doReturn(slotOwner).when(provider).getConnectionFromSlot(JedisClusterCRC16.getSlot("foo"));
+
+    CommandArguments args = new CommandArguments(Protocol.Command.GET).key("foo");
+
+    assertSame(slotOwner, provider.getConnection(args));
+  }
+
+  @Test
+  public void keyedCommandGetsTheReplicaConnectionForItsSlot() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection slotReplica = mock(Connection.class);
+    doReturn(slotReplica).when(provider)
+        .getReplicaConnectionFromSlot(JedisClusterCRC16.getSlot("foo"));
+
+    CommandArguments args = new CommandArguments(Protocol.Command.GET).key("foo");
+
+    assertSame(slotReplica, provider.getReplicaConnection(args));
+  }
+}

--- a/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
@@ -2,8 +2,10 @@ package redis.clients.jedis.providers;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,8 +58,32 @@ public class ClusterConnectionProviderTest {
     doReturn(nodes).when(provider).getNodes();
     doReturn(nodes).when(provider).getPrimaryNodes();
     doReturn(anyNode).when(provider).getConnection();
+    doNothing().when(provider).renewSlotCache();
 
     assertSame(anyNode, provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
+    verify(provider).renewSlotCache();
+  }
+
+  @Test
+  public void keylessReplicaCommandUsesAReplicaThatOnlyTheRenewedTopologyKnows() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection replicaConnection = mock(Connection.class);
+    ConnectionPool primaryPool = mock(ConnectionPool.class);
+    ConnectionPool replicaPool = mock(ConnectionPool.class);
+    doReturn(replicaConnection).when(replicaPool).getResource();
+
+    Map<String, ConnectionPool> primaryOnly = Collections.singletonMap("127.0.0.1:7000",
+      primaryPool);
+    Map<String, ConnectionPool> afterRenew = new HashMap<>(primaryOnly);
+    afterRenew.put("127.0.0.1:7001", replicaPool);
+    doReturn(primaryOnly).doReturn(afterRenew).when(provider).getNodes();
+    doReturn(primaryOnly).when(provider).getPrimaryNodes();
+    doReturn(mock(Connection.class)).when(provider).getConnection();
+    doNothing().when(provider).renewSlotCache();
+
+    assertSame(replicaConnection,
+      provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
+    verify(provider).renewSlotCache();
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
@@ -2,14 +2,12 @@ package redis.clients.jedis.providers;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,59 +29,28 @@ public class ClusterConnectionProviderTest {
   }
 
   @Test
-  public void keylessCommandGetsAReplicaConnectionFromANodeThatIsNotAPrimary() {
+  public void keylessCommandGetsAReplicaConnectionFromAReplicaOfTheTopology() {
     ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
     Connection replicaConnection = mock(Connection.class);
-    ConnectionPool primaryPool = mock(ConnectionPool.class);
     ConnectionPool replicaPool = mock(ConnectionPool.class);
     doReturn(replicaConnection).when(replicaPool).getResource();
-
-    Map<String, ConnectionPool> nodes = new HashMap<>();
-    nodes.put("127.0.0.1:7000", primaryPool);
-    nodes.put("127.0.0.1:7001", replicaPool);
-    doReturn(nodes).when(provider).getNodes();
-    doReturn(Collections.singletonMap("127.0.0.1:7000", primaryPool)).when(provider)
-        .getPrimaryNodes();
+    doReturn(Collections.singletonMap("127.0.0.1:7001", replicaPool)).when(provider)
+        .getReplicaNodes();
 
     assertSame(replicaConnection,
       provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
   }
 
   @Test
-  public void keylessReplicaCommandFallsBackToAPrimaryWhenTheClusterHasNoReplica() {
+  public void keylessReplicaCommandFallsBackToAPrimaryWithoutRenewingTheSlotCache() {
     ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
     Connection anyNode = mock(Connection.class);
-    ConnectionPool primaryPool = mock(ConnectionPool.class);
-    Map<String, ConnectionPool> nodes = Collections.singletonMap("127.0.0.1:7000", primaryPool);
-    doReturn(nodes).when(provider).getNodes();
-    doReturn(nodes).when(provider).getPrimaryNodes();
+    doReturn(Collections.<String, ConnectionPool> emptyMap()).when(provider).getReplicaNodes();
     doReturn(anyNode).when(provider).getConnection();
-    doNothing().when(provider).renewSlotCache();
 
     assertSame(anyNode, provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
-    verify(provider).renewSlotCache();
-  }
-
-  @Test
-  public void keylessReplicaCommandUsesAReplicaThatOnlyTheRenewedTopologyKnows() {
-    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
-    Connection replicaConnection = mock(Connection.class);
-    ConnectionPool primaryPool = mock(ConnectionPool.class);
-    ConnectionPool replicaPool = mock(ConnectionPool.class);
-    doReturn(replicaConnection).when(replicaPool).getResource();
-
-    Map<String, ConnectionPool> primaryOnly = Collections.singletonMap("127.0.0.1:7000",
-      primaryPool);
-    Map<String, ConnectionPool> afterRenew = new HashMap<>(primaryOnly);
-    afterRenew.put("127.0.0.1:7001", replicaPool);
-    doReturn(primaryOnly).doReturn(afterRenew).when(provider).getNodes();
-    doReturn(primaryOnly).when(provider).getPrimaryNodes();
-    doReturn(mock(Connection.class)).when(provider).getConnection();
-    doNothing().when(provider).renewSlotCache();
-
-    assertSame(replicaConnection,
-      provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
-    verify(provider).renewSlotCache();
+    // a cluster without replicas would otherwise renew the whole topology on every keyless call
+    verify(provider, never()).renewSlotCache();
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
@@ -29,17 +29,7 @@ public class ClusterConnectionProviderTest {
   }
 
   @Test
-  public void keylessCommandGetsAReplicaConnectionFromAnyReplica() {
-    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
-    Connection anyReplica = mock(Connection.class);
-    doReturn(anyReplica).when(provider).getReplicaConnection();
-
-    assertSame(anyReplica,
-      provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
-  }
-
-  @Test
-  public void anyReplicaConnectionSkipsThePrimaryNodes() {
+  public void keylessCommandGetsAReplicaConnectionFromANodeThatIsNotAPrimary() {
     ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
     Connection replicaConnection = mock(Connection.class);
     ConnectionPool primaryPool = mock(ConnectionPool.class);
@@ -53,11 +43,12 @@ public class ClusterConnectionProviderTest {
     doReturn(Collections.singletonMap("127.0.0.1:7000", primaryPool)).when(provider)
         .getPrimaryNodes();
 
-    assertSame(replicaConnection, provider.getReplicaConnection());
+    assertSame(replicaConnection,
+      provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
   }
 
   @Test
-  public void anyReplicaConnectionFallsBackToAPrimaryWhenTheClusterHasNoReplica() {
+  public void keylessReplicaCommandFallsBackToAPrimaryWhenTheClusterHasNoReplica() {
     ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
     Connection anyNode = mock(Connection.class);
     ConnectionPool primaryPool = mock(ConnectionPool.class);
@@ -66,7 +57,7 @@ public class ClusterConnectionProviderTest {
     doReturn(nodes).when(provider).getPrimaryNodes();
     doReturn(anyNode).when(provider).getConnection();
 
-    assertSame(anyNode, provider.getReplicaConnection());
+    assertSame(anyNode, provider.getReplicaConnection(new CommandArguments(Protocol.Command.PING)));
   }
 
   @Test

--- a/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
+++ b/src/test/java/redis/clients/jedis/providers/ClusterConnectionProviderTest.java
@@ -2,6 +2,7 @@ package redis.clients.jedis.providers;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -74,5 +75,34 @@ public class ClusterConnectionProviderTest {
     CommandArguments args = new CommandArguments(Protocol.Command.GET).key("foo");
 
     assertSame(slotReplica, provider.getReplicaConnection(args));
+  }
+
+  @Test
+  public void keyedReplicaCommandFallsBackToAPrimaryWithoutRenewingTheSlotCacheWhenReplicasAreNotRecorded() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection slotOwner = mock(Connection.class);
+    int slot = JedisClusterCRC16.getSlot("foo");
+    doReturn(null).when(provider).getSlotReplicaPools(slot);
+    doReturn(slotOwner).when(provider).getConnectionFromSlot(slot);
+    doNothing().when(provider).renewSlotCache();
+
+    assertSame(slotOwner, provider.getReplicaConnectionFromSlot(slot));
+    // renewing cannot record a replica for a client that does not track them
+    verify(provider, never()).renewSlotCache();
+  }
+
+  @Test
+  public void keyedReplicaCommandRenewsTheSlotCacheWhenTheSlotHasNoRecordedReplicaYet() {
+    ClusterConnectionProvider provider = mock(ClusterConnectionProvider.class, CALLS_REAL_METHODS);
+    Connection replicaConnection = mock(Connection.class);
+    ConnectionPool replicaPool = mock(ConnectionPool.class);
+    doReturn(replicaConnection).when(replicaPool).getResource();
+    int slot = JedisClusterCRC16.getSlot("foo");
+    doReturn(Collections.<ConnectionPool> emptyList())
+        .doReturn(Collections.singletonList(replicaPool)).when(provider).getSlotReplicaPools(slot);
+    doNothing().when(provider).renewSlotCache();
+
+    assertSame(replicaConnection, provider.getReplicaConnectionFromSlot(slot));
+    verify(provider).renewSlotCache();
   }
 }


### PR DESCRIPTION
Fixes #4720

## Summary

Both `CommandArguments` overloads call `slots.iterator().next()` after checking only for more than one slot, so a keyless command (PING, INFO) throws `NoSuchElementException`.

## Key Decisions

The primary path returns `getConnection()`, what the dead `slot >= 0` ternary was for (`getSlot` never returns -1). The replica path picks from the replicas the slot cache recorded, which it does only with `readOnlyForRedisClusterReplicas` on. `getSlotReplicaPools` now separates the two no-replica cases: null when the client records none, empty when the slot has none yet. Neither replica path renews the cache for a result the renewal cannot change, and the keyed one no longer throws `NullPointerException`.

## Testing

Unit tests cover keyless and keyed routing, both fallbacks and disabled tracking; each new one fails without its fix. 3306 tests, release note updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Redis Cluster connection selection for keyless and replica reads; fixes exceptions but alters which node handles those commands.
> 
> **Overview**
> Fixes cluster routing when a command has **no key** (`PING`, `INFO`, etc.). `ClusterConnectionProvider` previously called `slots.iterator().next()` on an empty hash-slot set and threw **`NoSuchElementException`** before opening a connection.
> 
> **Primary path:** empty slots now use **`getConnection()`** (any reachable primary). **Replica path:** keyless commands use a random recorded replica via new **`getAnyReplicaConnection()`**, or fall back to a primary when the topology has no replicas.
> 
> **Replica tracking:** `JedisClusterInfoCache.getSlotReplicaPools(int)` now distinguishes clients that **do not record replicas** (`null` when `readOnlyForRedisClusterReplicas` is off) from slots with **no replica known yet** (empty list). Keyed replica routing skips **`renewSlotCache()`** when renewal cannot add replicas, avoiding **`NullPointerException`** and repeated topology refresh on keyless replica calls. A **`replicaNodesCache`** and public **`getReplicaNodes()`** support picking any replica for keyless replica commands.
> 
> Release notes for 8.1.0 document the behavior change; unit and integration tests cover cache semantics and routing fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2a81f91395d4acbcfac593c907bdcc14fba261d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->