### PR TITLE
Discard pooled connections after aborted pub/sub loops

### DIFF
--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -62,13 +62,16 @@ pub/sub frames from a connection without going through the `JedisPubSub`/
 `getUnflushedObject()`) will no longer receive those frames; use the pub/sub APIs or
 register a custom `PushConsumer` that propagates them.
 
-### Discard connections after an aborted subscription ([#4722](https://github.com/redis/jedis/issues/4722))
+### Pooled connections are discarded after aborted subscriptions ([#4722](https://github.com/redis/jedis/issues/4722))
+
+An exception in a pub/sub callback or an interrupted subscription loop could
+return a still-subscribed connection to the pool, allowing another caller to
+reuse it.
 
 `subscribe`, `psubscribe`, and sharded `ssubscribe` now mark the connection broken
-if the subscription loop throws or returns while still subscribed, including
-when the listener thread is interrupted. Pooled clients discard that connection
-instead of returning it to the pool for another caller. This also applies to
-`JedisCluster` and `RedisClusterClient`. Normal unsubscription still allows reuse.
+if the subscription loop throws or returns while still subscribed. Pooled clients
+discard it instead of reusing it. This also applies to `JedisCluster` and
+`RedisClusterClient`. Normal unsubscription still allows reuse.
 
 **Action required:** none. Callback exceptions and the thread's interrupt status
 are preserved. This does not change how interruption affects a blocking socket

--- a/docs/release-notes/8.1.0.md
+++ b/docs/release-notes/8.1.0.md
@@ -61,3 +61,15 @@ pub/sub frames from a connection without going through the `JedisPubSub`/
 `JedisShardedPubSub` loops (e.g. hand-rolled `sendCommand(SUBSCRIBE)` +
 `getUnflushedObject()`) will no longer receive those frames; use the pub/sub APIs or
 register a custom `PushConsumer` that propagates them.
+
+### Discard connections after an aborted subscription ([#4722](https://github.com/redis/jedis/issues/4722))
+
+`subscribe`, `psubscribe`, and sharded `ssubscribe` now mark the connection broken
+if the subscription loop throws or returns while still subscribed, including
+when the listener thread is interrupted. Pooled clients discard that connection
+instead of returning it to the pool for another caller. This also applies to
+`JedisCluster` and `RedisClusterClient`. Normal unsubscription still allows reuse.
+
+**Action required:** none. Callback exceptions and the thread's interrupt status
+are preserved. This does not change how interruption affects a blocking socket
+read or detach the subscriber from its connection after the loop exits.

