### PR TITLE
Stabilize search-on-timeout FAIL tests against worker-thread race

### DIFF
--- a/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
@@ -1561,11 +1561,14 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
   }
 
   /**
-   * Number of documents indexed by the on-timeout tests. Large enough that scanning, scoring and
-   * sorting them cannot complete within the 1ms per-query timeout, so the query engine's on-timeout
-   * policy is guaranteed to kick in.
+   * Number of documents indexed by the on-timeout tests. With {@code search-workers > 0} the
+   * {@code FAIL} policy is enforced by a blocked-client timeout callback racing the worker thread
+   * that runs the query: the error is only returned when the callback wins, so a query that only
+   * slightly overruns its timeout may still return full results (intended server behavior). The
+   * query runtime must therefore exceed the 1ms per-query timeout by a wide margin — outcomes were
+   * measured flaky below ~10x, while 100k documents keep the margin around ~200x.
    */
-  private static final int ON_TIMEOUT_DOC_COUNT = 10_000;
+  private static final int ON_TIMEOUT_DOC_COUNT = 100_000;
 
   private void populateOnTimeoutIndex() {
     assertOK(jedis.ftCreate(INDEX, FTCreateParams.createParams(), TextField.of("title"),

--- a/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
@@ -1566,8 +1566,8 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
    * that runs the query: the error is only returned when the callback wins, so a query that only
    * slightly overruns its timeout may still return full results (intended server behavior). The
    * query runtime must therefore exceed the 1ms per-query timeout by a wide margin — outcomes were
-   * measured flaky below ~10x, while 100k documents keep the margin around ~200x.
-   * Relevant tests are filtered for earlier Redis versions( <8.10.0) with the message "search-on-timeout policy".
+   * measured flaky below ~10x, while 100k documents keep the margin around ~200x. Relevant tests
+   * are filtered for earlier Redis versions( <8.10.0) with the message "search-on-timeout policy".
    */
   private static final int ON_TIMEOUT_DOC_COUNT = 100_000;
 

--- a/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
+++ b/src/test/java/redis/clients/jedis/commands/unified/search/SearchWithParamsCommandsTestBase.java
@@ -1567,6 +1567,7 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
    * slightly overruns its timeout may still return full results (intended server behavior). The
    * query runtime must therefore exceed the 1ms per-query timeout by a wide margin — outcomes were
    * measured flaky below ~10x, while 100k documents keep the margin around ~200x.
+   * Relevant tests are filtered for earlier Redis versions( <8.10.0) with the message "search-on-timeout policy".
    */
   private static final int ON_TIMEOUT_DOC_COUNT = 100_000;
 
@@ -1601,6 +1602,7 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
    * not be automatically retried. See CAE-3003 (initiative RED-132340: "Timeout guardrails").
    */
   @Test
+  @SinceRedisVersion(value = "8.10.0", message = "search-on-timeout policy")
   public void searchOnTimeoutFailReturnsError() {
     assumeTrue(RedisConditions.of(jedis).moduleVersionIsGreaterThanOrEqual(SEARCH_MOD_VER_810M3),
       "ON_TIMEOUT FAIL policy");
@@ -1628,6 +1630,7 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
    * FT.SEARCH, so this is asserted on RESP3 only. See CAE-3003.
    */
   @Test
+  @SinceRedisVersion(value = "8.10.0", message = "search-on-timeout policy")
   public void searchOnTimeoutReturnPopulatesWarnings() {
     assumeTrue(RedisConditions.of(jedis).moduleVersionIsGreaterThanOrEqual(SEARCH_MOD_VER_810M3),
       "ON_TIMEOUT RETURN warnings");
@@ -1663,6 +1666,7 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
    * on-timeout policy must surface a server error rather than partial results. See CAE-3003.
    */
   @Test
+  @SinceRedisVersion(value = "8.10.0", message = "search-on-timeout policy")
   public void aggregateOnTimeoutFailReturnsError() {
     assumeTrue(RedisConditions.of(jedis).moduleVersionIsGreaterThanOrEqual(SEARCH_MOD_VER_810M3),
       "ON_TIMEOUT FAIL policy");
@@ -1686,6 +1690,7 @@ public abstract class SearchWithParamsCommandsTestBase extends UnifiedJedisComma
    * See CAE-3003.
    */
   @Test
+  @SinceRedisVersion(value = "8.10.0", message = "search-on-timeout policy")
   public void aggregateOnTimeoutReturnPopulatesWarnings() {
     assumeTrue(RedisConditions.of(jedis).moduleVersionIsGreaterThanOrEqual(SEARCH_MOD_VER_810M3),
       "ON_TIMEOUT RETURN warnings");


### PR DESCRIPTION
## Summary
The `searchOnTimeoutFailReturnsError` / `aggregateOnTimeoutFailReturnsError` tests [fail nightly against Redis unstable](https://github.com/redis-developer/redis-oss-release-automation/actions/runs/33448618352/job/99673236515) since 2026-08-27. As of RediSearch/RediSearch#10961, the `FAIL` on-timeout policy is enforced by a blocked-client timeout callback racing the worker thread running the query — confirmed as intended behavior in [RediSearch#11274](https://github.com/RediSearch/RediSearch/issues/11274): when the worker wins, an over-budget query returns full results instead of an error. With 10k documents the query overran the 1ms timeout by only a few milliseconds, leaving the outcome to scheduling jitter. Raising `ON_TIMEOUT_DOC_COUNT` to 100k gives a ~200x runtime-to-timeout margin so the callback deterministically wins.

## Key Decisions & Assumptions
- Keep testing the realistic workers-enabled path with `TIMEOUT 1`, rather than forcing `search-workers 0` (inline execution sidesteps the race).
- Flakiness was measured below ~10x margin; the constant's javadoc records this threshold.

## Testing
Test-only change, verified via redis-cli against the failing image (`unstable-33278213642-debian`): at 100k docs the FAIL error returned 50/50 (search) and 20/20 (aggregate), versus 1/10 at 10k. The shared fixture also serves the RETURN-policy warning tests, which remain valid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to document count, comments, and version filtering; no production client or runtime behavior changes.
> 
> **Overview**
> Stabilizes flaky **search-on-timeout** integration tests that assert `FAIL` vs `RETURN` behavior for `FT.SEARCH` and `FT.AGGREGATE`.
> 
> **`ON_TIMEOUT_DOC_COUNT`** is raised from **10k to 100k** so timed-out queries run far past the 1ms limit (~200× margin). With `search-workers > 0`, RediSearch’s `FAIL` policy depends on a race between the blocked-client timeout callback and the worker thread; a small overrun could still return full results, which made nightly runs flaky at 10k docs. The fixture javadoc now documents that race and the ~10× flakiness threshold.
> 
> All four on-timeout tests gain **`@SinceRedisVersion("8.10.0", message = "search-on-timeout policy")`** so they are skipped on older Redis where the unified `search-on-timeout` policy is not in scope. Existing `assumeTrue` checks on the Search module version remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28211db04e034d31bb9dabff540729b1a47dd05d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->