### PR TITLE
Fix flaky sentinel failover test: align replica master host with sentinel monitor

### DIFF
--- a/src/test/resources/env/sentinel-standalone2-failover/config/node-6385/redis.conf
+++ b/src/test/resources/env/sentinel-standalone2-failover/config/node-6385/redis.conf
@@ -3,4 +3,4 @@ requirepass foobared
 masterauth foobared
 save ""
 appendonly no
-slaveof localhost 6384
+slaveof 127.0.0.1 6384

--- a/src/test/resources/env/standalone2-sentinel/config/node-6382-16382/redis.conf
+++ b/src/test/resources/env/standalone2-sentinel/config/node-6382-16382/redis.conf
@@ -4,4 +4,4 @@ requirepass foobared
 masterauth foobared
 save ""
 appendonly no
-slaveof localhost 6381
+slaveof 127.0.0.1 6381


### PR DESCRIPTION
## Summary
`JedisSentinelTest.sentinelFailover` has been failing in the containerized CI since Sept 4 with
`FailoverAbortedException: -failover-abort-no-good-slave` (e.g. nightly run
[34298534564](https://github.com/redis/jedis/actions/runs/34298534564), PR run
[34321235777](https://github.com/redis/jedis/actions/runs/34321235777)). The replica in the
failover env is configured with `slaveof localhost 6384` while the sentinel monitors
`127.0.0.1 6384`. With `resolve-hostnames` off, Sentinel treats the replica as misconfigured and,
120 s after discovering it (`failover-timeout`), issues `+fix-slave-config`, which re-points the
replica and kills its connections. When that coincides with the test's `SENTINEL FAILOVER`, the
replica is disqualified and the failover aborts. This PR makes the replica config use `127.0.0.1`,
matching the sentinel.

## Key Decisions & Assumptions
- No code change; only the test environment config. The same mismatch in `standalone2-sentinel`
  (`node-6382`) is fixed too, to avoid the same connection kill at the 2-minute mark.
- The failure surfaced now because CI got ~30 s faster around Sept 4, so the test started landing
  in the 120–140 s window after container start. Which matrix version fails varies by run.

## Testing
Reproduced locally on `client-libs-test:7.2.12` by firing the failover 120 s after replica
discovery: the old config aborts exactly as in CI, the new config completes with `+switch-master`.
All test classes using the two environments were re-run against the fixed config and pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test fixture config only; no production or library runtime behavior changes.
> 
> **Overview**
> Fixes flaky **`JedisSentinelTest.sentinelFailover`** (and similar runs) in containerized CI by updating test Redis replica configs so **`slaveof`** uses **`127.0.0.1`** instead of **`localhost`**, matching how Sentinel monitors the master in the same envs.
> 
> With hostname resolution disabled, that mismatch led Sentinel to treat replicas as misconfigured, trigger **`+fix-slave-config`** around the failover timeout, and abort forced failovers with **`-failover-abort-no-good-slave`**. Both **`sentinel-standalone2-failover`** (`node-6385`) and **`standalone2-sentinel`** (`node-6382`) are updated; no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ed9ac2296b09695c8a6c27e611a0abe7e38155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->