### PR TITLE
[maintenance events - cluster] Wire cluster maintenance notifications through family-agnostic controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -656,6 +656,11 @@
 						<include>**/sch/*.java</include>
 						<include>**/ConnectionFactoryRebindTest.java</include>
 						<include>**/JedisClusterInfoCache.java</include>
+						<include>**/ClusterMaintenanceCoordinator.java</include>
+						<include>**/ClusterMaintenanceEvent.java</include>
+						<include>**/HashSlotRanges.java</include>
+						<include>**/ClusterMaintenanceEventTest.java</include>
+						<include>**/HashSlotRangesTest.java</include>
 					</includes>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -655,6 +655,7 @@
 						<include>**/SocketAddress*.java</include>
 						<include>**/sch/*.java</include>
 						<include>**/ConnectionFactoryRebindTest.java</include>
+						<include>**/JedisClusterInfoCache.java</include>
 					</includes>
 				</configuration>
 				<executions>

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceController.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceController.java
@@ -75,7 +75,7 @@ final class ClusterMaintenanceController
     warnUnsupported(e, c);
   }
 
-  private void warnUnsupported(MaintenanceEvent e, Connection c) {
+  private static void warnUnsupported(MaintenanceEvent e, Connection c) {
     logger.warn(
       "Standalone maintenance events are not supported on cluster connections: {} conn={}", e,
       c.toIdentityString());

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceController.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceController.java
@@ -1,0 +1,84 @@
+package redis.clients.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Per-pool controller for the cluster message family: dispatches SMIGRATING/SMIGRATED to the
+ * client-wide {@link ClusterMaintenanceCoordinator} and consumes any standalone/enterprise event
+ * with a warning — those must not occur on a cluster connection. Carries none of the pool-local
+ * machinery of {@link MaintenanceEventController}: no registry, no marking scheduler, no retirement
+ * — Case-2 teardown is pool-level.
+ */
+final class ClusterMaintenanceController
+    implements MaintenanceController, MaintenanceEventListener {
+
+  private static final Logger logger = LoggerFactory.getLogger(ClusterMaintenanceController.class);
+
+  private final ClusterMaintenanceCoordinator coordinator;
+
+  ClusterMaintenanceController(ClusterMaintenanceCoordinator coordinator) {
+    this.coordinator = coordinator;
+  }
+
+  @Override
+  public MaintenanceNotificationsConfig getConfig() {
+    return coordinator.getConfig();
+  }
+
+  @Override
+  public void register(Connection connection) {
+    connection.getTimeoutSource()
+        .addOverride(new ManagedTimeoutSource(coordinator.getTimeoutSupplier()));
+    connection.addMaintenanceEventListener(this);
+  }
+
+  @Override
+  public void unregister(Connection connection) {
+    connection.removeMaintenanceEventListener(this);
+    ChainedTimeoutSource cts = connection.getTimeoutSource();
+    cts.removeOverride(cts.seekBy(coordinator.getTimeoutSupplier()));
+  }
+
+  @Override
+  public void onSMigrating(SMigratingEvent e, Connection c) {
+    coordinator.onSMigrating(e, c);
+  }
+
+  @Override
+  public void onSMigrated(SMigratedEvent e, Connection c) {
+    coordinator.onSMigrated(e, c);
+  }
+
+  @Override
+  public void onMoving(MovingEvent e, Connection c) {
+    warnUnsupported(e, c);
+  }
+
+  @Override
+  public void onMigrating(MigratingEvent e, Connection c) {
+    warnUnsupported(e, c);
+  }
+
+  @Override
+  public void onMigrated(MigratedEvent e, Connection c) {
+    warnUnsupported(e, c);
+  }
+
+  @Override
+  public void onFailingOver(FailingOverEvent e, Connection c) {
+    warnUnsupported(e, c);
+  }
+
+  @Override
+  public void onFailedOver(FailedOverEvent e, Connection c) {
+    warnUnsupported(e, c);
+  }
+
+  private void warnUnsupported(MaintenanceEvent e, Connection c) {
+    logger.warn(
+      "Standalone maintenance events are not supported on cluster connections: {} conn={}", e,
+      c.toIdentityString());
+  }
+
+}

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
@@ -1,0 +1,209 @@
+package redis.clients.jedis;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.TimeoutSource.TimeoutInfo;
+
+/**
+ * Cluster maintenance coordinator — one per cluster client, the single dedup/apply point for the
+ * per-node SMIGRATING/SMIGRATED broadcast. Owns the seq-keyed operations table that (a) folds the
+ * N-connection broadcast into one client-wide operation and (b) drives the shared relax gate:
+ * timeouts stay relaxed while ANY operation is open, so overlapping migrations unrelax only when
+ * the last one closes, and a connection created mid-event relaxes from the moment its overlay is
+ * installed. On SMIGRATED it applies the slot delta atomically through
+ * {@link JedisClusterInfoCache#applyMigrationDelta} — queued and drained after completion when a
+ * full topology refresh is in flight, never blocking a read thread — and retires the connections
+ * of nodes left without slots via each pool's own {@link MaintenanceEventController}, resolved at
+ * event time (no node map here). The pools remain their controllers' sole owners; this class only
+ * calls.
+ */
+final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
+
+  private static final Logger logger = LoggerFactory.getLogger(ClusterMaintenanceCoordinator.class);
+
+  private final JedisClusterInfoCache cache;
+  /** Backstop for an SMIGRATING whose SMIGRATED is lost, and retention of closed entries. */
+  private final long maxRelaxedDurationNanos;
+  private final Supplier<TimeoutInfo> timeoutSupplier;
+
+  /** Seq-keyed operations: open entries gate the relax; closed entries absorb late duplicates. */
+  private final ConcurrentHashMap<Object, MigrationOperation> operations = new ConcurrentHashMap<>();
+
+  /** SMIGRATED deltas received while a full refresh was in flight; drained post-refresh. */
+  private final ConcurrentLinkedQueue<SMigratedEvent> pendingDeltas = new ConcurrentLinkedQueue<>();
+
+  ClusterMaintenanceCoordinator(JedisClusterInfoCache cache,
+      MaintenanceNotificationsConfig config) {
+    this.cache = cache;
+    this.maxRelaxedDurationNanos = config.getRelaxedWindowMaxDuration().toNanos();
+    TimeoutInfo relaxedTimeoutInfo = new TimeoutInfo(config.getRelaxedTimeout(),
+        config.getRelaxedBlockingTimeout());
+    this.timeoutSupplier = () -> hasActiveMigration() ? relaxedTimeoutInfo : null;
+    cache.setPostRefreshHook(this::drainPendingDeltas);
+  }
+
+  /** The client-wide relax gate consulted by every cluster connection's timeout overlay. */
+  Supplier<TimeoutInfo> getTimeoutSupplier() {
+    return timeoutSupplier;
+  }
+
+  /**
+   * True while any migration window is open (SMIGRATING seen, SMIGRATED not yet, TTL unexpired).
+   */
+  boolean hasActiveMigration() {
+    if (operations.isEmpty()) {
+      return false;
+    }
+    boolean active = false;
+    for (MigrationOperation op : operations.values()) {
+      if (op.isExpired()) {
+        operations.remove(op.id, op);
+      } else if (!op.closed) {
+        active = true;
+      }
+    }
+    return active;
+  }
+
+  @Override
+  public void onSMigrating(SMigratingEvent e, Connection c) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Slot migration starting: {} (seq={}) conn={}", e.slots, e.seq,
+        c.toIdentityString());
+    }
+    long deadline = NanoClock.INSTANCE.getAsLong() + maxRelaxedDurationNanos;
+    operations.computeIfAbsent(e.identity(), k -> new MigrationOperation(k, deadline));
+    c.applyCurrentTimeout(); // the gate just opened; push the relax to the receiving socket now
+  }
+
+  @Override
+  public void onSMigrated(SMigratedEvent e, Connection c) {
+    long deadline = NanoClock.INSTANCE.getAsLong() + maxRelaxedDurationNanos;
+    boolean[] firstDelivery = { false };
+    operations.compute(e.identity(), (k, cur) -> { // atomic per identity
+      if (cur == null) {
+        // SMIGRATED without a preceding SMIGRATING (e.g. connected mid-event): still applied
+        firstDelivery[0] = true;
+        return MigrationOperation.closed(k, deadline);
+      }
+      if (!cur.closed) {
+        firstDelivery[0] = true;
+        return cur.close();
+      }
+      return cur; // duplicate broadcast delivery; retained to absorb the rest
+    });
+    c.applyCurrentTimeout(); // unrelax the receiving socket if the gate just shut
+    if (!firstDelivery[0]) {
+      return;
+    }
+    logger.debug("Slot migration done (seq={}, entries={})", e.seq, e.migrations.size());
+    if (cache.isRenewInFlight()) {
+      // Never block the read thread on a running full refresh; apply after it completes. If the
+      // refresh finished between the check and the enqueue, drain immediately — poll() makes a
+      // double drain harmless.
+      pendingDeltas.add(e);
+      if (!cache.isRenewInFlight()) {
+        drainPendingDeltas();
+      }
+      return;
+    }
+    applyDelta(e);
+  }
+
+  private void drainPendingDeltas() {
+    SMigratedEvent e;
+    while ((e = pendingDeltas.poll()) != null) {
+      applyDelta(e);
+    }
+  }
+
+  /**
+   * Applies the delta and retires the connections of nodes left without slots (Case 2). A node
+   * still owning slots after the delta keeps its connections untouched (Case 1). Retirement goes
+   * through the node pool's own controller, resolved now — a pool destroyed by a racing refresh
+   * simply no longer resolves.
+   */
+  private void applyDelta(SMigratedEvent e) {
+    Set<HostAndPort> slotless = cache.applyMigrationDelta(e.migrations);
+    if (slotless.isEmpty()) {
+      return;
+    }
+    long now = NanoClock.INSTANCE.getAsLong();
+    Map<String, ConnectionPool> nodes = cache.getNodes();
+    for (HostAndPort node : slotless) {
+      ConnectionPool pool = nodes.get(JedisClusterInfoCache.getNodeKey(node));
+      MaintenanceEventController controller = pool == null ? null : pool.getMaintenanceController();
+      if (controller != null) {
+        logger.debug("Node {} owns no slots after migration (seq={}); retiring its connections",
+          node, e.seq);
+        controller.retireAll(now);
+      }
+    }
+  }
+
+  /** One client-wide migration operation, folded from the per-node broadcast; keyed by seq. */
+  private static final class MigrationOperation {
+    final Object id;
+    final long deadlineNanos;
+    final boolean closed;
+
+    private MigrationOperation(Object id, long deadlineNanos, boolean closed) {
+      this.id = id;
+      this.deadlineNanos = deadlineNanos;
+      this.closed = closed;
+    }
+
+    MigrationOperation(Object id, long deadlineNanos) {
+      this(id, deadlineNanos, false);
+    }
+
+    static MigrationOperation closed(Object id, long deadlineNanos) {
+      return new MigrationOperation(id, deadlineNanos, true);
+    }
+
+    MigrationOperation close() {
+      return new MigrationOperation(id, deadlineNanos, true);
+    }
+
+    boolean isExpired() {
+      return deadlineNanos - NanoClock.INSTANCE.getAsLong() <= 0;
+    }
+  }
+
+  @Override
+  public void onMoving(MovingEvent e, Connection c) {
+    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
+
+  @Override
+  public void onMigrating(MigratingEvent e, Connection c) {
+    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
+
+  @Override
+  public void onMigrated(MigratedEvent e, Connection c) {
+    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
+
+  @Override
+  public void onFailingOver(FailingOverEvent e, Connection c) {
+    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
+
+  @Override
+  public void onFailedOver(FailedOverEvent e, Connection c) {
+    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
+}

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
@@ -18,7 +18,7 @@ import redis.clients.jedis.TimeoutSource.TimeoutInfo;
  * {@link JedisClusterInfoCache#applySlotMigration}, which queues and applies it atomically against
  * the refresh lifecycle — never blocking or spinning a read thread on a running refresh.
  */
-final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
+final class ClusterMaintenanceCoordinator {
 
   private static final Logger logger = LoggerFactory.getLogger(ClusterMaintenanceCoordinator.class);
 
@@ -33,13 +33,24 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
    */
   private final ConcurrentHashMap<Object, MigrationOperation> operations = new ConcurrentHashMap<>();
 
+  private final MaintenanceNotificationsConfig config;
+
   ClusterMaintenanceCoordinator(JedisClusterInfoCache cache,
       MaintenanceNotificationsConfig config) {
     this.cache = cache;
+    this.config = config;
     this.maxRelaxedDurationNanos = config.getRelaxedWindowMaxDuration().toNanos();
     TimeoutInfo relaxedTimeoutInfo = new TimeoutInfo(config.getRelaxedTimeout(),
         config.getRelaxedBlockingTimeout());
     this.timeoutSupplier = () -> hasActiveMigration() ? relaxedTimeoutInfo : null;
+  }
+
+  /**
+   * The config this coordinator was built from; drives the cluster connections' MAINT_NOTIFICATIONS
+   * handshake.
+   */
+  MaintenanceNotificationsConfig getConfig() {
+    return config;
   }
 
   /** The client-wide relax gate consulted by every cluster connection's timeout overlay. */
@@ -64,8 +75,8 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
     return false;
   }
 
-  @Override
-  public void onSMigrating(SMigratingEvent e, Connection c) {
+  /** Dispatched by each pool's {@link ClusterMaintenanceController} on the read thread. */
+  void onSMigrating(SMigratingEvent e, Connection c) {
     if (logger.isDebugEnabled()) {
       logger.debug("Slot migration starting: {} (seq={}) conn={}", e.slots, e.seq,
         c.toIdentityString());
@@ -75,8 +86,8 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
     c.applyCurrentTimeout(); // the gate just opened; push the relax to the receiving socket now
   }
 
-  @Override
-  public void onSMigrated(SMigratedEvent e, Connection c) {
+  /** Dispatched by each pool's {@link ClusterMaintenanceController} on the read thread. */
+  void onSMigrated(SMigratedEvent e, Connection c) {
     long deadline = NanoClock.INSTANCE.getAsLong() + maxRelaxedDurationNanos;
     boolean[] firstDelivery = { false };
     operations.compute(e.identity(), (k, cur) -> { // atomic per identity
@@ -139,33 +150,4 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
     }
   }
 
-  @Override
-  public void onMoving(MovingEvent e, Connection c) {
-    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
-      c);
-  }
-
-  @Override
-  public void onMigrating(MigratingEvent e, Connection c) {
-    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
-      c);
-  }
-
-  @Override
-  public void onMigrated(MigratedEvent e, Connection c) {
-    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
-      c);
-  }
-
-  @Override
-  public void onFailingOver(FailingOverEvent e, Connection c) {
-    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
-      c);
-  }
-
-  @Override
-  public void onFailedOver(FailedOverEvent e, Connection c) {
-    logger.warn("Standalone maintenance events are not supported by this controller: {} conn={}", e,
-      c);
-  }
 }

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
@@ -19,8 +19,8 @@ import redis.clients.jedis.TimeoutSource.TimeoutInfo;
  * the last one closes, and a connection created mid-event relaxes from the moment its overlay is
  * installed. On SMIGRATED it applies the slot delta atomically through
  * {@link JedisClusterInfoCache#applyMigrationDelta} — queued and drained after completion when a
- * full topology refresh is in flight, never blocking a read thread — and retires the connections
- * of nodes left without slots via each pool's own {@link MaintenanceEventController}, resolved at
+ * full topology refresh is in flight, never blocking a read thread — and retires the connections of
+ * nodes left without slots via each pool's own {@link MaintenanceEventController}, resolved at
  * event time (no node map here). The pools remain their controllers' sole owners; this class only
  * calls.
  */
@@ -61,15 +61,14 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
     if (operations.isEmpty()) {
       return false;
     }
-    boolean active = false;
     for (MigrationOperation op : operations.values()) {
       if (op.isExpired()) {
         operations.remove(op.id, op);
-      } else if (!op.closed) {
-        active = true;
+      } else if (op.isMigrating()) {
+        return true;
       }
     }
-    return active;
+    return false;
   }
 
   @Override
@@ -79,7 +78,7 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
         c.toIdentityString());
     }
     long deadline = NanoClock.INSTANCE.getAsLong() + maxRelaxedDurationNanos;
-    operations.computeIfAbsent(e.identity(), k -> new MigrationOperation(k, deadline));
+    operations.computeIfAbsent(e.identity(), k -> new MigrationOperation(k, e.seq, deadline, true));
     c.applyCurrentTimeout(); // the gate just opened; push the relax to the receiving socket now
   }
 
@@ -91,14 +90,11 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
       if (cur == null) {
         // SMIGRATED without a preceding SMIGRATING (e.g. connected mid-event): still applied
         firstDelivery[0] = true;
-        return MigrationOperation.closed(k, deadline);
-      }
-      if (!cur.closed) {
-        firstDelivery[0] = true;
-        return cur.close();
+        return new MigrationOperation(k, e.seq, deadline, false);
       }
       return cur; // duplicate broadcast delivery; retained to absorb the rest
     });