--- a/src/main/java/redis/clients/jedis/JedisPubSubBase.java
+++ b/src/main/java/redis/clients/jedis/JedisPubSubBase.java
@@ -107,10 +107,15 @@ public abstract class JedisPubSubBase<T> {
     authenticator.registerForAuthentication(client);
     authenticator.client.setTimeoutInfinite();
     authenticator.client.setActiveSubscription(true);
+    boolean completed = false;
     try {
       subscribe(channels);
       process();
+      completed = true;
     } finally {
+      if (!completed || isSubscribed()) {
+        authenticator.client.setBroken();
+      }
       authenticator.client.setActiveSubscription(false);
       authenticator.client.rollbackTimeout();
     }
@@ -120,10 +125,15 @@ public abstract class JedisPubSubBase<T> {
     authenticator.registerForAuthentication(client);
     authenticator.client.setTimeoutInfinite();
     authenticator.client.setActiveSubscription(true);
+    boolean completed = false;
     try {
       psubscribe(patterns);
       process();
+      completed = true;
     } finally {
+      if (!completed || isSubscribed()) {
+        authenticator.client.setBroken();
+      }
       authenticator.client.setActiveSubscription(false);
       authenticator.client.rollbackTimeout();
     }

--- a/src/main/java/redis/clients/jedis/JedisShardedPubSubBase.java
+++ b/src/main/java/redis/clients/jedis/JedisShardedPubSubBase.java
@@ -61,10 +61,15 @@ public abstract class JedisShardedPubSubBase<T> {
     authenticator.registerForAuthentication(client);
     authenticator.client.setTimeoutInfinite();
     authenticator.client.setActiveSubscription(true);
+    boolean completed = false;
     try {
       ssubscribe(channels);
       process();
+      completed = true;
     } finally {
+      if (!completed || isSubscribed()) {
+        authenticator.client.setBroken();
+      }
       authenticator.client.setActiveSubscription(false);
       authenticator.client.rollbackTimeout();
     }

--- a/src/test/java/redis/clients/jedis/JedisPubSubConnectionCleanupIT.java
+++ b/src/test/java/redis/clients/jedis/JedisPubSubConnectionCleanupIT.java
@@ -1,0 +1,232 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import redis.clients.jedis.Protocol.Command;
+import redis.clients.jedis.providers.ClusterConnectionProvider;
+import redis.clients.jedis.providers.ConnectionProvider;
+import redis.clients.jedis.providers.PooledConnectionProvider;
+import redis.clients.jedis.util.JedisClusterCRC16;
+
+public class JedisPubSubConnectionCleanupIT {
+
+  private enum SubscriptionType {
+    SUBSCRIBE, PSUBSCRIBE, SSUBSCRIBE, LEGACY_SSUBSCRIBE;
+
+    boolean isSharded() {
+      return this == SSUBSCRIBE || this == LEGACY_SSUBSCRIBE;
+    }
+  }
+
+  private enum ExitMode {
+    CALLBACK_FAILURE, INTERRUPT, UNSUBSCRIBE
+  }
+
+  private static Stream<Arguments> subscriptions() {
+    return Arrays.stream(SubscriptionType.values())
+        .flatMap(type -> Stream.of(RedisProtocol.RESP2, RedisProtocol.RESP3)
+            .map(protocol -> Arguments.of(type, protocol)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("subscriptions")
+  public void discardsConnectionAfterCallbackFailure(SubscriptionType type, RedisProtocol protocol)
+      throws Exception {
+    assertCleanup(type, protocol, ExitMode.CALLBACK_FAILURE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("subscriptions")
+  public void discardsConnectionAfterInterruptedCallback(SubscriptionType type,
+      RedisProtocol protocol) throws Exception {
+    assertCleanup(type, protocol, ExitMode.INTERRUPT);
+  }
+
+  @ParameterizedTest
+  @MethodSource("subscriptions")
+  public void reusesConnectionAfterUnsubscribeConfirmation(SubscriptionType type,
+      RedisProtocol protocol) throws Exception {
+    assertCleanup(type, protocol, ExitMode.UNSUBSCRIBE);
+  }
+
+  private void assertCleanup(SubscriptionType type, RedisProtocol protocol, ExitMode exit)
+      throws Exception {
+    EndpointConfig endpoint = Endpoints
+        .getRedisEndpoint(type.isSharded() ? "cluster-stable" : "standalone0");
+    JedisClientConfig config = endpoint.getClientConfigBuilder().protocol(protocol)
+        .connectionTimeoutMillis(2000).socketTimeoutMillis(2000).build();
+    ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
+    poolConfig.setMaxTotal(1);
+    poolConfig.setMaxIdle(1);
+    poolConfig.setMinIdle(0);
+    // Pool validation must not hide a connection returned in subscriber mode.
+    poolConfig.setTestOnBorrow(false);
+    poolConfig.setTestOnReturn(false);
+    poolConfig.setTestWhileIdle(false);
+
+    ConnectionProvider provider = type.isSharded()
+        ? new ClusterConnectionProvider(new HashSet<>(endpoint.getHostsAndPorts()), config,
+            poolConfig)
+        : new PooledConnectionProvider(endpoint.getHostAndPort(), config, poolConfig);
+
+    try (UnifiedJedis client = createClient(type, endpoint, config, provider)) {
+      String channel = "jedis-4722-" + UUID.randomUUID();
+      Connection original;
+      try (Connection connection = borrow(provider, type, channel)) {
+        assertEquals(protocol, connection.getRedisProtocol());
+        original = connection;
+      }
+
+      CountDownLatch subscribed = new CountDownLatch(1);
+      RuntimeException failure = new IllegalStateException("callback failed");
+      AtomicReference<Throwable> thrown = new AtomicReference<>();
+      AtomicBoolean interrupted = new AtomicBoolean();
+      Runnable subscription = subscription(type, client, channel, subscribed, exit, failure);
+      Thread listener = new Thread(() -> {
+        try {
+          subscription.run();
+        } catch (Throwable t) {
+          thrown.set(t);
+        } finally {
+          interrupted.set(Thread.currentThread().isInterrupted());
+        }
+      }, "jedis-pubsub-cleanup");
+      listener.setDaemon(true);
+
+      try (Jedis publisher = new Jedis(original.getHostAndPort(), config)) {
+        listener.start();
+        try {
+          assertTrue(subscribed.await(5, TimeUnit.SECONDS), "listener did not subscribe");
+          Command publish = type.isSharded() ? Command.SPUBLISH : Command.PUBLISH;
+          long receivers = (Long) publisher.sendCommand(publish, channel, "message");
+          assertEquals(1L, receivers);
+          listener.join(5000);
+          assertFalse(listener.isAlive(), "listener did not exit");
+          if (exit == ExitMode.CALLBACK_FAILURE) {
+            assertSame(failure, thrown.get());
+          } else {
+            assertNull(thrown.get());
+          }
+          assertEquals(exit == ExitMode.INTERRUPT, interrupted.get());
+
+          // A unique key on the channel's slot also exercises the next borrower's read path.
+          assertNull(client.get(channel));
+          try (Connection next = borrow(provider, type, channel)) {
+            if (exit == ExitMode.UNSUBSCRIBE) {
+              assertSame(original, next);
+            } else {
+              assertNotSame(original, next);
+              assertTrue(original.isBroken());
+            }
+            assertFalse(next.isBroken());
+            assertFalse(next.isActiveSubscription());
+          }
+          assertNull(client.get(channel));
+        } finally {
+          if (listener.isAlive()) {
+            // Interrupt alone cannot unblock a socket read after a failed assertion.
+            original.forceDisconnect();
+            listener.join(5000);
+          }
+        }
+      }
+    }
+  }
+
+  private UnifiedJedis createClient(SubscriptionType type, EndpointConfig endpoint,
+      JedisClientConfig config, ConnectionProvider provider) {
+    if (type == SubscriptionType.LEGACY_SSUBSCRIBE) {
+      return new JedisCluster((ClusterConnectionProvider) provider, 1, Duration.ofSeconds(2));
+    }
+    if (type == SubscriptionType.SSUBSCRIBE) {
+      return RedisClusterClient.builder().nodes(new HashSet<>(endpoint.getHostsAndPorts()))
+          .clientConfig(config).connectionProvider(provider).maxAttempts(1).build();
+    }
+    return new UnifiedJedis(provider, config.getRedisProtocol());
+  }
+
+  private Connection borrow(ConnectionProvider provider, SubscriptionType type, String channel) {
+    return type.isSharded()
+        ? ((ClusterConnectionProvider) provider)
+            .getConnectionFromSlot(JedisClusterCRC16.getSlot(channel))
+        : provider.getConnection();
+  }
+
+  private Runnable subscription(SubscriptionType type, UnifiedJedis client, String channel,
+      CountDownLatch subscribed, ExitMode exit, RuntimeException failure) {
+    if (type.isSharded()) {
+      JedisShardedPubSub pubSub = new JedisShardedPubSub() {
+        @Override
+        public void onSSubscribe(String channel, int subscribedChannels) {
+          subscribed.countDown();
+        }
+
+        @Override
+        public void onSMessage(String channel, String message) {
+          exit(exit, failure, this::sunsubscribe);
+        }
+      };
+      return type == SubscriptionType.LEGACY_SSUBSCRIBE
+          ? () -> ((JedisCluster) client).ssubscribe(pubSub, channel)
+          : () -> ((RedisClusterClient) client).ssubscribe(pubSub, channel);
+    }
+
+    JedisPubSub pubSub = new JedisPubSub() {
+      @Override
+      public void onSubscribe(String channel, int subscribedChannels) {
+        subscribed.countDown();
+      }
+
+      @Override
+      public void onPSubscribe(String pattern, int subscribedChannels) {
+        subscribed.countDown();
+      }
+
+      @Override
+      public void onMessage(String channel, String message) {
+        exit(exit, failure, this::unsubscribe);
+      }
+
+      @Override
+      public void onPMessage(String pattern, String channel, String message) {
+        exit(exit, failure, this::punsubscribe);
+      }
+    };
+    return type == SubscriptionType.PSUBSCRIBE ? () -> client.psubscribe(pubSub, channel + "*")
+        : () -> client.subscribe(pubSub, channel);
+  }
+
+  private void exit(ExitMode exit, RuntimeException failure, Runnable unsubscribe) {
+    switch (exit) {
+      case CALLBACK_FAILURE:
+        throw failure;
+      case INTERRUPT:
+        Thread.currentThread().interrupt();
+        break;
+      case UNSUBSCRIBE:
+        unsubscribe.run();
+        break;
+      default:
+        throw new AssertionError(exit);
+    }
+  }
+}

--- a/src/test/java/redis/clients/jedis/JedisPubSubConnectionCleanupTest.java
+++ b/src/test/java/redis/clients/jedis/JedisPubSubConnectionCleanupTest.java
@@ -1,0 +1,200 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import redis.clients.jedis.Protocol.ResponseKeyword;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.providers.ConnectionProvider;
+import redis.clients.jedis.util.SafeEncoder;
+
+public class JedisPubSubConnectionCleanupTest {
+
+  private Connection connection;
+  private ConnectionPool pool;
+  private UnifiedJedis jedis;
+
+  @BeforeEach
+  public void setUp() {
+    // Keep the real broken flag and close() routing; stub only socket operations.
+    connection = spy(new Connection());
+    doNothing().when(connection).setTimeoutInfinite();
+    doNothing().when(connection).rollbackTimeout();
+    doNothing().when(connection).sendCommand(any(CommandArguments.class));
+    doNothing().when(connection).flush();
+    pool = mock(ConnectionPool.class);
+    connection.setHandlingPool(pool);
+    ConnectionProvider provider = mock(ConnectionProvider.class);
+    when(provider.getConnection()).thenReturn(connection);
+    jedis = new UnifiedJedis(provider, RedisProtocol.RESP2);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenMessageCallbackThrows(boolean patterns) {
+    RuntimeException failure = new IllegalStateException("callback failed");
+    JedisPubSub pubSub = messageCallback(() -> {
+      throw failure;
+    });
+    doReturn(subscriptionReply(patterns, 1), messageReply(patterns)).when(connection)
+        .getUnflushedObject();
+
+    assertSame(failure,
+      assertThrows(IllegalStateException.class, () -> subscribe(pubSub, patterns)));
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenMessageCallbackThrowsError(boolean patterns) {
+    Error failure = new AssertionError("callback failed");
+    JedisPubSub pubSub = messageCallback(() -> {
+      throw failure;
+    });
+    doReturn(subscriptionReply(patterns, 1), messageReply(patterns)).when(connection)
+        .getUnflushedObject();
+
+    assertSame(failure, assertThrows(AssertionError.class, () -> subscribe(pubSub, patterns)));
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenReadFailsBeforeSubscriptionReply(boolean patterns) {
+    JedisDataException failure = new JedisDataException("subscription failed");
+    doThrow(failure).when(connection).getUnflushedObject();
+    JedisPubSub pubSub = new JedisPubSub() {
+    };
+
+    assertSame(failure, assertThrows(JedisDataException.class, () -> subscribe(pubSub, patterns)));
+    assertFalse(pubSub.isSubscribed());
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenMessageTypeIsUnknown(boolean patterns) {
+    doReturn(subscriptionReply(patterns, 1),
+      Collections.singletonList(SafeEncoder.encode("unknown"))).when(connection)
+          .getUnflushedObject();
+
+    assertThrows(JedisException.class, () -> subscribe(new JedisPubSub() {
+    }, patterns));
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenInterruptedWhileSubscribed(boolean patterns) {
+    JedisPubSub pubSub = new JedisPubSub() {
+      @Override
+      public void onSubscribe(String channel, int subscribedChannels) {
+        Thread.currentThread().interrupt();
+      }
+
+      @Override
+      public void onPSubscribe(String pattern, int subscribedChannels) {
+        Thread.currentThread().interrupt();
+      }
+    };
+    doReturn(subscriptionReply(patterns, 1)).when(connection).getUnflushedObject();
+
+    try {
+      subscribe(pubSub, patterns);
+      assertTrue(Thread.currentThread().isInterrupted());
+      assertTrue(pubSub.isSubscribed());
+      assertDiscarded();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void returnsConnectionAfterUnsubscribeConfirmation(boolean patterns) {
+    JedisPubSub pubSub = new JedisPubSub() {
+    };
+    doReturn(subscriptionReply(patterns, 1), subscriptionReply(patterns, 0)).when(connection)
+        .getUnflushedObject();
+
+    subscribe(pubSub, patterns);
+
+    assertFalse(pubSub.isSubscribed());
+    assertFalse(connection.isBroken());
+    assertFalse(connection.isActiveSubscription());
+    verify(connection).rollbackTimeout();
+    verify(pool).returnResource(connection);
+    verify(pool, never()).returnBrokenResource(connection);
+  }
+
+  private void subscribe(JedisPubSub pubSub, boolean patterns) {
+    if (patterns) {
+      jedis.psubscribe(pubSub, "channel*");
+    } else {
+      jedis.subscribe(pubSub, "channel");
+    }
+  }
+
+  private void assertDiscarded() {
+    assertTrue(connection.isBroken());
+    assertFalse(connection.isActiveSubscription());
+    verify(connection).rollbackTimeout();
+    verify(pool).returnBrokenResource(connection);
+    verify(pool, never()).returnResource(connection);
+  }
+
+  private static JedisPubSub messageCallback(Runnable callback) {
+    return new JedisPubSub() {
+      @Override
+      public void onMessage(String channel, String message) {
+        callback.run();
+      }
+
+      @Override
+      public void onPMessage(String pattern, String channel, String message) {
+        callback.run();
+      }
+    };
+  }
+
+  private static List<Object> subscriptionReply(boolean patterns, int count) {
+    ResponseKeyword keyword = patterns
+        ? (count == 0 ? ResponseKeyword.PUNSUBSCRIBE : ResponseKeyword.PSUBSCRIBE)
+        : (count == 0 ? ResponseKeyword.UNSUBSCRIBE : ResponseKeyword.SUBSCRIBE);
+    return Arrays.asList(keyword.getRaw(), SafeEncoder.encode(patterns ? "channel*" : "channel"),
+      (long) count);
+  }
+
+  private static List<Object> messageReply(boolean patterns) {
+    if (patterns) {
+      return Arrays.asList(ResponseKeyword.PMESSAGE.getRaw(), SafeEncoder.encode("channel*"),
+        SafeEncoder.encode("channel"), SafeEncoder.encode("message"));
+    }
+    return Arrays.asList(ResponseKeyword.MESSAGE.getRaw(), SafeEncoder.encode("channel"),
+      SafeEncoder.encode("message"));
+  }
+}

--- a/src/test/java/redis/clients/jedis/JedisShardedPubSubConnectionCleanupTest.java
+++ b/src/test/java/redis/clients/jedis/JedisShardedPubSubConnectionCleanupTest.java
@@ -1,0 +1,218 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import redis.clients.jedis.Protocol.ResponseKeyword;
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.providers.ClusterConnectionProvider;
+import redis.clients.jedis.util.JedisClusterCRC16;
+import redis.clients.jedis.util.SafeEncoder;
+
+public class JedisShardedPubSubConnectionCleanupTest {
+
+  private Connection connection;
+  private ConnectionPool pool;
+  private ClusterConnectionProvider provider;
+
+  @BeforeEach
+  public void setUp() {
+    // Keep the real broken flag and close() routing; stub only socket operations.
+    connection = spy(new Connection());
+    doNothing().when(connection).setTimeoutInfinite();
+    doNothing().when(connection).rollbackTimeout();
+    doNothing().when(connection).sendCommand(any(CommandArguments.class));
+    doNothing().when(connection).flush();
+    pool = mock(ConnectionPool.class);
+    connection.setHandlingPool(pool);
+    provider = mock(ClusterConnectionProvider.class);
+    when(provider.getConnectionFromSlot(JedisClusterCRC16.getSlot("channel")))
+        .thenReturn(connection);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenMessageCallbackThrows(boolean legacy) {
+    RuntimeException failure = new IllegalStateException("callback failed");
+    JedisShardedPubSub pubSub = messageCallback(() -> {
+      throw failure;
+    });
+    doReturn(subscriptionReply(1), messageReply()).when(connection).getUnflushedObject();
+
+    assertSame(failure, assertThrows(IllegalStateException.class, () -> subscribe(pubSub, legacy)));
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenMessageCallbackThrowsError(boolean legacy) {
+    Error failure = new AssertionError("callback failed");
+    JedisShardedPubSub pubSub = messageCallback(() -> {
+      throw failure;
+    });
+    doReturn(subscriptionReply(1), messageReply()).when(connection).getUnflushedObject();
+
+    assertSame(failure, assertThrows(AssertionError.class, () -> subscribe(pubSub, legacy)));
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenReadFailsBeforeSubscriptionReply(boolean legacy) {
+    JedisDataException failure = new JedisDataException("subscription failed");
+    doThrow(failure).when(connection).getUnflushedObject();
+    JedisShardedPubSub pubSub = new JedisShardedPubSub() {
+    };
+
+    assertSame(failure, assertThrows(JedisDataException.class, () -> subscribe(pubSub, legacy)));
+    assertFalse(pubSub.isSubscribed());
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenMessageTypeIsUnknown(boolean legacy) {
+    doReturn(subscriptionReply(1), Collections.singletonList(SafeEncoder.encode("unknown")))
+        .when(connection).getUnflushedObject();
+
+    assertThrows(JedisException.class, () -> subscribe(new JedisShardedPubSub() {
+    }, legacy));
+
+    assertDiscarded();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenInterruptedWhileSubscribed(boolean legacy) {
+    JedisShardedPubSub pubSub = new JedisShardedPubSub() {
+      @Override
+      public void onSSubscribe(String channel, int subscribedChannels) {
+        Thread.currentThread().interrupt();
+      }
+    };
+    doReturn(subscriptionReply(1)).when(connection).getUnflushedObject();
+
+    try {
+      subscribe(pubSub, legacy);
+      assertTrue(Thread.currentThread().isInterrupted());
+      assertTrue(pubSub.isSubscribed());
+      assertDiscarded();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void returnsConnectionAfterUnsubscribeConfirmation(boolean legacy) {
+    doReturn(subscriptionReply(1), subscriptionReply(0)).when(connection).getUnflushedObject();
+    JedisShardedPubSub pubSub = new JedisShardedPubSub() {
+    };
+
+    subscribe(pubSub, legacy);
+
+    assertFalse(pubSub.isSubscribed());
+    assertFalse(connection.isBroken());
+    assertFalse(connection.isActiveSubscription());
+    verify(connection).rollbackTimeout();
+    verify(pool).returnResource(connection);
+    verify(pool, never()).returnBrokenResource(connection);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = { false, true })
+  public void discardsConnectionWhenBinaryMessageCallbackThrows(boolean legacy) {
+    RuntimeException failure = new IllegalStateException("binary callback failed");
+    BinaryJedisShardedPubSub pubSub = new BinaryJedisShardedPubSub() {
+      @Override
+      public void onSMessage(byte[] channel, byte[] message) {
+        throw failure;
+      }
+    };
+    doReturn(subscriptionReply(1), messageReply()).when(connection).getUnflushedObject();
+
+    assertSame(failure, assertThrows(IllegalStateException.class, () -> {
+      if (legacy) {
+        try (JedisCluster client = new JedisCluster(provider, 1, Duration.ofSeconds(1))) {
+          client.ssubscribe(pubSub, SafeEncoder.encode("channel"));
+        }
+      } else {
+        try (RedisClusterClient client = clusterClient()) {
+          client.ssubscribe(pubSub, SafeEncoder.encode("channel"));
+        }
+      }
+    }));
+
+    assertDiscarded();
+  }
+
+  private void subscribe(JedisShardedPubSub pubSub, boolean legacy) {
+    if (legacy) {
+      try (JedisCluster client = new JedisCluster(provider, 1, Duration.ofSeconds(1))) {
+        client.ssubscribe(pubSub, "channel");
+      }
+    } else {
+      try (RedisClusterClient client = clusterClient()) {
+        client.ssubscribe(pubSub, "channel");
+      }
+    }
+  }
+
+  private RedisClusterClient clusterClient() {
+    return RedisClusterClient.builder()
+        .nodes(Collections.singleton(new HostAndPort("localhost", 6379)))
+        .connectionProvider(provider).build();
+  }
+
+  private void assertDiscarded() {
+    assertTrue(connection.isBroken());
+    assertFalse(connection.isActiveSubscription());
+    verify(connection).rollbackTimeout();
+    verify(pool).returnBrokenResource(connection);
+    verify(pool, never()).returnResource(connection);
+  }
+
+  private static JedisShardedPubSub messageCallback(Runnable callback) {
+    return new JedisShardedPubSub() {
+      @Override
+      public void onSMessage(String channel, String message) {
+        callback.run();
+      }
+    };
+  }
+
+  private static List<Object> subscriptionReply(int count) {
+    ResponseKeyword keyword = count == 0 ? ResponseKeyword.SUNSUBSCRIBE
+        : ResponseKeyword.SSUBSCRIBE;
+    return Arrays.asList(keyword.getRaw(), SafeEncoder.encode("channel"), (long) count);
+  }
+
+  private static List<Object> messageReply() {
+    return Arrays.asList(ResponseKeyword.SMESSAGE.getRaw(), SafeEncoder.encode("channel"),
+      SafeEncoder.encode("message"));
+  }
+}


### PR DESCRIPTION
Refs #4722.

Implements the pooled-connection cleanup suggested in the issue for `subscribe`, `psubscribe`, and `ssubscribe`, including both `JedisCluster` and `RedisClusterClient`.

Mark the connection broken if the subscription call aborts or returns while still subscribed. Normal unsubscription still allows reuse. This is conservative: a fully parsed server error also causes the connection to be discarded if the call aborts.

The regression tests cover callback exceptions and errors, unknown replies, failures before the first subscription reply, interrupted listeners, and normal unsubscribe cleanup. The integration tests use a single-connection pool and check both the next GET and whether the original connection was replaced.

Validation on Corretto 8:

- Targeted unit tests: 28 passed.
- Redis 8.6.1 integration tests: 24 passed across RESP2/RESP3, using standalone and a three-primary-node cluster.
- Full unit suite: 3,449 tests, no failures or errors, 7 skipped.
- Formatter validation and `git diff --check` passed.
- The full Docker version matrix, TLS, and failover tests were not run locally.

Connection detachment, authentication-hook teardown, and interruption of blocking socket reads remain outside this patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection lifecycle for all pub/sub subscription paths; pooled clients are safer but may discard connections more often after listener errors or interrupts.
> 
> **Overview**
> Fixes a pool safety bug where pub/sub connections could be returned while still in subscriber mode after a callback exception, interrupt, or other aborted read loop.
> 
> **`JedisPubSubBase` and `JedisShardedPubSubBase`** now wrap the subscription `process()` loop in `try`/`finally` and call `setBroken()` when the loop does not finish cleanly or exits while `isSubscribed()` is still true. Pooled clients then discard the connection via `returnBrokenResource` instead of reusing it; a normal unsubscribe confirmation leaves the connection healthy. The same marking applies to non-pooled `Jedis`, which rejects later commands until the instance is closed.
> 
> Release notes for 8.1.0 document the behavior change ([#4722](https://github.com/redis/jedis/issues/4722)). New unit and integration tests cover callback failures, interrupts, unknown replies, early read failures, and successful unsubscribe across `subscribe`/`psubscribe`/`ssubscribe` (standalone, `JedisCluster`, `RedisClusterClient`, RESP2/RESP3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955f8c88abe91928fe41bdcda62d168e9b358b30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->