### PR TITLE
[maintenance events - cluster] Decode SMIGRATING/SMIGRATED cluster maintenance pushes into events

### DIFF
--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
@@ -8,21 +8,10 @@ import java.util.List;
  * {@link MaintenanceEvent}: the two message families are exclusive contracts — a connection
  * receives one family or the other, never both.
  */
-abstract class ClusterMaintenanceEvent {
-
-  final long seq;
+abstract class ClusterMaintenanceEvent extends MaintenanceEvent {
 
   ClusterMaintenanceEvent(long seq) {
-    this.seq = seq;
-  }
-
-  /**
-   * Identity of the server-side operation this event announces; SMIGRATING and its terminating
-   * SMIGRATED share the same seq, and equality is the dedup rule for folding the per-node broadcast
-   * into one client-wide operation.
-   */
-  Object identity() {
-    return seq;
+    super(seq);
   }
 }
 
@@ -37,6 +26,12 @@ final class SMigratingEvent extends ClusterMaintenanceEvent {
     super(seq);
     this.slots = slots;
   }
+
+  @Override
+  void accept(MaintenanceEventListener listener, Connection conn) {
+    listener.onSMigrating(this, conn);
+  }
+
 }
 
 /**
@@ -49,6 +44,11 @@ final class SMigratedEvent extends ClusterMaintenanceEvent {
   SMigratedEvent(long seq, List<SlotMigration> migrations) {
     super(seq);
     this.migrations = Collections.unmodifiableList(migrations);
+  }
+
+  @Override
+  void accept(MaintenanceEventListener listener, Connection conn) {
+    listener.onSMigrated(this, conn);
   }
 }
 

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
@@ -1,0 +1,71 @@
+package redis.clients.jedis;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A cluster maintenance event (OSS cluster mode). A hierarchy deliberately separate from
+ * {@link MaintenanceEvent}: the two message families are exclusive contracts — a connection
+ * receives one family or the other, never both.
+ */
+abstract class ClusterMaintenanceEvent {
+
+  final long seq;
+
+  ClusterMaintenanceEvent(long seq) {
+    this.seq = seq;
+  }
+
+  /**
+   * Identity of the server-side operation this event announces; SMIGRATING and its terminating
+   * SMIGRATED share the same seq, and equality is the dedup rule for folding the per-node broadcast
+   * into one client-wide operation.
+   */
+  Object identity() {
+    return seq;
+  }
+}
+
+/**
+ * {@code [SMIGRATING, seq, slots-or-ranges]} — a slot migration is starting; relax timeouts until
+ * the SMIGRATED with the same seq.
+ */
+final class SMigratingEvent extends ClusterMaintenanceEvent {
+  final HashSlotRanges slots;
+
+  SMigratingEvent(long seq, HashSlotRanges slots) {
+    super(seq);
+    this.slots = slots;
+  }
+}
+
+/**
+ * {@code [SMIGRATED, seq, [[src, dest, slots-or-ranges], ...]]} — the migration ended; unrelax,
+ * apply the slot delta, and retire connections to nodes left without slots.
+ */
+final class SMigratedEvent extends ClusterMaintenanceEvent {
+  final List<SlotMigration> migrations;
+
+  SMigratedEvent(long seq, List<SlotMigration> migrations) {
+    super(seq);
+    this.migrations = Collections.unmodifiableList(migrations);
+  }
+}
+
+/** One SMIGRATED entry: the given slots moved from {@code src} to {@code dest}. */
+final class SlotMigration {
+  final HostAndPort src;
+  final HostAndPort dest;
+  final HashSlotRanges slots;
+
+  SlotMigration(HostAndPort src, HostAndPort dest, HashSlotRanges slots) {
+    this.src = src;
+    this.dest = dest;
+    this.slots = slots;
+  }
+
+  @Override
+  public String toString() {
+    return src + " -> " + dest + " [" + slots + "]";
+  }
+}