+    discardOutdatedMigrationWindows(e.seq);
     c.applyCurrentTimeout(); // unrelax the receiving socket if the gate just shut
     if (!firstDelivery[0]) {
       return;
@@ -115,6 +111,26 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
       return;
     }
     applyDelta(e);
+  }
+
+  /**
+   * Seq ids are ordered and an opening/closing pair shares one, so a closing SMIGRATED also
+   * concludes any operation opened under a lower seq whose own SMIGRATED never arrived (lost or
+   * reordered) — the stale opener must not keep the relax gate held. A cancelled entry behaves like
+   * a closed one: it is retained until its TTL, so a late lower-seq SMIGRATED is absorbed as a
+   * duplicate rather than applying an out-of-order delta (the MOVED fallback self-heals the
+   * topology if that loses one).
+   */
+  private void discardOutdatedMigrationWindows(long closingSeq) {
+    for (MigrationOperation op : operations.values()) {
+      if (op.seq < closingSeq) {
+        operations.remove(op.id, op); // best-effort: a racing delivery may have already replaced it
+        if (logger.isDebugEnabled()) {
+          logger.debug("Discarding stale migration window (seq={}) on closing seq={}", op.seq,
+            closingSeq);
+        }
+      }
+    }
   }
 
   private void drainPendingDeltas() {
@@ -151,29 +167,23 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
   /** One client-wide migration operation, folded from the per-node broadcast; keyed by seq. */
   private static final class MigrationOperation {
     final Object id;
+    final long seq;
     final long deadlineNanos;
-    final boolean closed;
+    final boolean isMigrating;
 
-    private MigrationOperation(Object id, long deadlineNanos, boolean closed) {
+    private MigrationOperation(Object id, long seq, long deadlineNanos, boolean isMigrating) {
       this.id = id;
+      this.seq = seq;
       this.deadlineNanos = deadlineNanos;
-      this.closed = closed;
-    }
-
-    MigrationOperation(Object id, long deadlineNanos) {
-      this(id, deadlineNanos, false);
-    }
-
-    static MigrationOperation closed(Object id, long deadlineNanos) {
-      return new MigrationOperation(id, deadlineNanos, true);
-    }
-
-    MigrationOperation close() {
-      return new MigrationOperation(id, deadlineNanos, true);
+      this.isMigrating = isMigrating;
     }
 
     boolean isExpired() {
       return deadlineNanos - NanoClock.INSTANCE.getAsLong() <= 0;
+    }
+
+    boolean isMigrating() {
+      return isMigrating;
     }
   }
 

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
@@ -15,8 +15,8 @@ import redis.clients.jedis.TimeoutSource.TimeoutInfo;
  * timeouts stay relaxed while ANY operation is open, so overlapping migrations unrelax only when
  * the last one closes, and a connection created mid-event relaxes from the moment its overlay is
  * installed. On the first SMIGRATED delivery it hands the slot delta to
- * {@link JedisClusterInfoCache#applySlotMigration}, which queues and applies it atomically
- * against the refresh lifecycle — never blocking or spinning a read thread on a running refresh.
+ * {@link JedisClusterInfoCache#applySlotMigration}, which queues and applies it atomically against
+ * the refresh lifecycle — never blocking or spinning a read thread on a running refresh.
  */
 final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
 

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
@@ -14,23 +14,23 @@ import redis.clients.jedis.TimeoutSource.TimeoutInfo;
  * N-connection broadcast into one client-wide operation and (b) drives the shared relax gate:
  * timeouts stay relaxed while ANY operation is open, so overlapping migrations unrelax only when
  * the last one closes, and a connection created mid-event relaxes from the moment its overlay is
- * installed. On SMIGRATED it hands the slot delta to
- * {@link JedisClusterInfoCache#applyMigrationDelta}, which queues and applies it atomically
- * against the refresh lifecycle (never blocking a read thread), then — once the delta is really
- * applied — retires the connections of nodes left without slots via each pool's own
- * {@link MaintenanceEventController}, resolved at reaction time (no node map here). The pools
- * remain their controllers' sole owners; this class only calls.
+ * installed. On the first SMIGRATED delivery it hands the slot delta to
+ * {@link JedisClusterInfoCache#applySlotMigration}, which queues and applies it atomically
+ * against the refresh lifecycle — never blocking or spinning a read thread on a running refresh.
  */
 final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
 
   private static final Logger logger = LoggerFactory.getLogger(ClusterMaintenanceCoordinator.class);
 
   private final JedisClusterInfoCache cache;
-  /** Backstop for an SMIGRATING whose SMIGRATED is lost, and retention of closed entries. */
+  /** Backstop for an SMIGRATING whose SMIGRATED is lost, and retention of concluded entries. */
   private final long maxRelaxedDurationNanos;
   private final Supplier<TimeoutInfo> timeoutSupplier;
 
-  /** Seq-keyed operations: open entries gate the relax; closed entries absorb late duplicates. */
+  /**
+   * Seq-keyed operations: migrating (SMIGRATING) entries gate the relax; non-migrating (SMIGRATED)
+   * entries absorb the remaining broadcast duplicates until their TTL.
+   */
   private final ConcurrentHashMap<Object, MigrationOperation> operations = new ConcurrentHashMap<>();
 
   ClusterMaintenanceCoordinator(JedisClusterInfoCache cache,
@@ -93,18 +93,16 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
       return;
     }
     logger.debug("Slot migration done (seq={}, entries={})", e.seq, e.migrations.size());
-    // the cache queues and applies atomically against its refresh lifecycle; the reaction fires
-    // once the delta is really applied, possibly on a later drainer's thread
-    cache.applyMigrationDelta(e.migrations);
+    // the cache queues and applies atomically against its refresh lifecycle; a delta racing a
+    // refresh may be applied later, on the refreshing/draining thread
+    cache.applySlotMigration(e.migrations);
   }
 
   /**
-   * Seq ids are ordered and an opening/closing pair shares one, so a closing SMIGRATED also
-   * concludes any operation opened under a lower seq whose own SMIGRATED never arrived (lost or
-   * reordered) — the stale opener must not keep the relax gate held. A cancelled entry behaves like
-   * a closed one: it is retained until its TTL, so a late lower-seq SMIGRATED is absorbed as a
-   * duplicate rather than applying an out-of-order delta (the MOVED fallback self-heals the
-   * topology if that loses one).
+   * Seq ids are ordered, so a closing SMIGRATED also concludes any operation opened under a lower
+   * seq whose own SMIGRATED never arrived (lost or reordered) — the stale opener must not keep the
+   * relax gate held. Discarded entries are removed outright; a late lower-seq SMIGRATED would then
+   * re-apply as a fresh delta (the MOVED fallback self-heals the topology if it was stale).
    */
   private void discardOutdatedMigrationWindows(long closingSeq) {
     for (MigrationOperation op : operations.values()) {

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceCoordinator.java
@@ -1,9 +1,6 @@
 package redis.clients.jedis;
 
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -17,12 +14,12 @@ import redis.clients.jedis.TimeoutSource.TimeoutInfo;
  * N-connection broadcast into one client-wide operation and (b) drives the shared relax gate:
  * timeouts stay relaxed while ANY operation is open, so overlapping migrations unrelax only when
  * the last one closes, and a connection created mid-event relaxes from the moment its overlay is
- * installed. On SMIGRATED it applies the slot delta atomically through
- * {@link JedisClusterInfoCache#applyMigrationDelta} — queued and drained after completion when a
- * full topology refresh is in flight, never blocking a read thread — and retires the connections of
- * nodes left without slots via each pool's own {@link MaintenanceEventController}, resolved at
- * event time (no node map here). The pools remain their controllers' sole owners; this class only
- * calls.
+ * installed. On SMIGRATED it hands the slot delta to
+ * {@link JedisClusterInfoCache#applyMigrationDelta}, which queues and applies it atomically
+ * against the refresh lifecycle (never blocking a read thread), then — once the delta is really
+ * applied — retires the connections of nodes left without slots via each pool's own
+ * {@link MaintenanceEventController}, resolved at reaction time (no node map here). The pools
+ * remain their controllers' sole owners; this class only calls.
  */
 final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
 
@@ -36,9 +33,6 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
   /** Seq-keyed operations: open entries gate the relax; closed entries absorb late duplicates. */
   private final ConcurrentHashMap<Object, MigrationOperation> operations = new ConcurrentHashMap<>();
 
-  /** SMIGRATED deltas received while a full refresh was in flight; drained post-refresh. */
-  private final ConcurrentLinkedQueue<SMigratedEvent> pendingDeltas = new ConcurrentLinkedQueue<>();
-
   ClusterMaintenanceCoordinator(JedisClusterInfoCache cache,
       MaintenanceNotificationsConfig config) {
     this.cache = cache;
@@ -46,7 +40,6 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
     TimeoutInfo relaxedTimeoutInfo = new TimeoutInfo(config.getRelaxedTimeout(),
         config.getRelaxedBlockingTimeout());
     this.timeoutSupplier = () -> hasActiveMigration() ? relaxedTimeoutInfo : null;
-    cache.setPostRefreshHook(this::drainPendingDeltas);
   }
 
   /** The client-wide relax gate consulted by every cluster connection's timeout overlay. */
@@ -100,17 +93,9 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
       return;
     }
     logger.debug("Slot migration done (seq={}, entries={})", e.seq, e.migrations.size());
-    if (cache.isRenewInFlight()) {
-      // Never block the read thread on a running full refresh; apply after it completes. If the
-      // refresh finished between the check and the enqueue, drain immediately — poll() makes a
-      // double drain harmless.
-      pendingDeltas.add(e);
-      if (!cache.isRenewInFlight()) {
-        drainPendingDeltas();
-      }
-      return;
-    }
-    applyDelta(e);
+    // the cache queues and applies atomically against its refresh lifecycle; the reaction fires
+    // once the delta is really applied, possibly on a later drainer's thread
+    cache.applyMigrationDelta(e.migrations);
   }
 
   /**
@@ -129,37 +114,6 @@ final class ClusterMaintenanceCoordinator implements MaintenanceEventListener {
           logger.debug("Discarding stale migration window (seq={}) on closing seq={}", op.seq,
             closingSeq);
         }
-      }
-    }
-  }
-
-  private void drainPendingDeltas() {
-    SMigratedEvent e;
-    while ((e = pendingDeltas.poll()) != null) {
-      applyDelta(e);
-    }
-  }
-
-  /**
-   * Applies the delta and retires the connections of nodes left without slots (Case 2). A node
-   * still owning slots after the delta keeps its connections untouched (Case 1). Retirement goes
-   * through the node pool's own controller, resolved now — a pool destroyed by a racing refresh
-   * simply no longer resolves.
-   */
-  private void applyDelta(SMigratedEvent e) {
-    Set<HostAndPort> slotless = cache.applyMigrationDelta(e.migrations);
-    if (slotless.isEmpty()) {
-      return;
-    }
-    long now = NanoClock.INSTANCE.getAsLong();
-    Map<String, ConnectionPool> nodes = cache.getNodes();
-    for (HostAndPort node : slotless) {
-      ConnectionPool pool = nodes.get(JedisClusterInfoCache.getNodeKey(node));
-      MaintenanceEventController controller = pool == null ? null : pool.getMaintenanceController();
-      if (controller != null) {
-        logger.debug("Node {} owns no slots after migration (seq={}); retiring its connections",
-          node, e.seq);
-        controller.retireAll(now);
       }
     }
   }

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
@@ -8,21 +8,10 @@ import java.util.List;
  * {@link MaintenanceEvent}: the two message families are exclusive contracts — a connection
  * receives one family or the other, never both.
  */
-abstract class ClusterMaintenanceEvent {
-
-  final long seq;
+abstract class ClusterMaintenanceEvent extends MaintenanceEvent {
 
   ClusterMaintenanceEvent(long seq) {
-    this.seq = seq;
-  }
-
-  /**
-   * Identity of the server-side operation this event announces; SMIGRATING and its terminating
-   * SMIGRATED share the same seq, and equality is the dedup rule for folding the per-node broadcast
-   * into one client-wide operation.
-   */
-  Object identity() {
-    return seq;
+    super(seq);
   }
 }
 
@@ -37,6 +26,12 @@ final class SMigratingEvent extends ClusterMaintenanceEvent {
     super(seq);
     this.slots = slots;
   }
+
+  @Override
+  void accept(MaintenanceEventListener listener, Connection conn) {
+    listener.onSMigrating(this, conn);
+  }
+
 }
 
 /**
@@ -49,6 +44,11 @@ final class SMigratedEvent extends ClusterMaintenanceEvent {
   SMigratedEvent(long seq, List<SlotMigration> migrations) {
     super(seq);
     this.migrations = Collections.unmodifiableList(migrations);
+  }
+
+  @Override
+  void accept(MaintenanceEventListener listener, Connection conn) {
+    listener.onSMigrated(this, conn);
   }
 }
 

--- a/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
+++ b/src/main/java/redis/clients/jedis/ClusterMaintenanceEvent.java
@@ -1,0 +1,71 @@
+package redis.clients.jedis;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A cluster maintenance event (OSS cluster mode). A hierarchy deliberately separate from
+ * {@link MaintenanceEvent}: the two message families are exclusive contracts — a connection
+ * receives one family or the other, never both.
+ */
+abstract class ClusterMaintenanceEvent {
+
+  final long seq;
+
+  ClusterMaintenanceEvent(long seq) {
+    this.seq = seq;
+  }
+
+  /**
+   * Identity of the server-side operation this event announces; SMIGRATING and its terminating
+   * SMIGRATED share the same seq, and equality is the dedup rule for folding the per-node broadcast
+   * into one client-wide operation.
+   */
+  Object identity() {
+    return seq;
+  }
+}
+
+/**
+ * {@code [SMIGRATING, seq, slots-or-ranges]} — a slot migration is starting; relax timeouts until
+ * the SMIGRATED with the same seq.
+ */
+final class SMigratingEvent extends ClusterMaintenanceEvent {
+  final HashSlotRanges slots;
+
+  SMigratingEvent(long seq, HashSlotRanges slots) {
+    super(seq);
+    this.slots = slots;
+  }
+}
+
+/**
+ * {@code [SMIGRATED, seq, [[src, dest, slots-or-ranges], ...]]} — the migration ended; unrelax,
+ * apply the slot delta, and retire connections to nodes left without slots.
+ */
+final class SMigratedEvent extends ClusterMaintenanceEvent {
+  final List<SlotMigration> migrations;
+
+  SMigratedEvent(long seq, List<SlotMigration> migrations) {
+    super(seq);
+    this.migrations = Collections.unmodifiableList(migrations);
+  }
+}
+
+/** One SMIGRATED entry: the given slots moved from {@code src} to {@code dest}. */
+final class SlotMigration {
+  final HostAndPort src;
+  final HostAndPort dest;
+  final HashSlotRanges slots;
+
+  SlotMigration(HostAndPort src, HostAndPort dest, HashSlotRanges slots) {
+    this.src = src;
+    this.dest = dest;
+    this.slots = slots;
+  }
+
+  @Override
+  public String toString() {
+    return src + " -> " + dest + " [" + slots + "]";
+  }
+}

--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -27,7 +27,7 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
     private JedisSocketFactory jedisSocketFactory;
     private Cache cache;
     private HostAndPort hostAndPort;
-    private MaintenanceEventController maintenanceController;
+    private MaintenanceController maintenanceController;
 
     // Fluent API methods (preferred)
     public Builder clientConfig(JedisClientConfig clientConfig) {
@@ -56,11 +56,11 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
     }
 
     /**
-     * Maintenance controller propagated to the default socket factory (as the post-DNS
-     * address mapper for MOVING redirects) and to the default {@link Connection.Builder} (so each
+     * Maintenance controller propagated to the default socket factory (as the controller's post-DNS
+     * address mapper, when it has one) and to the default {@link Connection.Builder} (so each
      * connection forwards push frames to it). {@code null} disables maintenance for this factory.
      */
-    Builder maintenanceController(MaintenanceEventController maintenanceController) {
+    Builder maintenanceController(MaintenanceController maintenanceController) {
       this.maintenanceController = maintenanceController;
       return this;
     }
@@ -107,7 +107,8 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
       if (hostAndPort == null) {
         throw new IllegalStateException("HostAndPort is required when no socketFactory is provided");
       }
-      return new DefaultJedisSocketFactory(hostAndPort, clientConfig, maintenanceController);
+      return new DefaultJedisSocketFactory(hostAndPort, clientConfig,
+          maintenanceController == null ? null : maintenanceController.socketAddressMapper());
     }
 
     private Connection.Builder createDefaultConnectionBuilder() {

--- a/src/main/java/redis/clients/jedis/ConnectionFactory.java
+++ b/src/main/java/redis/clients/jedis/ConnectionFactory.java
@@ -28,6 +28,7 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
     private Cache cache;
     private HostAndPort hostAndPort;
     private MaintenanceController maintenanceController;
+    private SocketAddressMapper socketAddressMapper;
 
     // Fluent API methods (preferred)
     public Builder clientConfig(JedisClientConfig clientConfig) {
@@ -62,6 +63,11 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
      */
     Builder maintenanceController(MaintenanceController maintenanceController) {
       this.maintenanceController = maintenanceController;
+      return this;
+    }
+
+    Builder socketAddressMapper(SocketAddressMapper socketAddressMapper) {
+      this.socketAddressMapper = socketAddressMapper;
       return this;
     }
 
@@ -107,8 +113,7 @@ public class ConnectionFactory implements PooledObjectFactory<Connection> {
       if (hostAndPort == null) {
         throw new IllegalStateException("HostAndPort is required when no socketFactory is provided");
       }
-      return new DefaultJedisSocketFactory(hostAndPort, clientConfig,
-          maintenanceController == null ? null : maintenanceController.socketAddressMapper());
+      return new DefaultJedisSocketFactory(hostAndPort, clientConfig, socketAddressMapper);
     }
 
     private Connection.Builder createDefaultConnectionBuilder() {

--- a/src/main/java/redis/clients/jedis/ConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/ConnectionPool.java
@@ -74,9 +74,14 @@ public class ConnectionPool extends Pool<Connection> {
         .cache(clientSideCache), poolConfig, maintConfig);
   }
 
-  private static MaintenanceEventController controllerFor(MaintenanceNotificationsConfig config) {
-    return config != null && config.isEnabledOrAuto() ? MaintenanceEventController.from(config)
-        : null;
+  private static MaintenanceEventController controllerFor(MaintenanceNotificationsConfig config,
+      ConnectionFactory.Builder factoryBuilder) {
+    if (config != null && config.isEnabledOrAuto()) {
+      MaintenanceEventController controller = MaintenanceEventController.from(config);
+      factoryBuilder.socketAddressMapper(controller);
+      return controller;
+    }
+    return null;
   }
 
   /**
@@ -87,7 +92,7 @@ public class ConnectionPool extends Pool<Connection> {
   @Experimental
   public ConnectionPool(ConnectionFactory.Builder factoryBuilder,
       GenericObjectPoolConfig<Connection> poolConfig, MaintenanceNotificationsConfig maintConfig) {
-    this(factoryBuilder, poolConfig, controllerFor(maintConfig));
+    this(factoryBuilder, poolConfig, controllerFor(maintConfig, factoryBuilder));
   }
 
   ConnectionPool(HostAndPort hostAndPort, JedisClientConfig clientConfig, Cache clientSideCache,

--- a/src/main/java/redis/clients/jedis/ConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/ConnectionPool.java
@@ -4,8 +4,6 @@ import java.util.function.Consumer;
 
 import org.apache.commons.pool2.PooledObjectFactory;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import redis.clients.authentication.core.Token;
 import redis.clients.jedis.annots.Experimental;
@@ -17,10 +15,8 @@ import redis.clients.jedis.util.Pool;
 
 public class ConnectionPool extends Pool<Connection> {
 
-  private static final Logger log = LoggerFactory.getLogger(ConnectionPool.class);
-
   private AuthXManager authXManager;
-  private MaintenanceController maintenanceController; // null = maintenance off
+  private PoolMaintenance maintenance = PoolMaintenance.OFF;
   private final Consumer<Connection> returnHook;
 
   // Primary constructors using factory
@@ -74,16 +70,6 @@ public class ConnectionPool extends Pool<Connection> {
         .cache(clientSideCache), poolConfig, maintConfig);
   }
 
-  private static MaintenanceEventController controllerFor(MaintenanceNotificationsConfig config,
-      ConnectionFactory.Builder factoryBuilder) {
-    if (config != null && config.isEnabledOrAuto()) {
-      MaintenanceEventController controller = MaintenanceEventController.from(config);
-      factoryBuilder.socketAddressMapper(controller);
-      return controller;
-    }
-    return null;
-  }
-
   /**
    * Creates the pool from a connection-factory builder with maintenance notifications configured
    * for its connections; {@code null} disables them.
@@ -92,58 +78,39 @@ public class ConnectionPool extends Pool<Connection> {
   @Experimental
   public ConnectionPool(ConnectionFactory.Builder factoryBuilder,
       GenericObjectPoolConfig<Connection> poolConfig, MaintenanceNotificationsConfig maintConfig) {
-    this(factoryBuilder, poolConfig, controllerFor(maintConfig, factoryBuilder));
+    this(factoryBuilder, poolConfig, PoolMaintenance.standalone(maintConfig));
   }
 
   ConnectionPool(HostAndPort hostAndPort, JedisClientConfig clientConfig, Cache clientSideCache,
-      GenericObjectPoolConfig<Connection> poolConfig, MaintenanceController controller) {
+      GenericObjectPoolConfig<Connection> poolConfig, PoolMaintenance maintenance) {
     this(ConnectionFactory.builder().hostAndPort(hostAndPort).clientConfig(clientConfig)
-        .cache(clientSideCache), poolConfig, controller);
+        .cache(clientSideCache), poolConfig, maintenance);
   }
 
   private ConnectionPool(ConnectionFactory.Builder factoryBuilder,
-      GenericObjectPoolConfig<Connection> poolConfig, MaintenanceController controller) {
-    super(factoryBuilder.maintenanceController(controller).build(), poolConfig);
-    this.maintenanceController = controller;
+      GenericObjectPoolConfig<Connection> poolConfig, PoolMaintenance maintenance) {
+    super(maintenance.configure(factoryBuilder).build(), poolConfig);
+    this.maintenance = maintenance;
     attachAuthenticationListener(factoryBuilder.getClientConfig().getAuthXManager());
-    if (controller instanceof MaintenanceEventController) {
-      // retirement plumbing exists only for the standalone controller; cluster connections are
-      // never retired individually — their Case-2 teardown is pool-level
-      setEvictionPolicy(new RebindAwareEvictionPolicy(getEvictionPolicy()));
-      // handoff processed: evict the retired idles
-      ((MaintenanceEventController) controller).setHandoffHook(this::evictQuietly);
-      returnHook = c -> {
+    if (maintenance == PoolMaintenance.OFF) {
+      this.returnHook = super::returnResource;
+    } else {
+      // a retired connection (Connection.isRetired) is destroyed on return instead of reused
+      this.returnHook = c -> {
         if (c.isRetired()) {
           super.returnBrokenResource(c);
         } else {
           super.returnResource(c);
         }
       };
-    } else {
-      returnHook = super::returnResource;
     }
-  }
-
-  /**
-   * Handoff-hook reaction: evict retired idles. Runs on the maintenance scheduler thread or inline
-   * on a notifying thread; must never propagate (a failed pass degrades to lazy recycling on
-   * return).
-   */
-  private void evictQuietly() {
-    if (isClosed()) {
-      return;
-    }
-    try {
-      evict();
-    } catch (Exception e) {
-      log.warn("Maintenance eviction pass failed; retired connections recycle on return", e);
-    }
+    maintenance.attach(this);
   }
 
   /** Exposes the pool's maintenance controller ({@code null} when off) for test clock injection. */
   @VisibleForTesting
   MaintenanceController getMaintenanceController() {
-    return maintenanceController;
+    return maintenance.controller();
   }
 
   @Override
@@ -169,9 +136,7 @@ public class ConnectionPool extends Pool<Connection> {
     try {
       super.destroy();
     } finally {
-      if (maintenanceController != null) {
-        maintenanceController.close();
-      }
+      maintenance.close();
     }
   }
 

--- a/src/main/java/redis/clients/jedis/ConnectionPool.java
+++ b/src/main/java/redis/clients/jedis/ConnectionPool.java
@@ -20,7 +20,7 @@ public class ConnectionPool extends Pool<Connection> {
   private static final Logger log = LoggerFactory.getLogger(ConnectionPool.class);
 
   private AuthXManager authXManager;
-  private MaintenanceEventController maintenanceController; // null = maintenance off
+  private MaintenanceController maintenanceController; // null = maintenance off
   private final Consumer<Connection> returnHook;
 
   // Primary constructors using factory
@@ -90,16 +90,24 @@ public class ConnectionPool extends Pool<Connection> {
     this(factoryBuilder, poolConfig, controllerFor(maintConfig));
   }
 
+  ConnectionPool(HostAndPort hostAndPort, JedisClientConfig clientConfig, Cache clientSideCache,
+      GenericObjectPoolConfig<Connection> poolConfig, MaintenanceController controller) {
+    this(ConnectionFactory.builder().hostAndPort(hostAndPort).clientConfig(clientConfig)
+        .cache(clientSideCache), poolConfig, controller);
+  }
+
   private ConnectionPool(ConnectionFactory.Builder factoryBuilder,
-      GenericObjectPoolConfig<Connection> poolConfig, MaintenanceEventController controller) {
+      GenericObjectPoolConfig<Connection> poolConfig, MaintenanceController controller) {
     super(factoryBuilder.maintenanceController(controller).build(), poolConfig);
     this.maintenanceController = controller;
     attachAuthenticationListener(factoryBuilder.getClientConfig().getAuthXManager());
-    if (controller != null) {
+    if (controller instanceof MaintenanceEventController) {
+      // retirement plumbing exists only for the standalone controller; cluster connections are
+      // never retired individually — their Case-2 teardown is pool-level
       setEvictionPolicy(new RebindAwareEvictionPolicy(getEvictionPolicy()));
       // handoff processed: evict the retired idles
-      controller.setHandoffHook(this::evictQuietly);
-       returnHook = c -> {
+      ((MaintenanceEventController) controller).setHandoffHook(this::evictQuietly);
+      returnHook = c -> {
         if (c.isRetired()) {
           super.returnBrokenResource(c);
         } else {
@@ -129,7 +137,7 @@ public class ConnectionPool extends Pool<Connection> {
 
   /** Exposes the pool's maintenance controller ({@code null} when off) for test clock injection. */
   @VisibleForTesting
-  MaintenanceEventController getMaintenanceController() {
+  MaintenanceController getMaintenanceController() {
     return maintenanceController;
   }
 

--- a/src/main/java/redis/clients/jedis/HashSlotRanges.java
+++ b/src/main/java/redis/clients/jedis/HashSlotRanges.java
@@ -1,0 +1,84 @@
+package redis.clients.jedis;
+
+import java.util.function.IntConsumer;
+
+/**
+ * An immutable set of hash slots expressed as comma-separated slots and/or inclusive
+ * {@code from-to} ranges, e.g. {@code "123,456,789-1000"} — the slots-or-ranges wire format of
+ * cluster maintenance pushes.
+ */
+final class HashSlotRanges {
+
+  /** Inclusive bounds, flattened as {@code [from0, to0, from1, to1, ...]} in wire order. */
+  private final int[] bounds;
+  private final String source;
+
+  private HashSlotRanges(int[] bounds, String source) {
+    this.bounds = bounds;
+    this.source = source;
+  }
+
+  /**
+   * Parses the slots-or-ranges wire format.
+   * @throws IllegalArgumentException on an empty string, a non-numeric token, an inverted range, or
+   *           a slot outside {@code [0, 16384)}
+   */
+  static HashSlotRanges parse(String s) {
+    if (s == null || s.isEmpty()) {
+      throw new IllegalArgumentException("Empty slot ranges");
+    }
+    String[] tokens = s.split(",");
+    int[] bounds = new int[tokens.length * 2];
+    for (int t = 0; t < tokens.length; t++) {
+      String token = tokens[t];
+      int dash = token.indexOf('-');
+      int from, to;
+      try {
+        if (dash < 0) {
+          from = to = Integer.parseInt(token);
+        } else {
+          from = Integer.parseInt(token.substring(0, dash));
+          to = Integer.parseInt(token.substring(dash + 1));
+        }
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Unparseable slot range token: " + token, e);
+      }
+      if (from < 0 || to < from || to >= Protocol.CLUSTER_HASHSLOTS) {
+        throw new IllegalArgumentException("Slot range out of bounds: " + token);
+      }
+      bounds[t * 2] = from;
+      bounds[t * 2 + 1] = to;
+    }
+    return new HashSlotRanges(bounds, s);
+  }
+
+  boolean contains(int slot) {
+    for (int i = 0; i < bounds.length; i += 2) {
+      if (slot >= bounds[i] && slot <= bounds[i + 1]) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  int slotCount() {
+    int count = 0;
+    for (int i = 0; i < bounds.length; i += 2) {
+      count += bounds[i + 1] - bounds[i] + 1;
+    }
+    return count;
+  }
+
+  void forEachSlot(IntConsumer action) {
+    for (int i = 0; i < bounds.length; i += 2) {
+      for (int slot = bounds[i]; slot <= bounds[i + 1]; slot++) {
+        action.accept(slot);
+      }
+    }
+  }
+
+  @Override
+  public String toString() {
+    return source;
+  }
+}

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -47,7 +47,10 @@ public class JedisClusterInfoCache {
   private final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
   private final Lock r = rwl.readLock();
   private final Lock w = rwl.writeLock();
-  private final Lock rediscoverLock = new ReentrantLock();
+  private final ReentrantLock rediscoverLock = new ReentrantLock();
+
+  /** Notified after every {@link #renewClusterSlots} attempt completes; see the cluster coordinator. */
+  private volatile Runnable postRefreshHook;
 
   private final GenericObjectPoolConfig<Connection> poolConfig;
   private final JedisClientConfig clientConfig;
@@ -232,8 +235,26 @@ public class JedisClusterInfoCache {
 
       } finally {
         rediscoverLock.unlock();
+        Runnable hook = postRefreshHook;
+        if (hook != null) {
+          hook.run();
+        }
       }
     }
+  }
+
+  /** True while a full topology refresh ({@link #renewClusterSlots}) is running. */
+  boolean isRenewInFlight() {
+    return rediscoverLock.isLocked();
+  }
+
+  /**
+   * Installs the hook run after every full-refresh attempt completes (successful or not), outside
+   * the rediscover lock. Single consumer: the cluster maintenance coordinator drains its queued
+   * slot deltas here.
+   */
+  void setPostRefreshHook(Runnable hook) {
+    this.postRefreshHook = hook;
   }
 
   private void discoverClusterSlots(Connection jedis) {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -365,6 +365,51 @@ public class JedisClusterInfoCache {
     }
   }
 
+  /**
+   * Applies an SMIGRATED slot delta atomically and reports which source nodes are left serving no
+   * slots. Under a SINGLE write-lock hold: provisions each destination node's pool
+   * ({@link #setupNodeIfNotExist}) and reassigns the entry's slots, then scans residual ownership
+   * for every distinct source. The single hold is a correctness requirement — applying and
+   * scanning in separate acquisitions leaves an interleaving window against
+   * {@link #renewClusterSlots}. Holds no event state; dedup of the broadcast is the caller's job.
+   * @return the source nodes that no longer own any slot (candidates for connection retirement);
+   *         their pools stay in place — removal belongs to the full-refresh dead-pool cleanup
+   */
+  Set<HostAndPort> applyMigrationDelta(List<SlotMigration> migrations) {
+    w.lock();
+    try {
+      for (SlotMigration migration : migrations) {
+        ConnectionPool destPool = setupNodeIfNotExist(migration.dest);
+        primaryNodesCache.put(getNodeKey(migration.dest), destPool);
+        migration.slots.forEachSlot(slot -> {
+          slots[slot] = destPool;
+          slotNodes[slot] = migration.dest;
+          if (replicaSlots != null) {
+            // the delta carries no replica placement; drop stale entries until the next refresh
+            replicaSlots[slot] = null;
+          }
+        });
+      }
+
+      Set<HostAndPort> slotless = new HashSet<>();
+      for (SlotMigration migration : migrations) {
+        slotless.add(migration.src);
+      }
+      for (int slot = 0; slot < slotNodes.length && !slotless.isEmpty(); slot++) {
+        if (slotNodes[slot] != null) {
+          slotless.remove(slotNodes[slot]);
+        }
+      }
+      // a slotless node is no longer a primary: keep broadcast/random selection off it
+      for (HostAndPort node : slotless) {
+        primaryNodesCache.remove(getNodeKey(node));
+      }
+      return slotless;
+    } finally {
+      w.unlock();
+    }
+  }
+
   public void assignSlotsToReplicaNode(List<Integer> targetSlots, HostAndPort targetNode) {
     w.lock();
     try {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -51,11 +51,14 @@ public class JedisClusterInfoCache {
   private final ReentrantLock rediscoverLock = new ReentrantLock();
 
   /**
-   * SMIGRATED slot deltas awaiting application. Deltas only ever apply under
-   * {@link #rediscoverLock} (see {@link #drainMigrationDeltas}), so they can never interleave with
-   * — and always order after — a full topology refresh.
+   * Guards slot-delta application. A full refresh holds it for its whole query→apply span (taken
+   * after, and released before, {@link #rediscoverLock} — only the refresh ever holds both, in that
+   * fixed order), so deltas can never interleave with — and always order after — a refresh, while a
+   * running drain never makes a concurrent {@link #renewClusterSlots} attempt skip itself.
    */
-  private final ConcurrentLinkedQueue<PendingMigrationDelta> pendingMigrationDeltas = new ConcurrentLinkedQueue<>();
+  private final ReentrantLock slotDeltaLock = new ReentrantLock();
+
+  private final ConcurrentLinkedQueue<PendingSlotDelta> pendingSlotDelta = new ConcurrentLinkedQueue<>();
 
   private final GenericObjectPoolConfig<Connection> poolConfig;
   private final JedisClientConfig clientConfig;
@@ -78,7 +81,8 @@ public class JedisClusterInfoCache {
     }
   }
 
-  public JedisClusterInfoCache(final JedisClientConfig clientConfig, final Set<HostAndPort> startNodes) {
+  public JedisClusterInfoCache(final JedisClientConfig clientConfig,
+      final Set<HostAndPort> startNodes) {
     this(clientConfig, null, null, startNodes);
   }
 
@@ -117,10 +121,11 @@ public class JedisClusterInfoCache {
       clientConfig.getAuthXManager().start();
     }
     if (topologyRefreshPeriod != null) {
-      logger.info("Cluster topology refresh start, period: {}, startNodes: {}", topologyRefreshPeriod, startNodes);
+      logger.info("Cluster topology refresh start, period: {}, startNodes: {}",
+        topologyRefreshPeriod, startNodes);
       topologyRefreshExecutor = Executors.newSingleThreadScheduledExecutor();
-      topologyRefreshExecutor.scheduleWithFixedDelay(new TopologyRefreshTask(), topologyRefreshPeriod.toMillis(),
-          topologyRefreshPeriod.toMillis(), TimeUnit.MILLISECONDS);
+      topologyRefreshExecutor.scheduleWithFixedDelay(new TopologyRefreshTask(),
+        topologyRefreshPeriod.toMillis(), topologyRefreshPeriod.toMillis(), TimeUnit.MILLISECONDS);
     }
     if (clientConfig.isReadOnlyForRedisClusterReplicas()) {
       replicaSlots = new ArrayList[Protocol.CLUSTER_HASHSLOTS];
@@ -130,7 +135,8 @@ public class JedisClusterInfoCache {
   }
 
   /**
-   * Check whether the number and order of slots in the cluster topology are equal to CLUSTER_HASHSLOTS
+   * Check whether the number and order of slots in the cluster topology are equal to
+   * CLUSTER_HASHSLOTS
    * @param slotsInfo the cluster topology
    * @return if slots is ok, return true, elese return false.
    */
@@ -198,9 +204,14 @@ public class JedisClusterInfoCache {
   }
 
   public void renewClusterSlots(Connection jedis) {
-    // If rediscovering is already in process - no need to start one more same rediscovering, just return
+    // If rediscovering is already in process - no need to start one more same rediscovering, just
+    // return
     if (rediscoverLock.tryLock()) {
       try {
+        // Exclude delta application for the whole query->apply span (blocking is fine: drains are
+        // short and memory-only). Deltas queued meanwhile apply in the finally below, ordered
+        // after the refreshed topology.
+        slotDeltaLock.lock();
         // First, if jedis is available, use jedis renew.
         if (jedis != null) {
           try {
@@ -239,11 +250,17 @@ public class JedisClusterInfoCache {
         }
 
       } finally {
+        slotDeltaLock.unlock();
         rediscoverLock.unlock();
+        try {
+          // releaser re-check: runs on every exit path, incl. success returns
+          drainSlotDeltas();
+        } catch (RuntimeException e) {
+          // never mask an in-flight discovery exception; queued deltas would re-drain on the next
+          // delta or refresh
+          logger.warn("Applying queued slot deltas after refresh failed", e);
+        }
       }
-      // deltas that arrived while this refresh held the lock could not drain; drain them now,
-      // ordered after the refreshed topology
-      drainMigrationDeltas();
     }
   }
 
@@ -377,62 +394,64 @@ public class JedisClusterInfoCache {
   }
 
   /**
-   * Queues an SMIGRATED slot delta and drains the queue if no full topology refresh is in flight.
-   * Enqueue-then-drain against {@link #rediscoverLock} makes the check atomic: deltas only ever
-   * apply while holding the lock, so a delta can neither interleave with a running refresh nor race
-   * ahead of it — a refresh drains whatever queued behind it as its own last step. Never blocks the
-   * calling (read) thread on a running refresh. {@code onSlotless} receives the source nodes the
-   * delta left without any slot (invoked outside all cache locks, possibly on a later drainer's
-   * thread); dedup of the broadcast is the caller's job.
+   * Queues a slot delta and drains the queue if no full topology refresh is in flight.
+   * Enqueue-then-drain against {@link #slotDeltaLock} makes the check atomic: deltas only ever
+   * apply while holding that lock, so a delta can neither interleave with a running refresh nor
+   * race ahead of it — a refresh drains whatever queued behind it right after releasing the lock
+   * (see {@link #renewClusterSlots}). Never blocks the calling (read) thread on a running refresh;
+   * dedup of the broadcast is the caller's job.
    */
-  void applyMigrationDelta(List<SlotMigration> migrations) {
-    pendingMigrationDeltas.add(new PendingMigrationDelta(migrations));
-    drainMigrationDeltas();
+  void applySlotMigration(List<SlotMigration> migrations) {
+    pendingSlotDelta.add(new PendingSlotDelta(migrations));
+    drainSlotDeltas();
   }
 
   /**
-   * Applies queued deltas while the rediscover lock is free; a failed {@code tryLock} means the
-   * holder — a running refresh or another drainer — drains as its last step. Re-checks after
-   * unlocking so an enqueue that slipped in during the drain is never stranded. Reactions run after
-   * unlock: no caller code executes under cache locks.
+   * Drains while {@link #slotDeltaLock} is free, re-checking the queue after every release: an
+   * enqueue can race a holder's last poll and see the lock still held — without the releaser
+   * looking again, that entry would strand until the next delta or refresh. A failed
+   * {@code tryLock} is safe to walk away from precisely because every holder re-checks after
+   * unlocking.
    */
-  private void drainMigrationDeltas() {
-    while (!pendingMigrationDeltas.isEmpty()) {
-      if (!rediscoverLock.tryLock()) {
+  private void drainSlotDeltas() {
+    // the loop on empty check to make sure no items left behind when race between multiple drain
+    // attempts
+    while (!pendingSlotDelta.isEmpty()) {
+      if (!slotDeltaLock.tryLock()) {
+        // never spin or block behind the holder
         return;
       }
       try {
-        PendingMigrationDelta delta;
-        while ((delta = pendingMigrationDeltas.poll()) != null) {
-          applySlotMigration(delta.migrations);
+        PendingSlotDelta delta;
+        while ((delta = pendingSlotDelta.poll()) != null) {
+          processSlotDelta(delta.migrations);
         }
       } finally {
-        rediscoverLock.unlock();
+        slotDeltaLock.unlock();
       }
-
     }
   }
 
-  /** An SMIGRATED delta awaiting application, with the caller's retirement reaction. */
-  private static final class PendingMigrationDelta {
+  /** A slot migration delta awaiting application. */
+  private static final class PendingSlotDelta {
     final List<SlotMigration> migrations;
 
-    PendingMigrationDelta(List<SlotMigration> migrations) {
+    PendingSlotDelta(List<SlotMigration> migrations) {
       this.migrations = migrations;
     }
   }
 
   /**
-   * Applies an SMIGRATED slot delta atomically and reports which source nodes are left serving no
+   * Applies a slot migration delta atomically and reports which source nodes are left serving no
    * slots. Under a SINGLE write-lock hold: provisions each destination node's pool
    * ({@link #setupNodeIfNotExist}) and reassigns the entry's slots, then scans residual ownership
    * for every distinct source. The single hold is a correctness requirement — applying and scanning
    * in separate acquisitions leaves an interleaving window against {@link #renewClusterSlots}. Only
-   * ever called under {@link #rediscoverLock} (see {@link #drainMigrationDeltas}).
+   * ever called under {@link #slotDeltaLock} (see {@link #drainSlotDeltas}).
    * @return the source nodes that no longer own any slot (candidates for connection retirement);
    *         their pools stay in place — removal belongs to the full-refresh dead-pool cleanup
    */
-  private Set<HostAndPort> applySlotMigration(List<SlotMigration> migrations) {
+  private Set<HostAndPort> processSlotDelta(List<SlotMigration> migrations) {
     w.lock();
     try {
       for (SlotMigration migration : migrations) {
@@ -618,8 +637,7 @@ public class JedisClusterInfoCache {
 
   @SuppressWarnings("unchecked")
   private List<Object> executeClusterSlots(Connection jedis) {
-    CommandArguments clusterSlotsCmd = new CommandArguments(Protocol.Command.CLUSTER).add(
-        "SLOTS");
+    CommandArguments clusterSlotsCmd = new CommandArguments(Protocol.Command.CLUSTER).add("SLOTS");
     return (List<Object>) jedis.executeCommand(clusterSlotsCmd);
   }
 

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -13,6 +13,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -49,8 +50,12 @@ public class JedisClusterInfoCache {
   private final Lock w = rwl.writeLock();
   private final ReentrantLock rediscoverLock = new ReentrantLock();
 
-  /** Notified after every {@link #renewClusterSlots} attempt completes; see the cluster coordinator. */
-  private volatile Runnable postRefreshHook;
+  /**
+   * SMIGRATED slot deltas awaiting application. Deltas only ever apply under
+   * {@link #rediscoverLock} (see {@link #drainMigrationDeltas}), so they can never interleave with
+   * — and always order after — a full topology refresh.
+   */
+  private final ConcurrentLinkedQueue<PendingMigrationDelta> pendingMigrationDeltas = new ConcurrentLinkedQueue<>();
 
   private final GenericObjectPoolConfig<Connection> poolConfig;
   private final JedisClientConfig clientConfig;
@@ -132,7 +137,7 @@ public class JedisClusterInfoCache {
   private boolean checkClusterSlotSequence(List<Object> slotsInfo) {
     List<Integer> slots = new ArrayList<>();
     for (Object slotInfoObj : slotsInfo) {
-      List<Object> slotInfo = (List<Object>)slotInfoObj;
+      List<Object> slotInfo = (List<Object>) slotInfoObj;
       slots.addAll(getAssignedSlotArray(slotInfo));
     }
     Collections.sort(slots);
@@ -235,26 +240,11 @@ public class JedisClusterInfoCache {
 
       } finally {
         rediscoverLock.unlock();
-        Runnable hook = postRefreshHook;
-        if (hook != null) {
-          hook.run();
-        }
       }
+      // deltas that arrived while this refresh held the lock could not drain; drain them now,
+      // ordered after the refreshed topology
+      drainMigrationDeltas();
     }
-  }
-
-  /** True while a full topology refresh ({@link #renewClusterSlots}) is running. */
-  boolean isRenewInFlight() {
-    return rediscoverLock.isLocked();
-  }
-
-  /**
-   * Installs the hook run after every full-refresh attempt completes (successful or not), outside
-   * the rediscover lock. Single consumer: the cluster maintenance coordinator drains its queued
-   * slot deltas here.
-   */
-  void setPostRefreshHook(Runnable hook) {
-    this.postRefreshHook = hook;
   }
 
   private void discoverClusterSlots(Connection jedis) {
@@ -387,16 +377,62 @@ public class JedisClusterInfoCache {
   }
 
   /**
+   * Queues an SMIGRATED slot delta and drains the queue if no full topology refresh is in flight.
+   * Enqueue-then-drain against {@link #rediscoverLock} makes the check atomic: deltas only ever
+   * apply while holding the lock, so a delta can neither interleave with a running refresh nor race
+   * ahead of it — a refresh drains whatever queued behind it as its own last step. Never blocks the
+   * calling (read) thread on a running refresh. {@code onSlotless} receives the source nodes the
+   * delta left without any slot (invoked outside all cache locks, possibly on a later drainer's
+   * thread); dedup of the broadcast is the caller's job.
+   */
+  void applyMigrationDelta(List<SlotMigration> migrations) {
+    pendingMigrationDeltas.add(new PendingMigrationDelta(migrations));
+    drainMigrationDeltas();
+  }
+
+  /**
+   * Applies queued deltas while the rediscover lock is free; a failed {@code tryLock} means the
+   * holder — a running refresh or another drainer — drains as its last step. Re-checks after
+   * unlocking so an enqueue that slipped in during the drain is never stranded. Reactions run after
+   * unlock: no caller code executes under cache locks.
+   */
+  private void drainMigrationDeltas() {
+    while (!pendingMigrationDeltas.isEmpty()) {
+      if (!rediscoverLock.tryLock()) {
+        return;
+      }
+      try {
+        PendingMigrationDelta delta;
+        while ((delta = pendingMigrationDeltas.poll()) != null) {
+          applySlotMigration(delta.migrations);
+        }
+      } finally {
+        rediscoverLock.unlock();
+      }
+
+    }
+  }
+
+  /** An SMIGRATED delta awaiting application, with the caller's retirement reaction. */
+  private static final class PendingMigrationDelta {
+    final List<SlotMigration> migrations;
+
+    PendingMigrationDelta(List<SlotMigration> migrations) {
+      this.migrations = migrations;
+    }
+  }
+
+  /**
    * Applies an SMIGRATED slot delta atomically and reports which source nodes are left serving no
    * slots. Under a SINGLE write-lock hold: provisions each destination node's pool
    * ({@link #setupNodeIfNotExist}) and reassigns the entry's slots, then scans residual ownership
-   * for every distinct source. The single hold is a correctness requirement — applying and
-   * scanning in separate acquisitions leaves an interleaving window against
-   * {@link #renewClusterSlots}. Holds no event state; dedup of the broadcast is the caller's job.
+   * for every distinct source. The single hold is a correctness requirement — applying and scanning
+   * in separate acquisitions leaves an interleaving window against {@link #renewClusterSlots}. Only
+   * ever called under {@link #rediscoverLock} (see {@link #drainMigrationDeltas}).
    * @return the source nodes that no longer own any slot (candidates for connection retirement);
    *         their pools stay in place — removal belongs to the full-refresh dead-pool cleanup
    */
-  Set<HostAndPort> applyMigrationDelta(List<SlotMigration> migrations) {
+  private Set<HostAndPort> applySlotMigration(List<SlotMigration> migrations) {
     w.lock();
     try {
       for (SlotMigration migration : migrations) {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -64,6 +64,8 @@ public class JedisClusterInfoCache {
   private final JedisClientConfig clientConfig;
   private final Cache clientSideCache;
   private final Set<HostAndPort> startNodes;
+  /** The client-wide SMIGRATING/SMIGRATED coordinator; non-null iff cluster maintenance is on. */
+  private final ClusterMaintenanceCoordinator maintenanceCoordinator;
 
   private static final int MASTER_NODE_INDEX = 2;
 
@@ -113,10 +115,25 @@ public class JedisClusterInfoCache {
   public JedisClusterInfoCache(final JedisClientConfig clientConfig, Cache clientSideCache,
       final GenericObjectPoolConfig<Connection> poolConfig, final Set<HostAndPort> startNodes,
       final Duration topologyRefreshPeriod) {
+    this(clientConfig, clientSideCache, poolConfig, startNodes, topologyRefreshPeriod, null);
+  }
+
+  /**
+   * Creates the cache with cluster maintenance notifications configured for every node pool's
+   * connections; a {@code null} or DISABLED config turns the feature off.
+   * @since 8.1
+   */
+  @Experimental
+  public JedisClusterInfoCache(final JedisClientConfig clientConfig, Cache clientSideCache,
+      final GenericObjectPoolConfig<Connection> poolConfig, final Set<HostAndPort> startNodes,
+      final Duration topologyRefreshPeriod, final MaintenanceNotificationsConfig maintConfig) {
     this.poolConfig = poolConfig;
     this.clientConfig = clientConfig;
     this.clientSideCache = clientSideCache;
     this.startNodes = startNodes;
+    this.maintenanceCoordinator = maintConfig != null && maintConfig.isEnabledOrAuto()
+        ? new ClusterMaintenanceCoordinator(this, maintConfig)
+        : null;
     if (clientConfig.getAuthXManager() != null) {
       clientConfig.getAuthXManager().start();
     }
@@ -354,19 +371,12 @@ public class JedisClusterInfoCache {
   }
 
   private ConnectionPool createNodePool(HostAndPort node) {
-    if (poolConfig == null) {
-      if (clientSideCache == null) {
-        return new ConnectionPool(node, clientConfig);
-      } else {
-        return new ConnectionPool(node, clientConfig, clientSideCache);
-      }
-    } else {
-      if (clientSideCache == null) {
-        return new ConnectionPool(node, clientConfig, poolConfig);
-      } else {
-        return new ConnectionPool(node, clientConfig, clientSideCache, poolConfig);
-      }
-    }
+    GenericObjectPoolConfig<Connection> cfg = poolConfig != null ? poolConfig
+        : new GenericObjectPoolConfig<>();
+    // cluster-maintenance-aware pool: handshake visitor + coordinator listener per connection
+    ClusterMaintenanceController controller = maintenanceCoordinator == null ? null
+        : new ClusterMaintenanceController(maintenanceCoordinator);
+    return new ConnectionPool(node, clientConfig, clientSideCache, cfg, controller);
   }
 
   public void assignSlotToNode(int slot, HostAndPort targetNode) {

--- a/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
+++ b/src/main/java/redis/clients/jedis/JedisClusterInfoCache.java
@@ -373,10 +373,8 @@ public class JedisClusterInfoCache {
   private ConnectionPool createNodePool(HostAndPort node) {
     GenericObjectPoolConfig<Connection> cfg = poolConfig != null ? poolConfig
         : new GenericObjectPoolConfig<>();
-    // cluster-maintenance-aware pool: handshake visitor + coordinator listener per connection
-    ClusterMaintenanceController controller = maintenanceCoordinator == null ? null
-        : new ClusterMaintenanceController(maintenanceCoordinator);
-    return new ConnectionPool(node, clientConfig, clientSideCache, cfg, controller);
+    return new ConnectionPool(node, clientConfig, clientSideCache, cfg,
+        PoolMaintenance.cluster(maintenanceCoordinator));
   }
 
   public void assignSlotToNode(int slot, HostAndPort targetNode) {

--- a/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceAwareVisitor.java
@@ -1,59 +1,49 @@
 package redis.clients.jedis;
 
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.Protocol.Command;
-import redis.clients.jedis.TimeoutSource.TimeoutInfo;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.exceptions.JedisException;
 import redis.clients.jedis.util.JedisAsserts;
 
 /**
- * Connection-init visitor wiring maintenance notifications: performs the
- * {@code CLIENT MAINT_NOTIFICATIONS} handshake and installs the relaxed-timeout overlays.
+ * Connection-init visitor wiring maintenance notifications, identically for both deployment types:
+ * performs the {@code CLIENT MAINT_NOTIFICATIONS} handshake, registers the pool's controller as the
+ * connection's maintenance listener, and installs the controller's relax overlays. What those
+ * overlays are, whether the connection is tracked, and how events are reacted to is entirely the
+ * {@link MaintenanceController} subtype's business.
  */
 class MaintenanceAwareVisitor implements InitVisitor {
 
   private static final Logger logger = LoggerFactory.getLogger(MaintenanceAwareVisitor.class);
 
   private final Connection.Builder builder;
-  private final MaintenanceEventController controller;
+  private final MaintenanceController controller;
 
-  MaintenanceAwareVisitor(Connection.Builder builder,
-      MaintenanceEventController maintenanceController) {
+  MaintenanceAwareVisitor(Connection.Builder builder, MaintenanceController controller) {
     JedisAsserts.notNull(builder, "Connection.Builder must not be null");
-    JedisAsserts.notNull(maintenanceController, "MaintenanceEventController must not be null");
+    JedisAsserts.notNull(controller, "MaintenanceController must not be null");
     this.builder = builder;
-    this.controller = maintenanceController;
+    this.controller = controller;
   }
 
   /**
-   * Installs the pool-wide MOVING rebind timeout overlay before the handshake runs, so a connection
-   * opened while a rebind window is open already relaxes its AUTH/HELLO handshake reads. The
-   * overlay is torn down again in {@link #visitAfterHandshake(Connection)} if the feature turns out
-   * to be unsupported on this connection. Also registers the connection for maintenance-event
-   * tracking — before {@code connect()}, so a connect racing a MOVING is either visible to the
-   * marking pass (registered first) or redirected by the applied rebind via the address mapper.
+   * Tracks the connection (before {@code connect()}, so a connect racing a maintenance operation is
+   * visible to the controller) and installs the controller's relax overlays before the handshake
+   * runs, so a connection opened while a relax window is open already relaxes its AUTH/HELLO
+   * handshake reads. The overlays are torn down again in {@link #visitAfterHandshake(Connection)}
+   * if the feature turns out to be unsupported on this connection.
    */
   @Override
   public void visitBeforeHandshake(Connection connection) {
-    // must precede connect(): a connect racing a MOVING is then visible to the pass or remapped
-    controller.registry().register(connection);
     MaintenanceNotificationsConfig mConfig = builder.getMaintenanceConfig();
     if (!isMaintenanceEnabled(mConfig)) {
       return;
     }
-
-    ChainedTimeoutSource dts = connection.getTimeoutSource();
-    dts.addOverride(new RebindTimeoutSource(controller));
-
-    TimeoutInfo relaxedTimeout = new TimeoutInfo(mConfig.getRelaxedTimeout(),
-        mConfig.getRelaxedBlockingTimeout());
-    dts.addOverride(new ExpiringTimeoutSource(relaxedTimeout));
+    controller.register(connection);
   }
 
   @Override
@@ -66,6 +56,7 @@ class MaintenanceAwareVisitor implements InitVisitor {
     boolean strict = mConfig.getMode() == MaintenanceNotificationsConfig.Mode.ENABLED;
     boolean keepOverrides = false;
 
+    MaintenanceEventConsumer consumer = null;
     try {
       // Maintenance push frames require RESP3.
       RedisProtocol protocol = connection.getRedisProtocol();
@@ -79,15 +70,10 @@ class MaintenanceAwareVisitor implements InitVisitor {
         return;
       }
 
-      Set<MaintenanceEventListener> maintenanceEventListeners = connection
-          .getMaintenanceEventListeners();
-      maintenanceEventListeners.add(controller);
-
-      // The server must accept CLIENT MAINT_NOTIFICATIONS ON. Pre-register the consumer so a
-      // push
+      // The server must accept CLIENT MAINT_NOTIFICATIONS ON. Pre-register the consumer so a push
       // frame the server emits immediately on accepting the subscription cannot race ahead.
-      MaintenanceEventConsumer consumer = new MaintenanceEventConsumer(connection,
-          maintenanceEventListeners);
+      consumer = new MaintenanceEventConsumer(connection,
+          connection.getMaintenanceEventListeners());
       connection.addPushConsumer(consumer);
 
       connection.sendCommand(Command.CLIENT, "MAINT_NOTIFICATIONS", "ON", "moving-endpoint-type",
@@ -96,7 +82,6 @@ class MaintenanceAwareVisitor implements InitVisitor {
         connection.getStatusCodeReply();
         keepOverrides = true;
       } catch (JedisDataException e) {
-        connection.removePushConsumer(consumer);
 
         if (strict) {
           throw new JedisConnectionException(
@@ -108,11 +93,10 @@ class MaintenanceAwareVisitor implements InitVisitor {
       }
     } finally {
       if (!keepOverrides) {
-        // Undo the rebind overlay installed before the handshake — this connection does NOT support
-        // maintenance notifications.
-        ChainedTimeoutSource dts = connection.getTimeoutSource();
-        dts.removeOverride(dts.seekBy(controller));
-        dts.removeOverride(dts.seekBy(ExpiringTimeoutSource.class));
+        connection.removePushConsumer(consumer);
+        // Undo the relax overlays installed before the handshake — this connection does NOT
+        // support maintenance notifications.
+        controller.unregister(connection);
       }
     }
   }
@@ -143,22 +127,6 @@ class MaintenanceAwareVisitor implements InitVisitor {
         return "none";
       default:
         throw new JedisException("Unknown endpoint type: " + endpointType);
-    }
-  }
-
-  /** Pool-wide MOVING rebind overlay: active while the controller reports a valid rebind window. */
-  private static final class RebindTimeoutSource extends ChainedTimeoutSource {
-
-    private final MaintenanceEventController controller;
-
-    RebindTimeoutSource(MaintenanceEventController controller) {
-      super(null, controller);
-      this.controller = controller;
-    }
-
-    @Override
-    protected TimeoutInfo getOwnInfo() {
-      return controller.getTimeoutSupplier().get();
     }
   }
 }

--- a/src/main/java/redis/clients/jedis/MaintenanceController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceController.java
@@ -4,12 +4,13 @@ package redis.clients.jedis;
  * Per-pool maintenance controller contract: the connection-facing surface that
  * {@link MaintenanceAwareVisitor} wires identically for both deployment types — the handshake
  * config, the per-connection relax overlays with their stable teardown identities, the event
- * listener to register on the connection, optional connection tracking, and an optional post-DNS
- * address mapper. Deliberately separate from {@link MaintenanceEventListener}: reacting to the
- * events is the implementations' business ({@link MaintenanceEventController} for the
- * standalone/enterprise family, {@link ClusterMaintenanceController} for the cluster family). A
- * controller has exactly one owner (its pool), which creates it and must {@link #close()} it. Never
- * shared.
+ * listener to register on the connection, and optional connection tracking. Deliberately separate
+ * from {@link MaintenanceEventListener}: reacting to the events is the implementations' business
+ * ({@link MaintenanceEventController} for the standalone/enterprise family,
+ * {@link ClusterMaintenanceController} for the cluster family). Anything a family needs from its
+ * pool or connection factory beyond this surface is wired by {@link PoolMaintenance}, not through
+ * this interface. A controller has exactly one owner (its pool's {@link PoolMaintenance}), which
+ * creates it and must {@link #close()} it. Never shared.
  */
 interface MaintenanceController extends AutoCloseable {
 

--- a/src/main/java/redis/clients/jedis/MaintenanceController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceController.java
@@ -1,0 +1,32 @@
+package redis.clients.jedis;
+
+/**
+ * Per-pool maintenance controller contract: the connection-facing surface that
+ * {@link MaintenanceAwareVisitor} wires identically for both deployment types — the handshake
+ * config, the per-connection relax overlays with their stable teardown identities, the event
+ * listener to register on the connection, optional connection tracking, and an optional post-DNS
+ * address mapper. Deliberately separate from {@link MaintenanceEventListener}: reacting to the
+ * events is the implementations' business ({@link MaintenanceEventController} for the
+ * standalone/enterprise family, {@link ClusterMaintenanceController} for the cluster family). A
+ * controller has exactly one owner (its pool), which creates it and must {@link #close()} it. Never
+ * shared.
+ */
+interface MaintenanceController extends AutoCloseable {
+
+  /** The config this controller was built from; drives the MAINT_NOTIFICATIONS handshake. */
+  MaintenanceNotificationsConfig getConfig();
+
+  // TODO : verify if this should be a part of the interface
+  /** Post-DNS address mapper for this controller's connections; {@code null} = no remap. */
+  default SocketAddressMapper socketAddressMapper() {
+    return null;
+  }
+
+  void register(Connection connection);
+
+  void unregister(Connection connection);
+
+  @Override
+  default void close() {
+  }
+}

--- a/src/main/java/redis/clients/jedis/MaintenanceController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceController.java
@@ -16,12 +16,6 @@ interface MaintenanceController extends AutoCloseable {
   /** The config this controller was built from; drives the MAINT_NOTIFICATIONS handshake. */
   MaintenanceNotificationsConfig getConfig();
 
-  // TODO : verify if this should be a part of the interface
-  /** Post-DNS address mapper for this controller's connections; {@code null} = no remap. */
-  default SocketAddressMapper socketAddressMapper() {
-    return null;
-  }
-
   void register(Connection connection);
 
   void unregister(Connection connection);

--- a/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
@@ -1,6 +1,7 @@
 package redis.clients.jedis;
 
 import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +29,7 @@ final class MaintenanceEventConsumer implements PushConsumer {
     PushMessage message = context.getMessage();
     MaintenancePushCodec.PushType type = MaintenancePushCodec.PushType.resolve(message.getType());
 
-    // not a maintenance event; cluster-family frames pass through until their dispatch path
-    // (ClusterMaintenanceEventListener) is wired
+    // not a maintenance event
     if (type == null) {
       return context;
     }

--- a/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
@@ -1,7 +1,6 @@
 package redis.clients.jedis;
 
 import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +28,9 @@ final class MaintenanceEventConsumer implements PushConsumer {
     PushMessage message = context.getMessage();
     MaintenancePushCodec.PushType type = MaintenancePushCodec.PushType.resolve(message.getType());
 
-    // not a maintenance event
-    if (type == null) {
+    // not a maintenance event; cluster-family frames pass through until their dispatch path
+    // (ClusterMaintenanceEventListener) is wired
+    if (type == null || type.isCluster()) {
       return context;
     }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventConsumer.java
@@ -30,7 +30,7 @@ final class MaintenanceEventConsumer implements PushConsumer {
 
     // not a maintenance event; cluster-family frames pass through until their dispatch path
     // (ClusterMaintenanceEventListener) is wired
-    if (type == null || type.isCluster()) {
+    if (type == null) {
       return context;
     }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -290,4 +290,16 @@ final class MaintenanceEventController
     }
     c.applyCurrentTimeout();
   }
+
+  @Override
+  public void onSMigrating(SMigratingEvent e, Connection c) {
+    logger.warn("Cluster maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
+
+  @Override
+  public void onSMigrated(SMigratedEvent e, Connection c) {
+    logger.warn("Cluster maintenance events are not supported by this controller: {} conn={}", e,
+      c);
+  }
 }

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -234,6 +234,16 @@ final class MaintenanceEventController
     return registry;
   }
 
+  /**
+   * Retires every registered connection at the given instant and runs the handoff hook — the
+   * cluster Case-2 reaction, invoked by the cluster coordinator when this pool's node no longer
+   * owns any slot. Caller-only access: the pool remains this controller's sole owner.
+   */
+  void retireAll(long retireAtNanos) {
+    registry.forEachLive(conn -> conn.retireAt(retireAtNanos));
+    handoffHook.run();
+  }
+
   @Override
   public void close() {
     synchronized (schedulerLock) {

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import redis.clients.jedis.MovingOperations.MovingOperation;
 import redis.clients.jedis.TimeoutSource.TimeoutInfo;
+import redis.clients.jedis.annots.VisibleForTesting;
 
 /**
  * Maintenance coordinator: reacts to maintenance events. MOVING deliveries are deduplicated into
@@ -24,7 +25,7 @@ import redis.clients.jedis.TimeoutSource.TimeoutInfo;
  * shared.
  */
 final class MaintenanceEventController
-    implements MaintenanceEventListener, SocketAddressMapper, AutoCloseable {
+    implements MaintenanceController, MaintenanceEventListener, SocketAddressMapper {
 
   private static final Logger logger = LoggerFactory.getLogger(MaintenanceEventController.class);
 
@@ -34,6 +35,7 @@ final class MaintenanceEventController
   /** The owner's reaction to a completed marking pass; see {@link #setHandoffHook}. */
   private volatile Runnable handoffHook = () -> {
   };
+  private final TimeoutInfo relaxedTimeoutInfo;
   private final Supplier<TimeoutInfo> timeoutSupplier;
 
   private final ConnectionRegistry registry = new ConnectionRegistry();
@@ -51,9 +53,33 @@ final class MaintenanceEventController
     this.maxRelaxedDurationNanos = config.getRelaxedWindowMaxDuration().toNanos();
     this.scheduler = scheduler;
 
-    TimeoutInfo relaxedTimeoutInfo = new TimeoutInfo(config.getRelaxedTimeout(),
+    this.relaxedTimeoutInfo = new TimeoutInfo(config.getRelaxedTimeout(),
         config.getRelaxedBlockingTimeout());
     this.timeoutSupplier = () -> movingOperations.hasActive() ? relaxedTimeoutInfo : null;
+  }
+
+  @Override
+  public void register(Connection connection) {
+    // must precede connect(): a connect racing a maintenance operation is then visible/remapped
+    registry.register(connection);
+    ChainedTimeoutSource dts = connection.getTimeoutSource();
+    dts.addOverride(new ManagedTimeoutSource(this.timeoutSupplier));
+    dts.addOverride(new ExpiringTimeoutSource(relaxedTimeoutInfo));
+    connection.addMaintenanceEventListener(this);
+  }
+
+  @Override
+  public void unregister(Connection connection) {
+    connection.removeMaintenanceEventListener(this);
+    ChainedTimeoutSource dts = connection.getTimeoutSource();
+    // remove ManagedTimeoutSource by identity
+    dts.removeOverride(dts.seekBy(this.timeoutSupplier));
+    dts.removeOverride(dts.seekBy(ExpiringTimeoutSource.class));
+  }
+
+  @Override
+  public SocketAddressMapper socketAddressMapper() {
+    return this;
   }
 
   /**
@@ -107,7 +133,8 @@ final class MaintenanceEventController
    * The config this controller was built from; drives the connection's MAINT_NOTIFICATIONS
    * handshake.
    */
-  MaintenanceNotificationsConfig getConfig() {
+  @Override
+  public MaintenanceNotificationsConfig getConfig() {
     return config;
   }
 
@@ -234,16 +261,6 @@ final class MaintenanceEventController
     return registry;
   }
 
-  /**
-   * Retires every registered connection at the given instant and runs the handoff hook — the
-   * cluster Case-2 reaction, invoked by the cluster coordinator when this pool's node no longer
-   * owns any slot. Caller-only access: the pool remains this controller's sole owner.
-   */
-  void retireAll(long retireAtNanos) {
-    registry.forEachLive(conn -> conn.retireAt(retireAtNanos));
-    handoffHook.run();
-  }
-
   @Override
   public void close() {
     synchronized (schedulerLock) {
@@ -254,7 +271,8 @@ final class MaintenanceEventController
     }
   }
 
-  public Supplier<TimeoutInfo> getTimeoutSupplier() {
+  @VisibleForTesting
+  Supplier<TimeoutInfo> getTimeoutSupplier() {
     return timeoutSupplier;
   }
 

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -142,6 +142,7 @@ final class MaintenanceEventController
   }
 
   /** The currently installed handoff hook. Exposed for tests. */
+  @VisibleForTesting
   Runnable getHandoffHook() {
     return handoffHook;
   }

--- a/src/main/java/redis/clients/jedis/MaintenanceEventController.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventController.java
@@ -77,11 +77,6 @@ final class MaintenanceEventController
     dts.removeOverride(dts.seekBy(ExpiringTimeoutSource.class));
   }
 
-  @Override
-  public SocketAddressMapper socketAddressMapper() {
-    return this;
-  }
-
   /**
    * Construct a controller from the given config. The creator owns the controller and must
    * {@link #close()} it.

--- a/src/main/java/redis/clients/jedis/MaintenanceEventListener.java
+++ b/src/main/java/redis/clients/jedis/MaintenanceEventListener.java
@@ -18,4 +18,8 @@ interface MaintenanceEventListener {
   void onFailingOver(FailingOverEvent e, Connection c);
 
   void onFailedOver(FailedOverEvent e, Connection c);
+
+  void onSMigrating(SMigratingEvent e, Connection c);
+
+  void onSMigrated(SMigratedEvent e, Connection c);
 }

--- a/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
+++ b/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
@@ -1,15 +1,16 @@
 package redis.clients.jedis;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
-
 import redis.clients.jedis.util.SafeEncoder;
 
 /**
- * Decodes RESP3 maintenance push frames into {@link MaintenanceEvent}s — the push transport for
- * maintenance notifications. Token classification ({@link PushType#resolve}) and per-type field
- * extraction ({@link #build}) both live here.
+ * Decodes RESP3 maintenance push frames into {@link MaintenanceEvent}s or
+ * {@link ClusterMaintenanceEvent}s — the push transport for maintenance notifications. Token
+ * classification ({@link PushType#resolve}) and per-type field extraction ({@link #build},
+ * {@link #buildCluster}) both live here.
  */
 final class MaintenancePushCodec {
 
@@ -19,19 +20,36 @@ final class MaintenancePushCodec {
     MIGRATING(PushMessageTypes.MIGRATING_BYTES, MaintenancePushCodec::migrating),
     FAILING_OVER(PushMessageTypes.FAILING_OVER_BYTES, MaintenancePushCodec::failingOver),
     MIGRATED(PushMessageTypes.MIGRATED_BYTES, MaintenancePushCodec::migrated),
-    FAILED_OVER(PushMessageTypes.FAILED_OVER_BYTES, MaintenancePushCodec::failedOver);
+    FAILED_OVER(PushMessageTypes.FAILED_OVER_BYTES, MaintenancePushCodec::failedOver),
+    SMIGRATING(PushMessageTypes.SMIGRATING_BYTES, MaintenancePushCodec::sMigrating, true),
+    SMIGRATED(PushMessageTypes.SMIGRATED_BYTES, MaintenancePushCodec::sMigrated, true);
 
     private final byte[] token;
     private final Function<List<Object>, MaintenanceEvent> decoder;
+    private final Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder;
 
     PushType(byte[] token, Function<List<Object>, MaintenanceEvent> decoder) {
       this.token = token;
       this.decoder = decoder;
+      this.clusterDecoder = null;
+    }
+
+    PushType(byte[] token, Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder,
+        boolean cluster) {
+      this.token = token;
+      this.decoder = null;
+      this.clusterDecoder = clusterDecoder;
+    }
+
+    /** True for the OSS-cluster message family (decoded via {@link #buildCluster}). */
+    boolean isCluster() {
+      return clusterDecoder != null;
     }
 
     /**
      * Resolves a push type token to its maintenance type, or {@code null} when it is not a
-     * maintenance push. Length-switch fast path: rejects unrelated pushes with one comparison.
+     * maintenance push. Length-switch fast path: rejects unrelated pushes with at most two
+     * comparisons (MIGRATING and SMIGRATED share length 9).
      */
     static PushType resolve(byte[] type) {
       if (type == null) {
@@ -43,7 +61,12 @@ final class MaintenancePushCodec {
         case 8:
           return Arrays.equals(type, MIGRATED.token) ? MIGRATED : null;
         case 9:
-          return Arrays.equals(type, MIGRATING.token) ? MIGRATING : null;
+          if (Arrays.equals(type, MIGRATING.token)) {
+            return MIGRATING;
+          }
+          return Arrays.equals(type, SMIGRATED.token) ? SMIGRATED : null;
+        case 10:
+          return Arrays.equals(type, SMIGRATING.token) ? SMIGRATING : null;
         case 11:
           return Arrays.equals(type, FAILED_OVER.token) ? FAILED_OVER : null;
         case 12:
@@ -62,6 +85,17 @@ final class MaintenancePushCodec {
    */
   static MaintenanceEvent build(PushType type, PushMessage msg) {
     return type.decoder.apply(msg.getContent());
+  }
+
+  /**
+   * Builds the domain event for an already-resolved cluster push type
+   * ({@link PushType#isCluster()}).
+   * @throws MalformedMaintenanceEventException if the frame's fields are malformed (missing or
+   *           wrong-typed seq, unparseable slots-or-ranges, or an SMIGRATED entry without a valid
+   *           src/dest {@code host:port})
+   */
+  static ClusterMaintenanceEvent buildCluster(PushType type, PushMessage msg) {
+    return type.clusterDecoder.apply(msg.getContent());
   }
 
   private static MaintenanceEvent moving(List<Object> c) { // [MOVING, seq, time_s, host:port |
@@ -104,6 +138,55 @@ final class MaintenancePushCodec {
       throw malformed("FAILED_OVER", c);
     }
     return new FailedOverEvent((Long) c.get(1), shardIds(c, 2));
+  }
+
+  private static ClusterMaintenanceEvent sMigrating(List<Object> c) { // [SMIGRATING, seq, slots]
+    if (c.size() < 3 || !(c.get(1) instanceof Long) || !(c.get(2) instanceof byte[])) {
+      throw malformed("SMIGRATING", c);
+    }
+    return new SMigratingEvent((Long) c.get(1), slotRanges("SMIGRATING", c, (byte[]) c.get(2)));
+  }
+
+  private static ClusterMaintenanceEvent sMigrated(List<Object> c) { // [SMIGRATED, seq,
+                                                                     // [[src, dest, slots]...]]
+    if (c.size() < 3 || !(c.get(1) instanceof Long) || !(c.get(2) instanceof List)) {
+      throw malformed("SMIGRATED", c);
+    }
+    List<?> entries = (List<?>) c.get(2);
+    List<SlotMigration> migrations = new ArrayList<>(entries.size());
+    for (Object entryObj : entries) {
+      if (!(entryObj instanceof List)) {
+        throw malformed("SMIGRATED", c);
+      }
+      List<?> e = (List<?>) entryObj;
+      if (e.size() < 3 || !(e.get(0) instanceof byte[]) || !(e.get(1) instanceof byte[])
+          || !(e.get(2) instanceof byte[])) {
+        throw malformed("SMIGRATED", c);
+      }
+      migrations.add(new SlotMigration(nodeAddress("SMIGRATED", c, (byte[]) e.get(0)),
+          nodeAddress("SMIGRATED", c, (byte[]) e.get(1)),
+          slotRanges("SMIGRATED", c, (byte[]) e.get(2))));
+    }
+    return new SMigratedEvent((Long) c.get(1), migrations);
+  }
+
+  /** Slots-or-ranges field, e.g. {@code 123,456,789-1000}; throws when unparseable. */
+  private static HashSlotRanges slotRanges(String type, List<Object> c, byte[] raw) {
+    try {
+      return HashSlotRanges.parse(SafeEncoder.encode(raw));
+    } catch (IllegalArgumentException e) {
+      throw new MalformedMaintenanceEventException("Unparseable " + type + " slots: " + c, e);
+    }
+  }
+
+  /** Bare {@code host:port} node address (no labels on the wire); throws when unparseable. */
+  private static HostAndPort nodeAddress(String type, List<Object> c, byte[] raw) {
+    try {
+      return HostAndPort.from(SafeEncoder.encode(raw));
+    } catch (Exception e) {
+      throw new MalformedMaintenanceEventException("Unparseable " + type + " node address: " + c,
+          e);
+    }
   }
 
   /** Diagnostic shard-id list (stringified JSON array), logging only; required on the wire. */

--- a/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
+++ b/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
@@ -21,29 +21,15 @@ final class MaintenancePushCodec {
     FAILING_OVER(PushMessageTypes.FAILING_OVER_BYTES, MaintenancePushCodec::failingOver),
     MIGRATED(PushMessageTypes.MIGRATED_BYTES, MaintenancePushCodec::migrated),
     FAILED_OVER(PushMessageTypes.FAILED_OVER_BYTES, MaintenancePushCodec::failedOver),
-    SMIGRATING(PushMessageTypes.SMIGRATING_BYTES, MaintenancePushCodec::sMigrating, true),
-    SMIGRATED(PushMessageTypes.SMIGRATED_BYTES, MaintenancePushCodec::sMigrated, true);
+    SMIGRATING(PushMessageTypes.SMIGRATING_BYTES, MaintenancePushCodec::sMigrating),
+    SMIGRATED(PushMessageTypes.SMIGRATED_BYTES, MaintenancePushCodec::sMigrated);
 
     private final byte[] token;
     private final Function<List<Object>, MaintenanceEvent> decoder;
-    private final Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder;
 
     PushType(byte[] token, Function<List<Object>, MaintenanceEvent> decoder) {
       this.token = token;
       this.decoder = decoder;
-      this.clusterDecoder = null;
-    }
-
-    PushType(byte[] token, Function<List<Object>, ClusterMaintenanceEvent> clusterDecoder,
-        boolean cluster) {
-      this.token = token;
-      this.decoder = null;
-      this.clusterDecoder = clusterDecoder;
-    }
-
-    /** True for the OSS-cluster message family (decoded via {@link #buildCluster}). */
-    boolean isCluster() {
-      return clusterDecoder != null;
     }
 
     /**
@@ -85,17 +71,6 @@ final class MaintenancePushCodec {
    */
   static MaintenanceEvent build(PushType type, PushMessage msg) {
     return type.decoder.apply(msg.getContent());
-  }
-
-  /**
-   * Builds the domain event for an already-resolved cluster push type
-   * ({@link PushType#isCluster()}).
-   * @throws MalformedMaintenanceEventException if the frame's fields are malformed (missing or
-   *           wrong-typed seq, unparseable slots-or-ranges, or an SMIGRATED entry without a valid
-   *           src/dest {@code host:port})
-   */
-  static ClusterMaintenanceEvent buildCluster(PushType type, PushMessage msg) {
-    return type.clusterDecoder.apply(msg.getContent());
   }
 
   private static MaintenanceEvent moving(List<Object> c) { // [MOVING, seq, time_s, host:port |

--- a/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
+++ b/src/main/java/redis/clients/jedis/MaintenancePushCodec.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+
 import redis.clients.jedis.util.SafeEncoder;
 
 /**

--- a/src/main/java/redis/clients/jedis/ManagedTimeoutSource.java
+++ b/src/main/java/redis/clients/jedis/ManagedTimeoutSource.java
@@ -1,0 +1,18 @@
+package redis.clients.jedis;
+
+import java.util.function.Supplier;
+
+final class ManagedTimeoutSource extends ChainedTimeoutSource {
+
+  private final Supplier<TimeoutInfo> supplier;
+
+  ManagedTimeoutSource(Supplier<TimeoutInfo> supplier) {
+    super(null, supplier);
+    this.supplier = supplier;
+  }
+
+  @Override
+  protected TimeoutInfo getOwnInfo() {
+    return supplier.get();
+  }
+}

--- a/src/main/java/redis/clients/jedis/PoolMaintenance.java
+++ b/src/main/java/redis/clients/jedis/PoolMaintenance.java
@@ -1,0 +1,121 @@
+package redis.clients.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Everything one maintenance family contributes to the {@link ConnectionPool} hosting it, assembled
+ * where the family is known so the pool itself never asks which family it serves. The pool runs the
+ * kit in two phases around its own construction: {@link #configure} shapes the connection factory
+ * before the pool exists (the factory is built inside {@code super(...)}), and {@link #attach}
+ * installs the pool-side reactions once it does. Both are no-ops here; a family overrides only what
+ * it needs. The kit owns the controller's lifetime on the pool's behalf: {@link #close()} is the
+ * pool's last step in {@code destroy()}.
+ */
+abstract class PoolMaintenance implements AutoCloseable {
+
+  private static final Logger log = LoggerFactory.getLogger(PoolMaintenance.class);
+
+  /** Maintenance off: no controller, nothing to configure, nothing to attach. */
+  static final PoolMaintenance OFF = new PoolMaintenance(null) {
+  };
+
+  private final MaintenanceController controller; // null = maintenance off
+
+  private PoolMaintenance(MaintenanceController controller) {
+    this.controller = controller;
+  }
+
+  /**
+   * The standalone/enterprise family: MOVING remaps new connections to the announced endpoint and
+   * retires the affected ones, so the pool must recycle retired connections and evict the retired
+   * idles once a handoff has been processed. {@code null} or disabled config yields {@link #OFF}.
+   */
+  static PoolMaintenance standalone(MaintenanceNotificationsConfig config) {
+    if (config == null || !config.isEnabledOrAuto()) {
+      return OFF;
+    }
+    return new StandalonePoolMaintenance(MaintenanceEventController.from(config));
+  }
+
+  /**
+   * The cluster family: SMIGRATING/SMIGRATED are dispatched to the client-wide coordinator; nothing
+   * is remapped or retired per pool (Case-2 teardown is pool-level). {@code null} coordinator
+   * yields {@link #OFF}.
+   */
+  static PoolMaintenance cluster(ClusterMaintenanceCoordinator coordinator) {
+    if (coordinator == null) {
+      return OFF;
+    }
+    return new ClusterPoolMaintenance(new ClusterMaintenanceController(coordinator));
+  }
+
+  /** The connection-facing controller ({@code null} when off); exposed for test clock injection. */
+  MaintenanceController controller() {
+    return controller;
+  }
+
+  /** Phase 1, before the pool exists: wire the controller and any family-specific factory knobs. */
+  ConnectionFactory.Builder configure(ConnectionFactory.Builder factoryBuilder) {
+    return factoryBuilder;
+  }
+
+  /** Phase 2, once the pool exists: install the family's pool-side reactions. */
+  void attach(ConnectionPool pool) {
+  }
+
+  @Override
+  public void close() {
+    if (controller != null) {
+      controller.close();
+    }
+  }
+
+  /** Cluster pools need nothing beyond the controller itself. */
+  private static final class ClusterPoolMaintenance extends PoolMaintenance {
+
+    ClusterPoolMaintenance(ClusterMaintenanceController controller) {
+      super(controller);
+    }
+  }
+
+  /** Standalone pools remap new connections during MOVING and recycle the retired ones. */
+  private static final class StandalonePoolMaintenance extends PoolMaintenance {
+
+    private final MaintenanceEventController controller;
+
+    StandalonePoolMaintenance(MaintenanceEventController controller) {
+      super(controller);
+      this.controller = controller;
+    }
+
+    @Override
+    ConnectionFactory.Builder configure(ConnectionFactory.Builder factoryBuilder) {
+      return factoryBuilder.maintenanceController(controller).socketAddressMapper(controller);
+    }
+
+    @Override
+    void attach(ConnectionPool pool) {
+      // evictor passes destroy retired idles ahead of the delegate policy
+      pool.setEvictionPolicy(new RebindAwareEvictionPolicy(pool.getEvictionPolicy()));
+      // handoff processed: evict the retired idles right away
+      controller.setHandoffHook(() -> evictQuietly(pool));
+    }
+
+    /**
+     * Evicts retired idles once a handoff has been processed. Runs on the maintenance scheduler
+     * thread or inline on a notifying thread; must never propagate (a failed pass degrades to lazy
+     * recycling on return).
+     */
+    private void evictQuietly(ConnectionPool pool) {
+      if (pool.isClosed()) {
+        return;
+      }
+      try {
+        pool.evict();
+      } catch (Exception e) {
+        log.warn("Maintenance eviction pass failed; retired connections recycle on return", e);
+      }
+    }
+  }
+}

--- a/src/main/java/redis/clients/jedis/PushMessageTypes.java
+++ b/src/main/java/redis/clients/jedis/PushMessageTypes.java
@@ -157,4 +157,26 @@ public final class PushMessageTypes {
    */
   public static final String FAILED_OVER = "FAILED_OVER";
   public static final byte[] FAILED_OVER_BYTES = SafeEncoder.encode(FAILED_OVER);
+
+  // ==================== Cluster Maintenance Events ====================
+
+  /**
+   * Cluster slot migration starts — relax client timeouts until the matching SMIGRATED.
+   * <p>
+   * Format: ["SMIGRATING", seq, slots-or-ranges] — comma-separated slots and/or {@code from-to}
+   * ranges, e.g. {@code "123,456,789-1000"}.
+   * @since 8.1
+   */
+  public static final String SMIGRATING = "SMIGRATING";
+  public static final byte[] SMIGRATING_BYTES = SafeEncoder.encode(SMIGRATING);
+
+  /**
+   * Cluster slot migration complete — restore client timeouts and apply the slot delta.
+   * <p>
+   * Format: ["SMIGRATED", seq, [["src-host:port", "dest-host:port", slots-or-ranges], ...]] — each
+   * entry moves the given slots from the source node to the destination node.
+   * @since 8.1
+   */
+  public static final String SMIGRATED = "SMIGRATED";
+  public static final byte[] SMIGRATED_BYTES = SafeEncoder.encode(SMIGRATED);
 }

--- a/src/main/java/redis/clients/jedis/builders/ClusterClientBuilder.java
+++ b/src/main/java/redis/clients/jedis/builders/ClusterClientBuilder.java
@@ -7,6 +7,7 @@ import redis.clients.jedis.executors.ClusterCommandExecutor;
 import redis.clients.jedis.executors.CommandExecutor;
 import redis.clients.jedis.providers.ClusterConnectionProvider;
 import redis.clients.jedis.providers.ConnectionProvider;
+import redis.clients.jedis.util.JedisAsserts;
 
 /**
  * Builder for creating JedisCluster instances (Redis Cluster connections).
@@ -18,12 +19,37 @@ import redis.clients.jedis.providers.ConnectionProvider;
 public abstract class ClusterClientBuilder<C>
     extends AbstractClientBuilder<ClusterClientBuilder<C>, C> {
 
+  /**
+   * Maintenance notifications used when none is explicitly configured (AUTO). A dedicated instance,
+   * so an explicitly set value is distinguishable.
+   */
+  private static final MaintenanceNotificationsConfig UNSET_MAINTENANCE_NOTIFICATIONS = MaintenanceNotificationsConfig
+      .builder().mode(MaintenanceNotificationsConfig.Mode.AUTO).build();
+
   // Cluster-specific configuration fields
   private Set<HostAndPort> nodes = null;
   private int maxAttempts = RedisClusterClient.DEFAULT_MAX_ATTEMPTS;
   private Duration maxTotalRetriesDuration;
   private Duration topologyRefreshPeriod = null;
   private CommandFlagsRegistry commandFlags = null;
+  private MaintenanceNotificationsConfig maintNotificationsConfig = UNSET_MAINTENANCE_NOTIFICATIONS;
+
+  /**
+   * Configures cluster maintenance notifications (SMIGRATING/SMIGRATED): timeout relaxation during
+   * slot migrations and slot-map updates applied directly from the push.
+   * <p>
+   * Defaults to AUTO mode (enabled when the server supports it). To turn the feature off, pass
+   * {@link MaintenanceNotificationsConfig#DISABLED}.
+   * @param config maintenance notifications configuration; must not be {@code null}
+   * @return this builder
+   * @throws IllegalArgumentException if {@code config} is {@code null}
+   * @since 8.1
+   */
+  public ClusterClientBuilder<C> maintenanceNotifications(MaintenanceNotificationsConfig config) {
+    JedisAsserts.notNull(config, "MaintenanceNotificationsConfig must not be null");
+    this.maintNotificationsConfig = config;
+    return this;
+  }
 
   /**
    * Sets the cluster nodes to connect to.
@@ -107,7 +133,7 @@ public abstract class ClusterClientBuilder<C>
   @Override
   protected ConnectionProvider createDefaultConnectionProvider() {
     return new ClusterConnectionProvider(this.nodes, this.clientConfig, this.cache, this.poolConfig,
-        this.topologyRefreshPeriod);
+        this.topologyRefreshPeriod, this.maintNotificationsConfig);
   }
 
   /**

--- a/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
+++ b/src/main/java/redis/clients/jedis/providers/ClusterConnectionProvider.java
@@ -16,6 +16,7 @@ import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.ConnectionPool;
 import redis.clients.jedis.JedisClusterInfoCache;
+import redis.clients.jedis.MaintenanceNotificationsConfig;
 import redis.clients.jedis.annots.Experimental;
 import redis.clients.jedis.csc.Cache;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
@@ -58,9 +59,23 @@ public class ClusterConnectionProvider implements ConnectionProvider {
   }
 
   @Experimental
-  public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig, Cache clientSideCache,
-      GenericObjectPoolConfig<Connection> poolConfig, Duration topologyRefreshPeriod) {
-    this.cache = new JedisClusterInfoCache(clientConfig, clientSideCache, poolConfig, clusterNodes, topologyRefreshPeriod);
+  public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
+      Cache clientSideCache, GenericObjectPoolConfig<Connection> poolConfig,
+      Duration topologyRefreshPeriod) {
+    this(clusterNodes, clientConfig, clientSideCache, poolConfig, topologyRefreshPeriod, null);
+  }
+
+  /**
+   * Creates the provider with cluster maintenance notifications configured for every node pool's
+   * connections; a {@code null} or DISABLED config turns the feature off.
+   * @since 8.1
+   */
+  @Experimental
+  public ClusterConnectionProvider(Set<HostAndPort> clusterNodes, JedisClientConfig clientConfig,
+      Cache clientSideCache, GenericObjectPoolConfig<Connection> poolConfig,
+      Duration topologyRefreshPeriod, MaintenanceNotificationsConfig maintNotificationsConfig) {
+    this.cache = new JedisClusterInfoCache(clientConfig, clientSideCache, poolConfig, clusterNodes,
+        topologyRefreshPeriod, maintNotificationsConfig);
     initializeSlotsCache(clusterNodes, clientConfig);
   }
 

--- a/src/test/java/redis/clients/jedis/ClusterMaintenanceEventTest.java
+++ b/src/test/java/redis/clients/jedis/ClusterMaintenanceEventTest.java
@@ -1,0 +1,89 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for the {@link ClusterMaintenanceEvent} hierarchy: each event dispatches to its own
+ * listener callback with the owning connection, SMIGRATED exposes its delta read-only, and
+ * {@link SlotMigration} renders as {@code src -> dest [slots]}.
+ */
+@Tag("unit")
+public class ClusterMaintenanceEventTest {
+
+  private static final HostAndPort SRC = new HostAndPort("10.0.0.1", 7000);
+  private static final HostAndPort DEST = new HostAndPort("10.0.0.2", 7001);
+
+  private final MaintenanceEventListener listener = mock(MaintenanceEventListener.class);
+  private final Connection connection = mock(Connection.class);
+
+  @Test
+  public void sMigratingDispatchesToOnSMigrating() {
+    SMigratingEvent e = new SMigratingEvent(3L, HashSlotRanges.parse("0-100"));
+
+    e.accept(listener, connection);
+
+    verify(listener).onSMigrating(e, connection);
+    verifyNoMoreInteractions(listener);
+  }
+
+  @Test
+  public void sMigratedDispatchesToOnSMigrated() {
+    SMigratedEvent e = new SMigratedEvent(4L,
+        Collections.singletonList(new SlotMigration(SRC, DEST, HashSlotRanges.parse("0-100"))));
+
+    e.accept(listener, connection);
+
+    verify(listener).onSMigrated(e, connection);
+    verifyNoMoreInteractions(listener);
+  }
+
+  @Test
+  public void clusterEventsAreMaintenanceEvents() { // the codec/consumer handle one
+                                                    // MaintenanceEvent type
+    assertInstanceOf(MaintenanceEvent.class, new SMigratingEvent(1L, HashSlotRanges.parse("1")));
+    assertInstanceOf(MaintenanceEvent.class, new SMigratedEvent(1L, Collections.emptyList()));
+    assertEquals(1L, new SMigratingEvent(1L, HashSlotRanges.parse("1")).seq);
+    assertEquals(2L, new SMigratedEvent(2L, Collections.emptyList()).seq);
+  }
+
+  @Test
+  public void sMigratingExposesSlots() {
+    HashSlotRanges slots = HashSlotRanges.parse("123,456,789-1000");
+    assertSame(slots, new SMigratingEvent(1L, slots).slots);
+  }
+
+  @Test
+  public void sMigratedMigrationsAreReadOnly() {
+    List<SlotMigration> source = new ArrayList<>(
+        Arrays.asList(new SlotMigration(SRC, DEST, HashSlotRanges.parse("0-100")),
+          new SlotMigration(DEST, SRC, HashSlotRanges.parse("200"))));
+    SMigratedEvent e = new SMigratedEvent(1L, source);
+
+    assertEquals(source, e.migrations);
+    assertThrows(UnsupportedOperationException.class, () -> e.migrations.clear());
+    assertThrows(UnsupportedOperationException.class,
+      () -> e.migrations.add(new SlotMigration(SRC, DEST, HashSlotRanges.parse("5"))));
+  }
+
+  @Test
+  public void slotMigrationToString() {
+    SlotMigration m = new SlotMigration(SRC, DEST, HashSlotRanges.parse("123,456,789-1000"));
+    assertEquals("10.0.0.1:7000 -> 10.0.0.2:7001 [123,456,789-1000]", m.toString());
+    assertSame(SRC, m.src);
+    assertSame(DEST, m.dest);
+  }
+}

--- a/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
+++ b/src/test/java/redis/clients/jedis/ConnectionTestHelper.java
@@ -124,7 +124,8 @@ public class ConnectionTestHelper {
    * instead of polling.
    */
   public static void addHandoffHook(ConnectionPool pool, Runnable hook) {
-    MaintenanceEventController controller = pool.getMaintenanceController();
+    MaintenanceEventController controller = (MaintenanceEventController) pool
+        .getMaintenanceController();
     Runnable poolReaction = controller.getHandoffHook();
     controller.setHandoffHook(() -> {
       poolReaction.run(); // evict first: the pass is fully processed before the test observes it
@@ -138,7 +139,8 @@ public class ConnectionTestHelper {
    * configured endpoint, so tests assert other peers' mapping windows through this seam.
    */
   public static SocketAddress getMappedAddress(ConnectionPool pool, SocketAddress resolved) {
-    return pool.getMaintenanceController().getSocketAddress(resolved);
+    return ((MaintenanceEventController) pool.getMaintenanceController())
+        .getSocketAddress(resolved);
   }
 
   public static void setClockNanos(LongSupplier clock) {

--- a/src/test/java/redis/clients/jedis/HashSlotRangesTest.java
+++ b/src/test/java/redis/clients/jedis/HashSlotRangesTest.java
@@ -1,0 +1,152 @@
+package redis.clients.jedis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for {@link HashSlotRanges}: the slots-or-ranges wire format
+ * ({@code 123,456,789-1000}) of cluster maintenance pushes — parsing, membership, counting,
+ * iteration order and rejection of malformed input.
+ */
+@Tag("unit")
+public class HashSlotRangesTest {
+
+  @Test
+  public void parseSingleSlot() {
+    HashSlotRanges r = HashSlotRanges.parse("42");
+    assertTrue(r.contains(42));
+    assertFalse(r.contains(41));
+    assertFalse(r.contains(43));
+    assertEquals(1, r.slotCount());
+    assertEquals(Arrays.asList(42), slots(r));
+  }
+
+  @Test
+  public void parseInclusiveRange() {
+    HashSlotRanges r = HashSlotRanges.parse("10-13");
+    assertFalse(r.contains(9));
+    assertTrue(r.contains(10));
+    assertTrue(r.contains(13));
+    assertFalse(r.contains(14));
+    assertEquals(4, r.slotCount());
+    assertEquals(Arrays.asList(10, 11, 12, 13), slots(r));
+  }
+
+  @Test
+  public void parseDegenerateRange() { // from == to is a one-slot range
+    HashSlotRanges r = HashSlotRanges.parse("7-7");
+    assertTrue(r.contains(7));
+    assertEquals(1, r.slotCount());
+    assertEquals(Arrays.asList(7), slots(r));
+  }
+
+  @Test
+  public void parseMixedSlotsAndRanges() {
+    HashSlotRanges r = HashSlotRanges.parse("123,456,789-1000");
+    assertTrue(r.contains(123));
+    assertTrue(r.contains(456));
+    assertTrue(r.contains(789));
+    assertTrue(r.contains(900));
+    assertTrue(r.contains(1000));
+    assertFalse(r.contains(0));
+    assertFalse(r.contains(124));
+    assertFalse(r.contains(788));
+    assertFalse(r.contains(1001));
+    assertEquals(2 + (1000 - 789 + 1), r.slotCount());
+  }
+
+  @Test
+  public void forEachSlotVisitsInWireOrder() { // not sorted: wire order is preserved
+    HashSlotRanges r = HashSlotRanges.parse("5,1-3,9");
+    assertEquals(Arrays.asList(5, 1, 2, 3, 9), slots(r));
+  }
+
+  @Test
+  public void overlappingRangesCountSlotsPerRange() { // no dedup: count is the sum of the ranges
+    HashSlotRanges r = HashSlotRanges.parse("1-3,2-4");
+    assertEquals(6, r.slotCount());
+    assertEquals(Arrays.asList(1, 2, 3, 2, 3, 4), slots(r));
+    assertTrue(r.contains(2));
+  }
+
+  @Test
+  public void parseAcceptsFullSlotSpace() {
+    HashSlotRanges r = HashSlotRanges.parse("0-16383");
+    assertTrue(r.contains(0));
+    assertTrue(r.contains(16383));
+    assertFalse(r.contains(-1));
+    assertFalse(r.contains(16384));
+    assertEquals(Protocol.CLUSTER_HASHSLOTS, r.slotCount());
+  }
+
+  @Test
+  public void parseAcceptsBoundarySlots() {
+    assertTrue(HashSlotRanges.parse("0").contains(0));
+    assertTrue(HashSlotRanges.parse("16383").contains(16383));
+  }
+
+  @Test
+  public void toStringIsTheWireSource() {
+    assertEquals("123,456,789-1000", HashSlotRanges.parse("123,456,789-1000").toString());
+    assertEquals("7", HashSlotRanges.parse("7").toString());
+  }
+
+  @Test
+  public void parseRejectsNullOrEmpty() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(null));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(""));
+  }
+
+  @Test
+  public void parseRejectsNonNumericTokens() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("abc"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,x"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1-x"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("x-5"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1.5"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(" 1"));
+  }
+
+  @Test
+  public void parseRejectsEmptyTokens() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,,2"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse(",1"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1-"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("-5"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("-"));
+  }
+
+  @Test
+  public void parseRejectsInvertedRange() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("10-9"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,10-9"));
+  }
+
+  @Test
+  public void parseRejectsSlotsOutsideHashSlotSpace() {
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("16384"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("0-16384"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("16383-99999"));
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1,2,3,16384"));
+  }
+
+  @Test
+  public void parseRejectsAnyBadTokenEvenAfterValidOnes() { // whole string is rejected atomically
+    assertThrows(IllegalArgumentException.class, () -> HashSlotRanges.parse("1-3,5,bad"));
+  }
+
+  private static List<Integer> slots(HashSlotRanges r) {
+    List<Integer> out = new ArrayList<>();
+    r.forEachSlot(out::add);
+    return out;
+  }
+}

--- a/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
@@ -159,5 +159,15 @@ public class MaintenanceEventConsumerTest {
     public void onFailedOver(FailedOverEvent e, Connection c) {
       calls.add(new Call("onFailedOver", e, c));
     }
+
+    @Override
+    public void onSMigrating(SMigratingEvent e, Connection c) {
+      throw new UnsupportedOperationException("Unimplemented method 'onSMigrating'");
+    }
+
+    @Override
+    public void onSMigrated(SMigratedEvent e, Connection c) {
+      throw new UnsupportedOperationException("Unimplemented method 'onSMigrated'");
+    }
   }
 }

--- a/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventConsumerTest.java
@@ -77,6 +77,38 @@ public class MaintenanceEventConsumerTest {
     assertCallback("onFailingOver", push(type("FAILING_OVER"), 3L, 5L, shards));
     assertCallback("onMigrated", push(type("MIGRATED"), 4L, shards));
     assertCallback("onFailedOver", push(type("FAILED_OVER"), 5L, shards));
+    assertCallback("onSMigrating", push(type("SMIGRATING"), 6L, bytes("0-100")));
+    assertCallback("onSMigrated", push(type("SMIGRATED"), 7L, Collections
+        .singletonList(Arrays.asList(bytes("h1:7000"), bytes("h2:7001"), bytes("0-100")))));
+  }
+
+  @Test
+  public void dispatchesClusterEventWithDecodedFields() {
+    RecordingListener l = new RecordingListener();
+    PushConsumerContext ctx = consume(Collections.singleton(l),
+      push(type("SMIGRATED"), 7L, Collections
+          .singletonList(Arrays.asList(bytes("h1:7000"), bytes("h2:7001"), bytes("0-100")))));
+
+    assertTrue(ctx.shouldDrop());
+    assertEquals(1, l.calls.size());
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class, l.calls.get(0).event);
+    assertEquals(7L, e.seq);
+    assertEquals(1, e.migrations.size());
+    assertEquals(new HostAndPort("h1", 7000), e.migrations.get(0).src);
+    assertEquals(new HostAndPort("h2", 7001), e.migrations.get(0).dest);
+    assertTrue(e.migrations.get(0).slots.contains(50));
+  }
+
+  @Test
+  public void malformedClusterFrameDropsWithoutDispatch() {
+    RecordingListener l = new RecordingListener();
+    // resolves as SMIGRATING but the slots field is unparseable -> build() throws, consumer
+    // discards
+    PushConsumerContext ctx = consume(Collections.singleton(l),
+      push(type("SMIGRATING"), 6L, bytes("not-slots")));
+
+    assertTrue(ctx.shouldDrop());
+    assertTrue(l.calls.isEmpty());
   }
 
   @Test
@@ -162,12 +194,12 @@ public class MaintenanceEventConsumerTest {
 
     @Override
     public void onSMigrating(SMigratingEvent e, Connection c) {
-      throw new UnsupportedOperationException("Unimplemented method 'onSMigrating'");
+      calls.add(new Call("onSMigrating", e, c));
     }
 
     @Override
     public void onSMigrated(SMigratedEvent e, Connection c) {
-      throw new UnsupportedOperationException("Unimplemented method 'onSMigrated'");
+      calls.add(new Call("onSMigrated", e, c));
     }
   }
 }

--- a/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventControllerTest.java
@@ -13,6 +13,7 @@ import java.net.SocketAddress;
 import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -298,6 +299,37 @@ public class MaintenanceEventControllerTest {
     // The hook runs on the controller's scheduler; each applied event fires it once.
     await().atMost(Duration.ofSeconds(1)).until(() -> fires.get() == 3);
     assertEquals(3, fires.get());
+  }
+
+  // --- Cluster maintenance events: out of contract for this controller, must be inert ---
+
+  @Test
+  public void clusterEvents_areIgnored() {
+    HashSlotRanges slots = HashSlotRanges.parse("0-100");
+    controller.onSMigrating(new SMigratingEvent(1L, slots), receiver);
+    controller.onSMigrated(new SMigratedEvent(1L,
+        Collections.singletonList(new SlotMigration(TARGET_B, TARGET_C, slots))),
+      receiver);
+
+    assertFalse(controller.isRebindActive(), "cluster events must not open a rebind window");
+    assertNull(controller.getTimeoutSupplier().get(), "cluster events must not relax pool-wide");
+    assertNull(controller.getSocketAddress(receiverPeer), "cluster events must not remap");
+  }
+
+  @Test
+  public void clusterEvents_doNotDisturbStandaloneState() {
+    moving(1L, TARGET_B, 10);
+    assertEquals(TARGET_B_ADDR, controller.getSocketAddress(receiverPeer));
+
+    controller.onSMigrating(new SMigratingEvent(2L, HashSlotRanges.parse("5")), receiver);
+    controller.onSMigrated(new SMigratedEvent(2L, Collections.emptyList()), receiver2);
+
+    assertEquals(TARGET_B_ADDR, controller.getSocketAddress(receiverPeer),
+      "MOVING remap survives cluster events");
+    assertNull(controller.getSocketAddress(receiver2Peer),
+      "a cluster event on another connection does not make it an affected source");
+    assertTrue(controller.isRebindActive(), "the MOVING window stays open");
+    assertNotNull(controller.getTimeoutSupplier().get(), "pool-wide relaxation stays in effect");
   }
 
   // --- Relax-on-borrow ---

--- a/src/test/java/redis/clients/jedis/MaintenanceEventIdentityTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenanceEventIdentityTest.java
@@ -3,14 +3,18 @@ package redis.clients.jedis;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
- * Identity semantics of {@link MaintenanceEvent#identity()}: seq for all types; MOVING is also
- * keyed by the original target endpoint, so concurrent MOVINGs to different endpoints stay distinct
- * operations. Identity excludes payload that may vary between deliveries of the same operation
- * (remaining time, shard diagnostics).
+ * Identity semantics of {@link MaintenanceEvent#identity()}: seq for all types (including the
+ * cluster SMIGRATING/SMIGRATED family); MOVING is also keyed by the original target endpoint, so
+ * concurrent MOVINGs to different endpoints stay distinct operations. Identity excludes payload
+ * that may vary between deliveries of the same operation (remaining time, shard diagnostics, slot
+ * ranges).
  */
 @Tag("sch")
 public class MaintenanceEventIdentityTest {
@@ -53,5 +57,30 @@ public class MaintenanceEventIdentityTest {
       new FailingOverEvent(5L, 10, "1").identity());
     assertNotEquals(new FailingOverEvent(5L, 10, "1").identity(),
       new MovingEvent(5L, 10, null).identity());
+  }
+
+  @Test
+  public void clusterEventsUseSeqIdentity() {
+    HashSlotRanges slotsA = HashSlotRanges.parse("0-100");
+    HashSlotRanges slotsB = HashSlotRanges.parse("200");
+    List<SlotMigration> delta = Collections
+        .singletonList(new SlotMigration(TARGET_B, TARGET_C, slotsA));
+
+    assertEquals(new SMigratingEvent(5L, slotsA).identity(),
+      new SMigratingEvent(5L, slotsB).identity(), "same seq: same operation regardless of slots");
+    assertEquals(new SMigratingEvent(5L, slotsA).identity().hashCode(),
+      new SMigratingEvent(5L, slotsB).identity().hashCode());
+    assertNotEquals(new SMigratingEvent(5L, slotsA).identity(),
+      new SMigratingEvent(6L, slotsA).identity());
+
+    assertEquals(new SMigratedEvent(5L, delta).identity(),
+      new SMigratedEvent(5L, Collections.emptyList()).identity(),
+      "same seq: same operation regardless of the slot delta");
+    assertNotEquals(new SMigratedEvent(5L, delta).identity(),
+      new SMigratedEvent(6L, delta).identity());
+
+    assertEquals(new SMigratingEvent(5L, slotsA).identity(),
+      new SMigratedEvent(5L, delta).identity(),
+      "an SMIGRATED terminates the SMIGRATING with the same seq");
   }
 }

--- a/src/test/java/redis/clients/jedis/MaintenancePushCodecTest.java
+++ b/src/test/java/redis/clients/jedis/MaintenancePushCodecTest.java
@@ -1,15 +1,18 @@
 package redis.clients.jedis;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static redis.clients.jedis.MaintenancePushCodec.build;
 import static redis.clients.jedis.MaintenancePushCodec.PushType.resolve;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -19,7 +22,8 @@ import redis.clients.jedis.util.SafeEncoder;
 
 /**
  * Unit coverage for {@link MaintenancePushCodec}: {@link PushType#resolve} token classification and
- * {@link MaintenancePushCodec#build} field extraction / malformed-frame rejection.
+ * {@link MaintenancePushCodec#build} field extraction / malformed-frame rejection, for both the
+ * standalone ({@link MaintenanceEvent}) and cluster ({@link ClusterMaintenanceEvent}) families.
  */
 @Tag("unit")
 public class MaintenancePushCodecTest {
@@ -148,12 +152,145 @@ public class MaintenancePushCodecTest {
     assertMalformed(PushType.FAILED_OVER, push(type("FAILED_OVER"), 7L)); // missing shards
   }
 
+  // resolve()/build(): cluster maintenance pushes (SMIGRATING / SMIGRATED)
+
+  @Test
+  public void resolveClassifiesClusterMaintenanceTokens() {
+    assertSame(PushType.SMIGRATING, resolve(type("SMIGRATING")));
+    assertSame(PushType.SMIGRATED, resolve(type("SMIGRATED")));
+  }
+
+  @Test
+  public void resolveDisambiguatesSameLengthTokens() {
+    // MIGRATING and SMIGRATED share length 9: neither may shadow the other or admit lookalikes
+    assertSame(PushType.MIGRATING, resolve(type("MIGRATING")));
+    assertSame(PushType.SMIGRATED, resolve(type("SMIGRATED")));
+    assertNull(resolve(type("SMIGRATEX")));
+    assertNull(resolve(type("XMIGRATED")));
+    assertNull(resolve(type("SMIGRATINX"))); // length 10, not SMIGRATING
+    assertNull(resolve(type("smigrating"))); // tokens are case-sensitive
+    assertNull(resolve(type("smigrated")));
+  }
+
+  @Test
+  public void buildSMigrating() {
+    SMigratingEvent e = assertInstanceOf(SMigratingEvent.class,
+      build(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("123,456,789-1000"))));
+    assertEquals(11L, e.seq);
+    assertEquals("123,456,789-1000", e.slots.toString());
+    assertTrue(e.slots.contains(123));
+    assertTrue(e.slots.contains(456));
+    assertTrue(e.slots.contains(1000));
+    assertFalse(e.slots.contains(1001));
+  }
+
+  @Test
+  public void buildSMigrated() {
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class,
+      build(PushType.SMIGRATED,
+        sMigrated(12L, entry(bytes("10.0.0.1:7000"), bytes("10.0.0.2:7001"), bytes("0-100")),
+          entry(bytes("node-a:7002"), bytes("node-b:7003"), bytes("200,300-310")))));
+    assertEquals(12L, e.seq);
+    assertEquals(2, e.migrations.size());
+
+    SlotMigration first = e.migrations.get(0);
+    assertEquals(new HostAndPort("10.0.0.1", 7000), first.src);
+    assertEquals(new HostAndPort("10.0.0.2", 7001), first.dest);
+    assertEquals("0-100", first.slots.toString());
+
+    SlotMigration second = e.migrations.get(1);
+    assertEquals(new HostAndPort("node-a", 7002), second.src);
+    assertEquals(new HostAndPort("node-b", 7003), second.dest);
+    assertTrue(second.slots.contains(200));
+    assertTrue(second.slots.contains(305));
+    assertFalse(second.slots.contains(299));
+  }
+
+  @Test
+  public void buildSMigratedWithNoEntries() { // an empty delta is a well-formed terminator
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class,
+      build(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, Collections.emptyList())));
+    assertEquals(12L, e.seq);
+    assertTrue(e.migrations.isEmpty());
+  }
+
+  @Test
+  public void buildSMigratedTrailingEntryFieldsAreIgnored() { // forward-compatible: >3 fields OK
+    SMigratedEvent e = assertInstanceOf(SMigratedEvent.class,
+      build(PushType.SMIGRATED, sMigrated(1L,
+        Arrays.asList(bytes("h1:7000"), bytes("h2:7001"), bytes("5"), bytes("extra")))));
+    assertEquals(1, e.migrations.size());
+    assertEquals("5", e.migrations.get(0).slots.toString());
+  }
+
+  @Test
+  public void buildRejectsMalformedSMigrating() {
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"))); // no seq
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L)); // missing slots
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), bytes("x"), bytes("1-5"))); // bad
+                                                                                              // seq
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, 5L)); // slots not byte[]
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, null)); // null slots
+    // unparseable slots-or-ranges
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("")));
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("abc")));
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("10-9")));
+    assertMalformed(PushType.SMIGRATING, push(type("SMIGRATING"), 11L, bytes("16384")));
+  }
+
+  @Test
+  public void buildRejectsMalformedSMigrated() {
+    List<Object> ok = entry(bytes("h1:7000"), bytes("h2:7001"), bytes("0-100"));
+
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"))); // no seq
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L)); // missing entries
+    assertMalformed(PushType.SMIGRATED,
+      push(type("SMIGRATED"), bytes("x"), Collections.singletonList(ok))); // bad seq
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, bytes("not-a-list")));
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, null));
+
+    // entry not a list
+    assertMalformed(PushType.SMIGRATED, push(type("SMIGRATED"), 12L, Arrays.asList(bytes("x"))));
+    // entry too short
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, Arrays.asList(bytes("h1:7000"), bytes("h2:7001"))));
+    // entry fields of the wrong type
+    assertMalformed(PushType.SMIGRATED, sMigrated(12L, entry(7000L, bytes("h2:7001"), bytes("0"))));
+    assertMalformed(PushType.SMIGRATED, sMigrated(12L, entry(bytes("h1:7000"), 7001L, bytes("0"))));
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:7001"), 5L)));
+    assertMalformed(PushType.SMIGRATED, sMigrated(12L, entry(null, bytes("h2:7001"), bytes("0"))));
+    // unparseable node addresses
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("no-port"), bytes("h2:7001"), bytes("0-100"))));
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:notaport"), bytes("0-100"))));
+    // unparseable slots
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:7001"), bytes("100-0"))));
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, entry(bytes("h1:7000"), bytes("h2:7001"), bytes(""))));
+    // one bad entry rejects the whole frame
+    assertMalformed(PushType.SMIGRATED,
+      sMigrated(12L, ok, entry(bytes("h1:7000"), bytes("h2:7001"), bytes("bad"))));
+  }
+
   private static void assertMalformed(PushType type, PushMessage msg) {
     assertThrows(MalformedMaintenanceEventException.class, () -> build(type, msg));
   }
 
   private static PushMessage push(Object... content) {
     return new PushMessage(Arrays.asList(content));
+  }
+
+  /** {@code [SMIGRATED, seq, [entries...]]} */
+  private static PushMessage sMigrated(long seq, List<?>... entries) {
+    return push(type("SMIGRATED"), seq, Arrays.asList(entries));
+  }
+
+  /** One SMIGRATED entry: {@code [src, dest, slots]}. */
+  private static List<Object> entry(Object src, Object dest, Object slots) {
+    return Arrays.asList(src, dest, slots);
   }
 
   private static byte[] type(String t) {


### PR DESCRIPTION
**This PR built on top of #4729** For the diff against it, [here](https://github.com/redis/jedis/compare/atakavci:ali/clusterCoordinator...atakavci:jedis:ali/wireClusterCoordinator). 

## Summary
Connects the cluster maintenance coordinator to the client: `RedisClusterClient` builders can now configure `MaintenanceNotificationsConfig` (default AUTO), and every node pool's connections perform the MAINT_NOTIFICATIONS handshake and route SMIGRATING/SMIGRATED to the client-wide coordinator. To make this possible without duplicating the connection-init path, the standalone and cluster reactions are split behind a common `MaintenanceController` contract, and everything a family needs from its pool or connection factory is assembled by a new `PoolMaintenance` kit instead of type checks inside `ConnectionPool`.

## Key Decisions & Assumptions
- `MaintenanceController` is deliberately connection-facing only: config for the handshake, `register`/`unregister` for per-connection overlays and listeners, `close`. Pool-side needs (post-DNS address remap, retirement-aware eviction and return, handoff-triggered eviction) live in `PoolMaintenance` subclasses built where the family is known, so the pool never branches on controller type.
- The cluster controller warns and drops standalone events (MOVING, MIGRATING, FAILING_OVER); the coordinator no longer implements `MaintenanceEventListener` itself.
- The socket-address mapper is now an explicit `ConnectionFactory.Builder` knob set by the standalone kit rather than a capability advertised on the controller interface.
- The per-connection relax overlay is generalized into `ManagedTimeoutSource`, driven by a `Supplier<TimeoutInfo>` from either controller, and removed by that supplier's identity.
- Cluster maintenance is off when the config is `null` or DISABLED; the coordinator is created only when enabled or AUTO.

## Behavioral / Conceptual Changes
- `ClusterClientBuilder.maintenanceNotifications(config)` is new (`@since 8.1`, rejects `null`); `ClusterConnectionProvider` and `JedisClusterInfoCache` gain overloads taking the config. Existing overloads delegate with maintenance off.
- Cluster node pools are always built with an explicit pool config; a `null` pool config now yields a default `GenericObjectPoolConfig` instead of selecting a different constructor.
- Retirement-aware return (`isRetired` → destroy instead of reuse) is installed whenever maintenance is on for a pool, including cluster pools where it is inert because cluster connections are never retired.
- `MaintenanceEventController.retireAll` is removed; cluster Case-2 teardown is pool-level and no longer routes through the standalone controller.

## Testing
Only the test helper changed, to cast the pool's controller to the standalone type for the handoff-hook and address-mapping seams. Existing maintenance unit and mock suites pass unchanged; no new tests cover the cluster wiring end to end.

## Notes
- The public constructors and builder methods added here are `@Experimental` and target the unreleased 8.1 line.
- Follow-up worth considering: replacing the handoff-hook eviction with retirement enforcement in `activateObject`, which would remove the last pool-side callback the standalone kit installs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cluster topology updates, timeout behavior during migrations, and connection pooling under maintenance—incorrect locking or delta ordering could misroute slots or leave stale primaries until refresh.
> 
> **Overview**
> Adds **cluster maintenance notifications** end to end: cluster clients can configure `MaintenanceNotificationsConfig` (default AUTO via `ClusterClientBuilder.maintenanceNotifications`), node pools handshake `CLIENT MAINT_NOTIFICATIONS`, and **SMIGRATING/SMIGRATED** pushes are decoded, deduped client-wide by `ClusterMaintenanceCoordinator`, and applied as slot-map deltas through `JedisClusterInfoCache.applySlotMigration` without blocking read threads on topology refresh.
> 
> Refactors maintenance so **standalone and cluster share one connection-init path** without `ConnectionPool` branching on controller type: new `MaintenanceController` plus `PoolMaintenance` (standalone vs cluster kits) own factory wiring (e.g. MOVING address remap only for standalone), timeout overlays via `ManagedTimeoutSource`, and pool hooks (retired-connection return, eviction). `MaintenanceAwareVisitor` only calls `register`/`unregister` on the pool’s controller; `ClusterMaintenanceController` forwards cluster events to the coordinator and warns on enterprise-style events.
> 
> **Codec and model**: `MaintenancePushCodec` and listeners gain SMIGRATING/SMIGRATED; `HashSlotRanges` parses the slots-or-ranges wire format. Slot deltas are queued and drained under `slotDeltaLock`, ordered after full `renewClusterSlots` refreshes. Unit tests cover parsing, codec routing, and event dispatch; cluster wiring is not covered by new integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d7d6e2555b82c83202029b0a14852a86092645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->