--- a/src/main/java/redis/clients/jedis/HashSlotRanges.java
+++ b/src/main/java/redis/clients/jedis/HashSlotRanges.java
@@ -1,0 +1,84 @@
+package redis.clients.jedis;
+
+import java.util.function.IntConsumer;
+
+/**
+ * An immutable set of hash slots expressed as comma-separated slots and/or inclusive
+ * {@code from-to} ranges, e.g. {@code "123,456,789-1000"} — the slots-or-ranges wire format of
+ * cluster maintenance pushes.
+ */
+final class HashSlotRanges {
+
+  /** Inclusive bounds, flattened as {@code [from0, to0, from1, to1, ...]} in wire order. */
+  private final int[] bounds;
+  private final String source;
+
+  private HashSlotRanges(int[] bounds, String source) {
+    this.bounds = bounds;
+    this.source = source;
+  }
+
+  /**
+   * Parses the slots-or-ranges wire format.
+   * @throws IllegalArgumentException on an empty string, a non-numeric token, an inverted range, or
+   *           a slot outside {@code [0, 16384)}
+   */
+  static HashSlotRanges parse(String s) {
+    if (s == null || s.isEmpty()) {
+      throw new IllegalArgumentException("Empty slot ranges");
+    }
+    String[] tokens = s.split(",");
+    int[] bounds = new int[tokens.length * 2];
+    for (int t = 0; t < tokens.length; t++) {
+      String token = tokens[t];
+      int dash = token.indexOf('-');
+      int from, to;
+      try {
+        if (dash < 0) {
+          from = to = Integer.parseInt(token);
+        } else {
+          from = Integer.parseInt(token.substring(0, dash));
+          to = Integer.parseInt(token.substring(dash + 1));
+        }
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Unparseable slot range token: " + token, e);
+      }
+      if (from < 0 || to < from || to >= Protocol.CLUSTER_HASHSLOTS) {
+        throw new IllegalArgumentException("Slot range out of bounds: " + token);
+      }
+      bounds[t * 2] = from;
+      bounds[t * 2 + 1] = to;
+    }
+    return new HashSlotRanges(bounds, s);
+  }
+
+  boolean contains(int slot) {
+    for (int i = 0; i < bounds.length; i += 2) {
+      if (slot >= bounds[i] && slot <= bounds[i + 1]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  int slotCount() {
+    int count = 0;
+    for (int i = 0; i < bounds.length; i += 2) {
+      count += bounds[i + 1] - bounds[i] + 1;
+    }
+    return count;
+  }
+
+  void forEachSlot(IntConsumer action) {
+    for (int i = 0; i < bounds.length; i += 2) {
+      for (int slot = bounds[i]; slot <= bounds[i + 1]; slot++) {
+        action.accept(slot);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return source;
+  }
+}

--- a/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis;
 
 import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +29,7 @@ final class MaintenanceEventConsumer implements PushConsumer {
     PushMessage message = context.getMessage();
     MaintenancePushCodec.PushType type = MaintenancePushCodec.PushType.resolve(message.getType());
 
-    // not a maintenance event; cluster-family frames pass through until their dispatch path
-    // (ClusterMaintenanceEventListener) is wired
+    // not a maintenance event
     if (type == null) {
       return context;
     }

--- a/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
@@ -1,7 +1,6 @@
 package redis.clients.jedis;
 
 import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +28,9 @@ final class MaintenanceEventConsumer implements PushConsumer {
     PushMessage message = context.getMessage();
     MaintenancePushCodec.PushType type = MaintenancePushCodec.PushType.resolve(message.getType());
 
-    // not a maintenance event
-    if (type == null) {
+    // not a maintenance event; cluster-family frames pass through until their dispatch path
+    // (ClusterMaintenanceEventListener) is wired
+    if (type == null || type.isCluster()) {
       return context;
     }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
@@ -30,7 +30,7 @@ final class MaintenanceEventConsumer implements PushConsumer {
 
     // not a maintenance event; cluster-family frames pass through until their dispatch path
     // (ClusterMaintenanceEventListener) is wired
-    if (type == null || type.isCluster()) {
+    if (type == null) {
       return context;
     }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -290,4 +290,16 @@ final class MaintenanceEventController
     }
     c.applyCurrentTimeout();
   }
+
+  @Override
+  public void onSMigrating(SMigratingEvent e, Connection c) {
+    logger.warn("Cluster maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
+
+  @Override
+  public void onSMigrated(SMigratedEvent e, Connection c) {
+    logger.warn("Cluster maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
 }

--- a/src/main/java/redis/clients/jedis/MaintenanceEventListener.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventListener.java
@@ -18,4 +18,8 @@ interface MaintenanceEventListener {
   void onFailingOver(FailingOverEvent e, Connection c);
 
   void onFailedOver(FailedOverEvent e, Connection c);
+
+  void onSMigrating(SMigratingEvent e, Connection c);
+
+  void onSMigrated(SMigratedEvent e, Connection c);
 }

--- a/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
+++ b/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
@@ -1,15 +1,16 @@
 package redis.clients.jedis;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-
 import redis.clients.jedis.util.SafeEncoder;
 
 /**
- * Decodes RESP3 maintenance push frames into {@link MaintenanceEvent}s — the push transport for
- * maintenance notifications. Token classification ({@link PushType#resolve}) and per-type field
- * extraction ({@link #build}) both live here.
+ * Decodes RESP3 maintenance push frames into {@link MaintenanceEvent}s or
+ * {@link ClusterMaintenanceEvent}s — the push transport for maintenance notifications. Token
+ * classification ({@link PushType#resolve}) and per-type field extraction ({@link #build},
+ * {@link #buildCluster}) both live here.
  */
 final class MaintenancePushCodec {
 
@@ -19,19 +20,36 @@ final class MaintenancePushCodec {
     MIGRATING(PushMessageTypes.MIGRATING_BYTES, MaintenancePushCodec::migrating),
     FAILING_OVER(PushMessageTypes.FAILING_OVER_BYTES, MaintenancePushCodec::failingOver),
     MIGRATED(PushMessageTypes.MIGRATED_BYTES, MaintenancePushCodec::migrated),
-    FAILED_OVER(PushMessageTypes.FAILED_OVER_BYTES, MaintenancePushCodec::failedOver);
+    FAILED_OVER(PushMessageTypes.FAILED_OVER_BYTES, MaintenancePushCodec::failedOver),
+    SMIGRATING(PushMessageTypes.SMIGRATING_BYTES, MaintenancePushCodec::sMigrating, true),
+    SMIGRATED(PushMessageTypes.SMIGRATED_BYTES, MaintenancePushCodec::sMigrated, true);
 
     private final byte[] token;
     private final Function<List<Object>, MaintenanceEvent> decoder;
+    private final Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder;
 
     PushType(byte[] token, Function<List<Object>, MaintenanceEvent> decoder) {
       this.token = token;
       this.decoder = decoder;
+      this.clusterDecoder = null;
+    }
+
+    PushType(byte[] token, Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder,
+        boolean cluster) {
+      this.token = token;
+      this.decoder = null;
+      this.clusterDecoder = clusterDecoder;
+    }
+
+    /** True for the OSS-cluster message family (decoded via {@link #buildCluster}). */
+    boolean isCluster() {
+      return clusterDecoder != null;
     }
 
     /**
      * Resolves a push type token to its maintenance type, or {@code null} when it is not a
-     * maintenance push. Length-switch fast path: rejects unrelated pushes with one comparison.
+     * maintenance push. Length-switch fast path: rejects unrelated pushes with at most two
+     * comparisons (MIGRATING and SMIGRATED share length 9).
      */
     static PushType resolve(byte[] type) {
       if (type == null) {
@@ -43,7 +61,12 @@ final class MaintenancePushCodec {
         case 8:
           return Arrays.equals(type, MIGRATED.token) ? MIGRATED : null;
         case 9:
-          return Arrays.equals(type, MIGRATING.token) ? MIGRATING : null;
+          if (Arrays.equals(type, MIGRATING.token)) {
+            return MIGRATING;
+          }
+          return Arrays.equals(type, SMIGRATED.token) ? SMIGRATED : null;
+        case 10:
+          return Arrays.equals(type, SMIGRATING.token) ? SMIGRATING : null;
         case 11:
           return Arrays.equals(type, FAILED_OVER.token) ? FAILED_OVER : null;
         case 12:
@@ -62,6 +85,17 @@ final class MaintenancePushCodec {
    */
   static MaintenanceEvent build(PushType type, PushMessage msg) {
     return type.decoder.apply(msg.getContent());
+  }
+
+  /**
+   * Builds the domain event for an already-resolved cluster push type
+   * ({@link PushType#isCluster()}).
+   * @throws MalformedMaintenanceEventException if the frame's fields are malformed (missing or
+   *           wrong-typed seq, unparseable slots-or-ranges, or an SMIGRATED entry without a valid
+   *           src/dest {@code host:port})
+   */
+  static ClusterMaintenanceEvent buildCluster(PushType type, PushMessage msg) {
+    return type.clusterDecoder.apply(msg.getContent());
   }
 
   private static MaintenanceEvent moving(List<Object> c) { // [MOVING, seq, time_s, host:port |
@@ -104,6 +138,55 @@ final class MaintenancePushCodec {
       throw malformed("FAILED_OVER", c);
     }
     return new FailedOverEvent((Long) c.get(1), shardIds(c, 2));
+  }
+
+  private static ClusterMaintenanceEvent sMigrating(List<Object> c) { // [SMIGRATING, seq, slots]
+    if (c.size() < 3 || !(c.get(1) instanceof Long) || !(c.get(2) instanceof byte[])) {
+      throw malformed("SMIGRATING", c);
+    }
+    return new SMigratingEvent((Long) c.get(1), slotRanges("SMIGRATING", c, (byte[]) c.get(2)));
+  }
+
+  private static ClusterMaintenanceEvent sMigrated(List<Object> c) { // [SMIGRATED, seq,
+                                                                     // [[src, dest, slots]...]]
+    if (c.size() < 3 || !(c.get(1) instanceof Long) || !(c.get(2) instanceof List)) {
+      throw malformed("SMIGRATED", c);
+    }
+    List<?> entries = (List<?>) c.get(2);
+    List<SlotMigration> migrations = new ArrayList<>(entries.size());
+    for (Object entryObj : entries) {
+      if (!(entryObj instanceof List)) {
+        throw malformed("SMIGRATED", c);
+      }
+      List<?> e = (List<?>) entryObj;
+      if (e.size() < 3 || !(e.get(0) instanceof byte[]) || !(e.get(1) instanceof byte[])
+          || !(e.get(2) instanceof byte[])) {
+        throw malformed("SMIGRATED", c);
+      }
+      migrations.add(new SlotMigration(nodeAddress("SMIGRATED", c, (byte[]) e.get(0)),
+          nodeAddress("SMIGRATED", c, (byte[]) e.get(1)),
+          slotRanges("SMIGRATED", c, (byte[]) e.get(2))));
+    }
+    return new SMigratedEvent((Long) c.get(1), migrations);
+  }
+
+  /** Slots-or-ranges field, e.g. {@code 123,456,789-1000}; throws when unparseable. */
+  private static HashSlotRanges slotRanges(String type, List<Object> c, byte[] raw) {
+    try {
+      return HashSlotRanges.parse(SafeEncoder.encode(raw));
+    } catch (IllegalArgumentException e) {
+      throw new MalformedMaintenanceEventException("Unparseable " + type + " slots: " + c, e);
+    }
+  }
+
+  /** Bare {@code host:port} node address (no labels on the wire); throws when unparseable. */
+  private static HostAndPort nodeAddress(String type, List<Object> c, byte[] raw) {
+    try {
+      return HostAndPort.from(SafeEncoder.encode(raw));
+    } catch (Exception e) {
+      throw new MalformedMaintenanceEventException("Unparseable " + type + " node address: " + c,
+          e);
+    }
   }
 
   /** Diagnostic shard-id list (stringified JSON array), logging only; required on the wire. */

--- a/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
+++ b/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
@@ -21,29 +21,15 @@ final class MaintenancePushCodec {
     FAILING_OVER(PushMessageTypes.FAILING_OVER_BYTES, MaintenancePushCodec::failingOver),
     MIGRATED(PushMessageTypes.MIGRATED_BYTES, MaintenancePushCodec::migrated),
     FAILED_OVER(PushMessageTypes.FAILED_OVER_BYTES, MaintenancePushCodec::failedOver),
-    SMIGRATING(PushMessageTypes.SMIGRATING_BYTES, MaintenancePushCodec::sMigrating, true),
-    SMIGRATED(PushMessageTypes.SMIGRATED_BYTES, MaintenancePushCodec::sMigrated, true);
+    SMIGRATING(PushMessageTypes.SMIGRATING_BYTES, MaintenancePushCodec::sMigrating),
+    SMIGRATED(PushMessageTypes.SMIGRATED_BYTES, MaintenancePushCodec::sMigrated);
 
     private final byte[] token;
     private final Function<List<Object>, MaintenanceEvent> decoder;
-    private final Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder;
 
     PushType(byte[] token, Function<List<Object>, MaintenanceEvent> decoder) {
       this.token = token;
       this.decoder = decoder;
-      this.clusterDecoder = null;
-    }
-
-    PushType(byte[] token, Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder,
-        boolean cluster) {
-      this.token = token;
-      this.decoder = null;
-      this.clusterDecoder = clusterDecoder;
-    }
-
-    /** True for the OSS-cluster message family (decoded via {@link #buildCluster}). */
-    boolean isCluster() {
-      return clusterDecoder != null;
     }
 
     /**
@@ -85,17 +71,6 @@ final class MaintenancePushCodec {
    */
   static MaintenanceEvent build(PushType type, PushMessage msg) {
     return type.decoder.apply(msg.getContent());
-  }
-
-  /**
-   * Builds the domain event for an already-resolved cluster push type
-   * ({@link PushType#isCluster()}).
-   * @throws MalformedMaintenanceEventException if the frame's fields are malformed (missing or
-   *           wrong-typed seq, unparseable slots-or-ranges, or an SMIGRATED entry without a valid
-   *           src/dest {@code host:port})
-   */
-  static ClusterMaintenanceEvent buildCluster(PushType type, PushMessage msg) {
-    return type.clusterDecoder.apply(msg.getContent());
   }
 
   private static MaintenanceEvent moving(List<Object> c) { // [MOVING, seq, time_s, host:port |

--- a/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
+++ b/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+
 import redis.clients.jedis.util.SafeEncoder;
 
 /**

--- a/src/main/java/redis/clients/jedis/PushMessageTypes.java
+++ b/src/main/java/redis/clients/jedis/PushMessageTypes.java
@@ -157,4 +157,26 @@ public final class PushMessageTypes {
    */
   public static final String FAILED_OVER = "FAILED_OVER";
   public static final byte[] FAILED_OVER_BYTES = SafeEncoder.encode(FAILED_OVER);
+
+  // ==================== Cluster Maintenance Events ====================
+
+  /**
+   * Cluster slot migration starts — relax client timeouts until the matching SMIGRATED.
+   * <p>
+   * Format: ["SMIGRATING", seq, slots-or-ranges] — comma-separated slots and/or {@code from-to}
+   * ranges, e.g. {@code "123,456,789-1000"}.
+   * @since 8.1
+   */
+  public static final String SMIGRATING = "SMIGRATING";
+  public static final byte[] SMIGRATING_BYTES = SafeEncoder.encode(SMIGRATING);
+
+  /**
+   * Cluster slot migration complete — restore client timeouts and apply the slot delta.
+   * <p>
+   * Format: ["SMIGRATED", seq, [["src-host:port", "dest-host:port", slots-or-ranges], ...]] — each
+   * entry moves the given slots from the source node to the destination node.
+   * @since 8.1
+   */
+  public static final String SMIGRATED = "SMIGRATED";
+  public static final byte[] SMIGRATED_BYTES = SafeEncoder.encode(SMIGRATED);
 }

--- a/src/test/java/redis/clients/jedis/ClusterMaintenanceEventTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterMaintenanceEventTest.java
@@ -1,0 +1,89 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for the {@link ClusterMaintenanceEvent} hierarchy: each event dispatches to its own
+ * listener callback with the owning connection, SMIGRATED exposes its delta read-only, and
+ * {@link SlotMigration} renders as {@code src -> dest [slots]}.
+ */
+@Tag("unit")
+public class ClusterMaintenanceEventTest {
+
+  private static final HostAndPort SRC = new HostAndPort("10.0.0.1", 7000);
+  private static final HostAndPort DEST = new HostAndPort("10.0.0.2", 7001);
+
+  private final MaintenanceEventListener listener = mock(MaintenanceEventListener.class);
+  private final Connection connection = mock(Connection.class);
+
+  @Test
+  public void sMigratingDispatchesToOnSMigrating() {
+    SMigratingEvent e = new SMigratingEvent(3L, HashSlotRanges.parse("0-100"));
+
+    e.accept(listener, connection);
+
+    verify(listener).onSMigrating(e, connection);
+    verifyNoMoreInteractions(listener);
+  }
+
+  @Test
+  public void sMigratedDispatchesToOnSMigrated() {
+    SMigratedEvent e = new SMigratedEvent(4L,
+        Collections.singletonList(new SlotMigration(SRC, DEST, HashSlotRanges.parse("0-100"))));
+
+    e.accept(listener, connection);
+
+    verify(listener).onSMigrated(e, connection);
+    verifyNoMoreInteractions(listener);
+  }
+
+  @Test
+  public void clusterEventsAreMaintenanceEvents() { // the codec/consumer handle one
+                                                    // MaintenanceEvent type
+    assertInstanceOf(MaintenanceEvent.class, new SMigratingEvent(1L, HashSlotRanges.parse("1")));
+    assertInstanceOf(MaintenanceEvent.class, new SMigratedEvent(1L, Collections.emptyList()));
+    assertEquals(1L, new SMigratingEvent(1L, HashSlotRanges.parse("1")).seq);
+    assertEquals(2L, new SMigratedEvent(2L, Collections.emptyList()).seq);
+  }
+
+  @Test
+  public void sMigratingExposesSlots() {
+    HashSlotRanges slots = HashSlotRanges.parse("123,456,789-1000");
+    assertSame(slots, new SMigratingEvent(1L, slots).slots);
+  }
+
+  @Test
+  public void sMigratedMigrationsAreReadOnly() {
+    List<SlotMigration> source = new ArrayList<>(
+        Arrays.asList(new SlotMigration(SRC, DEST, HashSlotRanges.parse("0-100")),
+          new SlotMigration(DEST, SRC, HashSlotRanges.parse("200"))));
+    SMigratedEvent e = new SMigratedEvent(1L, source);
+
+    assertEquals(source, e.migrations);
+    assertThrows(UnsupportedOperationException.class, () -> e.migrations.clear());
+    assertThrows(UnsupportedOperationException.class,
+      () -> e.migrations.add(new SlotMigration(SRC, DEST, HashSlotRanges.parse("5"))));
+  }
+
+  @Test
+  public void slotMigrationToString() {
+    SlotMigration m = new SlotMigration(SRC, DEST, HashSlotRanges.parse("123,456,789-1000"));
+    assertEquals("10.0.0.1:7000 -> 10.0.0.2:7001 [123,456,789-1000]", m.toString());
+    assertSame(SRC, m.src);
+    assertSame(DEST, m.dest);
+  }
+}

--- a/src/test/java/redis/clients/jedis/HashSlotRangesTest.java
+++ b/src/test/java/redis/clients/jedis/HashSlotRangesTest.java
@@ -1,0 +1,152 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for {@link HashSlotRanges}: the slots-or-ranges wire format
+ * ({@code 123,456,789-1000}) of cluster maintenance pushes — parsing, membership, counting,
+ * iteration order and rejection of malformed input.
+ */
+@Tag("unit")
+public class HashSlotRangesTest {
+
+  @Test
+  public void parseSingleSlot() {
+    HashSlotRanges r = HashSlotRanges.parse("42");
+    assertTrue(r.contains(42));
+    assertFalse(r.contains(41));
+    assertFalse(r.contains(43));
+    assertEquals(1, r.slotCount());
+    assertEquals(Arrays.asList(42), slots(r));
+  }
+
+  @Test
+  public void parseInclusiveRange() {
+    HashSlotRanges r = HashSlotRanges.parse("10-13");
+    assertFalse(r.contains(9));
+    assertTrue(r.contains(10));
+    assertTrue(r.contains(13));
+    assertFalse(r.contains(14));
+    assertEquals(4, r.slotCount());
+    assertEquals(Arrays.asList(10, 11, 12, 13), slots(r));
+  }
+
+  @Test
+  public void parseDegenerateRange() { // from == to is a one-slot range
+    HashSlotRanges r = HashSlotRanges.parse("7-7");
+    assertTrue(r.contains(7));
+    assertEquals(1, r.slotCount());
+    assertEquals(Arrays.asList(7), slots(r));
+  }
+
+  @Test
+  public void parseMixedSlotsAndRanges() {
+    HashSlotRanges r = HashSlotRanges.parse("123,456,789-1000");
+    assertTrue(r.contains(123));
+    assertTrue(r.contains(456));
+    assertTrue(r.contains(789));
+    assertTrue(r.contains(900));
+    assertTrue(r.contains(1000));
+    assertFalse(r.contains(0));
+    assertFalse(r.contains(124));
+    assertFalse(r.contains(788));
+    assertFalse(r.contains(1001));
+    assertEquals(2 + (1000 - 789 + 1), r.slotCount());
+  }
+
+  @Test
+  public void forEachSlotVisitsInWireOrder() { // not sorted: wire order is preserved
+    HashSlotRanges r = HashSlotRanges.parse("5,1-3,9");
+    assertEquals(Arrays.asList(5, 1, 2, 3, 9), slots(r));
+  }
+
+  @Test
+  public void overlappingRangesCountSlotsPerRange() { // no dedup: count is the sum of the ranges
+    HashSlotRanges r = HashSlotRanges.parse("1-3,2-4");
+    assertEquals(6, r.slotCount());
+    assertEquals(Arrays.asList(1, 2, 3, 2, 3, 4), slots(r));
+    assertTrue(r.contains(2));
+  }
+
+  @Test
+  public void parseAcceptsFullSlotSpace() {
+    HashSlotRanges r = HashSlotRanges.parse("0-16383");
+    assertTrue(r.contains(0));
+    assertTrue(r.contains(16383));
+    assertFalse(r.contains(-1));
+    assertFalse(r.contains(16384));
+    assertEquals(Protocol.CLUSTER_HASHSLOTS, r.slotCount());
+  }
+
+  @Test
+  public void parseAcceptsBoundarySlots() {
+    assertTrue(HashSlotRanges.parse("0").contains(0));
+    assertTrue(HashSlotRanges.parse("16383").contains(16383));
+  }
+
+  @Test
+  public void toStringIsTheWireSource() {
+    assertEquals("123,456,789-1000", HashSlotRanges.parse("123,456,789-1000").toString());
+    assertEquals("7", HashSlotRanges.parse("7").toString());
+  }
+
+  @Test
+  public void parseRejectsNullOrEmpty() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(null));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(""));
+  }
+
+  @Test
+  public void parseRejectsNonNumericTokens() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("abc"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,x"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1-x"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("x-5"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1.5"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(" 1"));
+  }
+
+  @Test
+  public void parseRejectsEmptyTokens() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,,2"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(",1"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1-"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("-5"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("-"));
+  }
+
+  @Test
+  public void parseRejectsInvertedRange() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("10-9"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,10-9"));
+  }
+
+  @Test
+  public void parseRejectsSlotsOutsideHashSlotSpace() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("16384"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("0-16384"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("16383-99999"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,2,3,16384"));
+  }
+
+  @Test
+  public void parseRejectsAnyBadTokenEvenAfterValidOnes() { // whole string is rejected atomically
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1-3,5,bad"));
+  }
+
+  private static List<Integer> slots(HashSlotRanges r) {
+    List<Integer> out = new ArrayList<>();
+    r.forEachSlot(out::add);
+    return out;
+  }
+}

--- a/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
@@ -159,5 +159,15 @@ public class MaintenanceEventConsumerTest {
     public void onFailedOver(FailedOverEvent e, Connection c) {
       calls.add(new Call("onFailedOver", e, c));
     }
+
+    @Override
+    public void onSMigrating(SMigratingEvent e, Connection c) {
+      throw new UnsupportedOperationException("Unimplemented method 'onSMigrating'");
+    }
+
+    @Override
+    public void onSMigrated(SMigratedEvent e, Connection c) {
+      throw new UnsupportedOperationException("Unimplemented method 'onSMigrated'");
+    }
   }
 }

--- a/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
@@ -77,6 +77,38 @@ public class MaintenanceEventConsumerTest {
     assertCallback("onFailingOver", push(type("FAILING_OVER"), 3L, 5L, shards));
     assertCallback("onMigrated", push(type("MIGRATED"), 4L, shards));
     assertCallback("onFailedOver", push(type("FAILED_OVER"), 5L, shards));
+    assertCallback("onSMigrating", push(type("SMIGRATING"), 6L, bytes("0-100")));
+    assertCallback("onSMigrated", push(type("SMIGRATED"), 7L, Collections
+        .singletonList(Arrays.asList(bytes("h1:7000"), bytes("h2:7001"), bytes("0-100")))));
+  }
+
+  @Test
+  public void dispatchesClusterEventWithDecodedFields() {
+    RecordingListener l = new RecordingListener();
+    PushConsumerContext ctx = consume(Collections.singleton(l),
+      push(type("SMIGRATED"), 7L, Collections
+          .singletonList(Arrays.asList(bytes("h1:7000"), bytes("h2:7001"), bytes("0-100")))));
+
+    assertTrue(ctx.shouldDrop());
+    assertEquals(1, l.calls.size());
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class, l.calls.get(0).event);
+    assertEquals(7L, e.seq);
+    assertEquals(1, e.migrations.size());
+    assertEquals(new HostAndPort("h1", 7000), e.migrations.get(0).src);
+    assertEquals(new HostAndPort("h2", 7001), e.migrations.get(0).dest);
+    assertTrue(e.migrations.get(0).slots.contains(50));
+  }
+
+  @Test
+  public void malformedClusterFrameDropsWithoutDispatch() {
+    RecordingListener l = new RecordingListener();
+    // resolves as SMIGRATING but the slots field is unparseable -> build() throws, consumer
+    // discards
+    PushConsumerContext ctx = consume(Collections.singleton(l),
+      push(type("SMIGRATING"), 6L, bytes("not-slots")));
+
+    assertTrue(ctx.shouldDrop());
+    assertTrue(l.calls.isEmpty());
   }
 
   @Test
@@ -162,12 +194,12 @@ public class MaintenanceEventConsumerTest {
 
     @Override
     public void onSMigrating(SMigratingEvent e, Connection c) {
-      throw new UnsupportedOperationException("Unimplemented method 'onSMigrating'");
+      calls.add(new Call("onSMigrating", e, c));
     }
 
     @Override
     public void onSMigrated(SMigratedEvent e, Connection c) {
-      throw new UnsupportedOperationException("Unimplemented method 'onSMigrated'");
+      calls.add(new Call("onSMigrated", e, c));
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
@@ -13,6 +13,7 @@ import java.net.SocketAddress;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -298,6 +299,37 @@ public class MaintenanceEventControllerTest {
     // The hook runs on the controller's scheduler; each applied event fires it once.
     await().atMost(Duration.ofSeconds(1)).until(() -> fires.get() == 3);
     assertEquals(3, fires.get());
+  }
+
+  // --- Cluster maintenance events: out of contract for this controller, must be inert ---
+
+  @Test
+  public void clusterEvents_areIgnored() {
+    HashSlotRanges slots = HashSlotRanges.parse("0-100");
+    controller.onSMigrating(new SMigratingEvent(1L, slots), receiver);
+    controller.onSMigrated(new SMigratedEvent(1L,
+        Collections.singletonList(new SlotMigration(TARGET_B, TARGET_C, slots))),
+      receiver);
+
+    assertFalse(controller.isRebindActive(), "cluster events must not open a rebind window");
+    assertNull(controller.getTimeoutSupplier().get(), "cluster events must not relax pool-wide");
+    assertNull(controller.getSocketAddress(receiverPeer), "cluster events must not remap");
+  }
+
+  @Test
+  public void clusterEvents_doNotDisturbStandaloneState() {
+    moving(1L, TARGET_B, 10);
+    assertEquals(TARGET_B_ADDR, controller.getSocketAddress(receiverPeer));
+
+    controller.onSMigrating(new SMigratingEvent(2L, HashSlotRanges.parse("5")), receiver);
+    controller.onSMigrated(new SMigratedEvent(2L, Collections.emptyList()), receiver2);
+
+    assertEquals(TARGET_B_ADDR, controller.getSocketAddress(receiverPeer),
+      "MOVING remap survives cluster events");
+    assertNull(controller.getSocketAddress(receiver2Peer),
+      "a cluster event on another connection does not make it an affected source");
+    assertTrue(controller.isRebindActive(), "the MOVING window stays open");
+    assertNotNull(controller.getTimeoutSupplier().get(), "pool-wide relaxation stays in effect");
   }
 
   // --- Relax-on-borrow ---

--- a/src/test/java/redis/clients/jedis/MaintenanceEventIdentityTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventIdentityTest.java
@@ -3,14 +3,18 @@ package redis.clients.jedis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * Identity semantics of {@link MaintenanceEvent#identity()}: seq for all types; MOVING is also
- * keyed by the original target endpoint, so concurrent MOVINGs to different endpoints stay distinct
- * operations. Identity excludes payload that may vary between deliveries of the same operation
- * (remaining time, shard diagnostics).
+ * Identity semantics of {@link MaintenanceEvent#identity()}: seq for all types (including the
+ * cluster SMIGRATING/SMIGRATED family); MOVING is also keyed by the original target endpoint, so
+ * concurrent MOVINGs to different endpoints stay distinct operations. Identity excludes payload
+ * that may vary between deliveries of the same operation (remaining time, shard diagnostics, slot
+ * ranges).
  */
 @Tag("sch")
 public class MaintenanceEventIdentityTest {
@@ -53,5 +57,30 @@ public class MaintenanceEventIdentityTest {
       new FailingOverEvent(5L, 10, "1").identity());
     assertNotEquals(new FailingOverEvent(5L, 10, "1").identity(),
       new MovingEvent(5L, 10, null).identity());
+  }
+
+  @Test
+  public void clusterEventsUseSeqIdentity() {
+    HashSlotRanges slotsA = HashSlotRanges.parse("0-100");
+    HashSlotRanges slotsB = HashSlotRanges.parse("200");
+    List<SlotMigration> delta = Collections
+        .singletonList(new SlotMigration(TARGET_B, TARGET_C, slotsA));
+
+    assertEquals(new SMigratingEvent(5L, slotsA).identity(),
+      new SMigratingEvent(5L, slotsB).identity(), "same seq: same operation regardless of slots");
+    assertEquals(new SMigratingEvent(5L, slotsA).identity().hashCode(),
+      new SMigratingEvent(5L, slotsB).identity().hashCode());
+    assertNotEquals(new SMigratingEvent(5L, slotsA).identity(),
+      new SMigratingEvent(6L, slotsA).identity());
+
+    assertEquals(new SMigratedEvent(5L, delta).identity(),
+      new SMigratedEvent(5L, Collections.emptyList()).identity(),
+      "same seq: same operation regardless of the slot delta");
+    assertNotEquals(new SMigratedEvent(5L, delta).identity(),
+      new SMigratedEvent(6L, delta).identity());
+
+    assertEquals(new SMigratingEvent(5L, slotsA).identity(),
+      new SMigratedEvent(5L, delta).identity(),
+      "an SMIGRATED terminates the SMIGRATING with the same seq");
   }
 }

--- a/src/test/java/redis/clients/jedis/MaintenancePushCodecTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenancePushCodecTest.java
@@ -1,15 +1,18 @@
 package redis.clients.jedis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static redis.clients.jedis.MaintenancePushCodec.build;
 import static redis.clients.jedis.MaintenancePushCodec.PushType.resolve;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -19,7 +22,8 @@ import redis.clients.jedis.util.SafeEncoder;
 
 /**
  * Unit coverage for {@link MaintenancePushCodec}: {@link PushType#resolve} token classification and
- * {@link MaintenancePushCodec#build} field extraction / malformed-frame rejection.
+ * {@link MaintenancePushCodec#build} field extraction / malformed-frame rejection, for both the
+ * standalone ({@link MaintenanceEvent}) and cluster ({@link ClusterMaintenanceEvent}) families.
  */
 @Tag("unit")
 public class MaintenancePushCodecTest {
@@ -148,12 +152,145 @@ public class MaintenancePushCodecTest {
     assertMalformed(PushType.FAILED_OVER, push(type("FAILED_OVER"), 7L)); // missing shards
   }
 
+  // resolve()/build(): cluster maintenance pushes (SMIGRATING / SMIGRATED)
+
+  @Test
+  public void resolveClassifiesClusterMaintenanceTokens() {
+    assertSame(PushType.SMIGRATING, resolve(type("SMIGRATING")));
+    assertSame(PushType.SMIGRATED, resolve(type("SMIGRATED")));
+  }
+
+  @Test
+  public void resolveDisambiguatesSameLengthTokens() {
+    // MIGRATING and SMIGRATED share length 9: neither may shadow the other or admit lookalikes
+    assertSame(PushType.MIGRATING, resolve(type("MIGRATING")));
+    assertSame(PushType.SMIGRATED, resolve(type("SMIGRATED")));
+    assertNull(resolve(type("SMIGRATEX")));
+    assertNull(resolve(type("XMIGRATED")));
+    assertNull(resolve(type("SMIGRATINX"))); // length 10, not SMIGRATING
+    assertNull(resolve(type("smigrating"))); // tokens are case-sensitive
+    assertNull(resolve(type("smigrated")));
+  }
+
+  @Test
+  public void buildSMigrating() {
+    SMigratingEvent e = assertInstanceOf(SMigratingEvent.class,
+      build(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("123,456,789-1000"))));
+    assertEquals(11L, e.seq);
+    assertEquals("123,456,789-1000", e.slots.toString());
+    assertTrue(e.slots.contains(123));
+    assertTrue(e.slots.contains(456));
+    assertTrue(e.slots.contains(1000));
+    assertFalse(e.slots.contains(1001));
+  }
+
+  @Test
+  public void buildSMigrated() {
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class,
+      build(PushType.SMIGRATED,
+        sMigrated(12L, entry(bytes("10.0.0.1:7000"), bytes("10.0.0.2:7001"), bytes("0-100")),
+          entry(bytes("node-a:7002"), bytes("node-b:7003"), bytes("200,300-310")))));
+    assertEquals(12L, e.seq);
+    assertEquals(2, e.migrations.size());
+
+    SlotMigration first = e.migrations.get(0);
+    assertEquals(new HostAndPort("10.0.0.1", 7000), first.src);
+    assertEquals(new HostAndPort("10.0.0.2", 7001), first.dest);
+    assertEquals("0-100", first.slots.toString());
+
+    SlotMigration second = e.migrations.get(1);
+    assertEquals(new HostAndPort("node-a", 7002), second.src);
+    assertEquals(new HostAndPort("node-b", 7003), second.dest);
+    assertTrue(second.slots.contains(200));
+    assertTrue(second.slots.contains(305));
+    assertFalse(second.slots.contains(299));
+  }
+
+  @Test
+  public void buildSMigratedWithNoEntries() { // an empty delta is a well-formed terminator
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class,
+      build(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, Collections.emptyList())));
+    assertEquals(12L, e.seq);
+    assertTrue(e.migrations.isEmpty());
+  }
+
+  @Test
+  public void buildSMigratedTrailingEntryFieldsAreIgnored() { // forward-compatible: >3 fields OK
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class,
+      build(PushType.SMIGRATED, sMigrated(1L,
+        Arrays.asList(bytes("h1:7000"), bytes("h2:7001"), bytes("5"), bytes("extra")))));
+    assertEquals(1, e.migrations.size());
+    assertEquals("5", e.migrations.get(0).slots.toString());
+  }
+
+  @Test
+  public void buildRejectsMalformedSMigrating() {
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"))); // no seq
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L)); // missing slots
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), bytes("x"), bytes("1-5"))); // bad
+                                                                                              // seq
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, 5L)); // slots not byte[]
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, null)); // null slots
+    // unparseable slots-or-ranges
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("")));
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("abc")));
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("10-9")));
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("16384")));
+  }
+
+  @Test
+  public void buildRejectsMalformedSMigrated() {
+    List<Object> ok = entry(bytes("h1:7000"), bytes("h2:7001"), bytes("0-100"));
+
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"))); // no seq
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L)); // missing entries
+    assertMalformed(PushType.SMIGRATED,
+      push(type("SMIGRATED"), bytes("x"), Collections.singletonList(ok))); // bad seq
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, bytes("not-a-list")));
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, null));
+
+    // entry not a list
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, Arrays.asList(bytes("x"))));
+    // entry too short
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, Arrays.asList(bytes("h1:7000"), bytes("h2:7001"))));
+    // entry fields of the wrong type
+    assertMalformed(PushType.SMIGRATED, sMigrated(12L, entry(7000L, bytes("h2:7001"), bytes("0"))));
+    assertMalformed(PushType.SMIGRATED, sMigrated(12L, entry(bytes("h1:7000"), 7001L, bytes("0"))));
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:7001"), 5L)));
+    assertMalformed(PushType.SMIGRATED, sMigrated(12L, entry(null, bytes("h2:7001"), bytes("0"))));
+    // unparseable node addresses
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("no-port"), bytes("h2:7001"), bytes("0-100"))));
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:notaport"), bytes("0-100"))));
+    // unparseable slots
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:7001"), bytes("100-0"))));
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:7001"), bytes(""))));
+    // one bad entry rejects the whole frame
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, ok, entry(bytes("h1:7000"), bytes("h2:7001"), bytes("bad"))));
+  }
+
   private static void assertMalformed(PushType type, PushMessage msg) {
     assertThrows(MalformedMaintenanceEventException.class, () -> build(type, msg));
   }
 
   private static PushMessage push(Object... content) {
     return new PushMessage(Arrays.asList(content));
+  }
+
+  /** {@code [SMIGRATED, seq, [entries...]]} */
+  private static PushMessage sMigrated(long seq, List<?>... entries) {
+    return push(type("SMIGRATED"), seq, Arrays.asList(entries));
+  }
+
+  /** One SMIGRATED entry: {@code [src, dest, slots]}. */
+  private static List<Object> entry(Object src, Object dest, Object slots) {
+    return Arrays.asList(src, dest, slots);
   }
 
   private static byte[] type(String t) {


### PR DESCRIPTION
## Summary
Adds RESP3 push decoding for the OSS-cluster maintenance notifications `SMIGRATING` and `SMIGRATED`, producing typed `SMigratingEvent` / `SMigratedEvent` domain objects alongside the existing standalone maintenance events. This PR is parsing and dispatch only: the events reach `MaintenanceEventListener`, but no cluster-aware handling (timeout relaxation, slot-map update, connection retirement) is implemented yet.

## Key Decisions & Assumptions
- Cluster events live in their own `ClusterMaintenanceEvent` hierarchy but still extend `MaintenanceEvent`, so the codec and consumer keep a single event type and dispatch path. The two families are treated as exclusive contracts: a connection receives one or the other.
- The slots-or-ranges wire field (`123,456,789-1000`) is modeled by a new package-private `HashSlotRanges` value type that keeps wire order, exposes membership, count and iteration, and validates every slot against `[0, 16384)`.
- `SMIGRATED` node addresses are assumed to be bare `host:port` strings parsed via `HostAndPort.from`.
- Events dedup by `seq` alone, like the non-MOVING standalone events.

## Behavioral / Conceptual Changes
- `PushMessageTypes` gains public `SMIGRATING` / `SMIGRATED` constants (`@since 8.1`).
- The push type resolver now handles a length collision: `MIGRATING` and `SMIGRATED` are both 9 bytes, so that case does two comparisons instead of one.
- Malformed cluster frames (wrong arity or types, unparseable slots or addresses, one bad entry in an `SMIGRATED` list) throw `MalformedMaintenanceEventException`, so the consumer drops them without dispatch, matching existing behavior.
- `MaintenanceEventListener` gains `onSMigrating` / `onSMigrated`. The standalone `MaintenanceEventController` implements them as no-ops that log a warning and leave pool-wide state untouched.

## Testing
New unit tests cover `HashSlotRanges` parsing and rejection rules, the event hierarchy (dispatch, read-only delta, rendering), and codec resolution and field extraction, including the exhaustive malformed-frame matrix. The consumer, identity and controller tests are extended to confirm routing to the new callbacks, seq-based identity, and that cluster events do not disturb an active MOVING window.

## Notes
- `HashSlotRanges.parse` accepts a lone or trailing comma (`","`, `"1,"`) silently because `String.split` drops trailing empty tokens. Worth tightening if the wire format should be strict.
- The `MaintenancePushCodec` class javadoc still references a removed `buildCluster` method.
- Breaking for any external `MaintenanceEventListener` implementations, but the interface is package-private, so none are expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive parsing and listener callbacks; cluster events are explicitly ignored by the standalone controller, with no slot-map or connection lifecycle impact yet.
> 
> **Overview**
> Adds **decode-and-dispatch** for OSS cluster maintenance pushes `SMIGRATING` and `SMIGRATED`, alongside the existing standalone maintenance events. Typed events (`SMigratingEvent`, `SMigratedEvent`, `SlotMigration`) live under a new `ClusterMaintenanceEvent` hierarchy but still extend `MaintenanceEvent`, so the existing codec/consumer path stays unified.
> 
> **`MaintenancePushCodec`** gains `SMIGRATING`/`SMIGRATED` decoders, a `HashSlotRanges` parser for the `slots-or-ranges` wire field, and updated token resolution (including disambiguating 9-byte `MIGRATING` vs `SMIGRATED`). Malformed cluster frames still throw `MalformedMaintenanceEventException` and are dropped without listener dispatch.
> 
> **`MaintenanceEventListener`** adds `onSMigrating` / `onSMigrated`. The standalone **`MaintenanceEventController`** implements them as warn-only no-ops so cluster pushes do not alter MOVING rebind, timeout relaxation, or remap behavior. **No cluster-aware handling** (slot-map updates, timeout relax on SMIGRATING, connection retirement) is in this PR.
> 
> Unit tests cover `HashSlotRanges`, event dispatch/identity, codec malformed matrices, consumer routing, and controller inertness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50615c11be8036f5c3b2ee57b6a46af6812cad1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->